### PR TITLE
fix: allow logging to user specified log files

### DIFF
--- a/cmd/versitygw/signal.go
+++ b/cmd/versitygw/signal.go
@@ -23,6 +23,7 @@ import (
 
 var (
 	sigDone = make(chan bool, 1)
+	sigHup  = make(chan bool, 1)
 )
 
 func setupSignalHandler() {
@@ -36,6 +37,7 @@ func setupSignalHandler() {
 			case syscall.SIGINT, syscall.SIGTERM:
 				sigDone <- true
 			case syscall.SIGHUP:
+				sigHup <- true
 			}
 		}
 	}()

--- a/s3log/audit-logger.go
+++ b/s3log/audit-logger.go
@@ -27,6 +27,8 @@ import (
 
 type AuditLogger interface {
 	Log(ctx *fiber.Ctx, err error, body []byte, meta LogMeta)
+	HangUp() error
+	Shutdown() error
 }
 
 type LogMeta struct {
@@ -36,7 +38,7 @@ type LogMeta struct {
 }
 
 type LogConfig struct {
-	IsFile     bool
+	LogFile    string
 	WebhookURL string
 }
 
@@ -70,14 +72,14 @@ type LogFields struct {
 }
 
 func InitLogger(cfg *LogConfig) (AuditLogger, error) {
-	if cfg.WebhookURL != "" && cfg.IsFile {
+	if cfg.WebhookURL != "" && cfg.LogFile != "" {
 		return nil, fmt.Errorf("there should be specified one of the following: file, webhook")
 	}
 	if cfg.WebhookURL != "" {
 		return InitWebhookLogger(cfg.WebhookURL)
 	}
-	if cfg.IsFile {
-		return InitFileLogger()
+	if cfg.LogFile != "" {
+		return InitFileLogger(cfg.LogFile)
 	}
 
 	return nil, nil


### PR DESCRIPTION
This also cleans up some the of the error output to send to stderr.

This adds the Shutdown() to the logging interface, so we can keep the log file open and just append entries.

This add HangUp() to the logging interface for log rotations.