### PR TITLE
Authentication errors refactoring

### DIFF
--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -4,6 +4,14 @@ func TestAuthentication(s *S3Conf) {
 	Authentication_empty_auth_header(s)
 	Authentication_invalid_auth_header(s)
 	Authentication_unsupported_signature_version(s)
+	Authentication_malformed_credentials(s)
+	Authentication_malformed_credentials_invalid_parts(s)
+	Authentication_credentials_terminated_string(s)
+	Authentication_credentials_incorrect_service(s)
+	Authentication_credentials_incorrect_region(s)
+	Authentication_credentials_invalid_date(s)
+	Authentication_credentials_future_date(s)
+	Authentication_credentials_past_date(s)
 }
 
 func TestCreateBucket(s *S3Conf) {

--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -1,5 +1,11 @@
 package integration
 
+func TestAuthentication(s *S3Conf) {
+	Authentication_empty_auth_header(s)
+	Authentication_invalid_auth_header(s)
+	Authentication_unsupported_signature_version(s)
+}
+
 func TestCreateBucket(s *S3Conf) {
 	CreateBucket_invalid_bucket_name(s)
 	CreateBucket_existing_bucket(s)
@@ -147,6 +153,7 @@ func TestGetBucketAcl(s *S3Conf) {
 }
 
 func TestFullFlow(s *S3Conf) {
+	TestAuthentication(s)
 	TestCreateBucket(s)
 	TestHeadBucket(s)
 	TestDeleteBucket(s)

--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -12,6 +12,14 @@ func TestAuthentication(s *S3Conf) {
 	Authentication_credentials_invalid_date(s)
 	Authentication_credentials_future_date(s)
 	Authentication_credentials_past_date(s)
+	Authentication_credentials_non_existing_access_key(s)
+	Authentication_invalid_signed_headers(s)
+	Authentication_missing_date_header(s)
+	Authentication_invalid_date_header(s)
+	Authentication_date_mismatch(s)
+	Authentication_incorrect_payload_hash(s)
+	Authentication_incorrect_md5(s)
+	Authentication_signature_error_incorrect_secret_key(s)
 }
 
 func TestCreateBucket(s *S3Conf) {

--- a/integration/tests.go
+++ b/integration/tests.go
@@ -3,11 +3,13 @@ package integration
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
 	"math"
 	"net/http"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -103,6 +105,287 @@ func Authentication_unsupported_signature_version(s *S3Conf) {
 		defer resp.Body.Close()
 		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrSignatureVersionNotSupported)); err != nil {
 			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_malformed_credentials(s *S3Conf) {
+	testName := "Authentication_malformed_credentials"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now(),
+	}, func(req *http.Request) error {
+		authHdr := req.Header.Get("Authorization")
+		regExp := regexp.MustCompile("Credential=[^,]+,")
+		hdr := regExp.ReplaceAllString(authHdr, "Credential-access/32234/us-east-1/s3/aws4_request,")
+		req.Header.Set("Authorization", hdr)
+
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrCredMalformed)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_malformed_credentials_invalid_parts(s *S3Conf) {
+	testName := "Authentication_malformed_credentials_invalid_parts"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now(),
+	}, func(req *http.Request) error {
+		authHdr := req.Header.Get("Authorization")
+		regExp := regexp.MustCompile("Credential=[^,]+,")
+		hdr := regExp.ReplaceAllString(authHdr, "Credential=access/32234/us-east-1/s3,")
+		req.Header.Set("Authorization", hdr)
+
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrCredMalformed)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_credentials_terminated_string(s *S3Conf) {
+	testName := "Authentication_credentials_terminated_string"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now(),
+	}, func(req *http.Request) error {
+		authHdr := req.Header.Get("Authorization")
+		regExp := regexp.MustCompile("Credential=[^,]+,")
+		hdr := regExp.ReplaceAllString(authHdr, "Credential=access/32234/us-east-1/s3/aws_request,")
+		req.Header.Set("Authorization", hdr)
+
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrSignatureTerminationStr)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_credentials_incorrect_service(s *S3Conf) {
+	testName := "Authentication_credentials_incorrect_service"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "ec2",
+		date:     time.Now(),
+	}, func(req *http.Request) error {
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrSignatureIncorrService)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_credentials_incorrect_region(s *S3Conf) {
+	testName := "Authentication_credentials_incorrect_region"
+	cfg := *s
+	if cfg.awsRegion == "us-east-1" {
+		cfg.awsRegion = "us-west-1"
+	} else {
+		cfg.awsRegion = "us-east-1"
+	}
+	authHandler(&cfg, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now(),
+	}, func(req *http.Request) error {
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+		apiErr := s3err.APIError{
+			Code:           "SignatureDoesNotMatch",
+			Description:    fmt.Sprintf("Credential should be scoped to a valid Region, not %v", cfg.awsRegion),
+			HTTPStatusCode: http.StatusForbidden,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if err := checkAuthErr(resp, apiErr); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_credentials_invalid_date(s *S3Conf) {
+	testName := "Authentication_credentials_invalid_date"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now(),
+	}, func(req *http.Request) error {
+		authHdr := req.Header.Get("Authorization")
+		regExp := regexp.MustCompile("Credential=[^,]+,")
+		hdr := regExp.ReplaceAllString(authHdr, "Credential=access/3223423234/us-east-1/s3/aws4_request,")
+		req.Header.Set("Authorization", hdr)
+
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrSignatureDateDoesNotMatch)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func Authentication_credentials_future_date(s *S3Conf) {
+	testName := "Authentication_credentials_future_date"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now().Add(time.Duration(5) * 24 * time.Hour),
+	}, func(req *http.Request) error {
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		var errResp s3err.APIErrorResponse
+		err = xml.Unmarshal(body, &errResp)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusForbidden {
+			return fmt.Errorf("expected response status code to be %v, instead got %v", http.StatusForbidden, resp.StatusCode)
+		}
+		if errResp.Code != "SignatureDoesNotMatch" {
+			return fmt.Errorf("expected error code to be %v, instead got %v", "SignatureDoesNotMatch", errResp.Code)
+		}
+		if !strings.Contains(errResp.Message, "Signature not yet current:") {
+			return fmt.Errorf("expected future date error message, instead got %v", errResp.Message)
+		}
+
+		return nil
+	})
+}
+
+func Authentication_credentials_past_date(s *S3Conf) {
+	testName := "Authentication_credentials_past_date"
+	authHandler(s, &authConfig{
+		testName: testName,
+		path:     "my-bucket",
+		method:   http.MethodGet,
+		body:     nil,
+		service:  "s3",
+		date:     time.Now().Add(time.Duration(-5) * 24 * time.Hour),
+	}, func(req *http.Request) error {
+		client := http.Client{
+			Timeout: shortTimeout,
+		}
+
+		resp, err := client.Do(req)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		var errResp s3err.APIErrorResponse
+		err = xml.Unmarshal(body, &errResp)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusForbidden {
+			return fmt.Errorf("expected response status code to be %v, instead got %v", http.StatusForbidden, resp.StatusCode)
+		}
+		if errResp.Code != "SignatureDoesNotMatch" {
+			return fmt.Errorf("expected error code to be %v, instead got %v", "SignatureDoesNotMatch", errResp.Code)
+		}
+		if !strings.Contains(errResp.Message, "Signature expired:") {
+			return fmt.Errorf("expected past date error message, instead got %v", errResp.Message)
 		}
 
 		return nil

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -1447,7 +1447,7 @@ func Test_XMLresponse(t *testing.T) {
 			args: args{
 				ctx:  &ctx,
 				resp: nil,
-				err:  s3err.GetAPIError(16),
+				err:  s3err.GetAPIError(s3err.ErrInternalError),
 			},
 			wantErr:    false,
 			statusCode: 500,
@@ -1457,7 +1457,7 @@ func Test_XMLresponse(t *testing.T) {
 			args: args{
 				ctx:  &ctx,
 				resp: nil,
-				err:  s3err.GetAPIError(50),
+				err:  s3err.GetAPIError(s3err.ErrNotImplemented),
 			},
 			wantErr:    false,
 			statusCode: 501,
@@ -1527,7 +1527,7 @@ func Test_response(t *testing.T) {
 			args: args{
 				ctx:  &ctx,
 				resp: nil,
-				err:  s3err.GetAPIError(16),
+				err:  s3err.GetAPIError(s3err.ErrInternalError),
 			},
 			wantErr:    false,
 			statusCode: 500,
@@ -1547,7 +1547,7 @@ func Test_response(t *testing.T) {
 			args: args{
 				ctx:  &ctx,
 				resp: nil,
-				err:  s3err.GetAPIError(50),
+				err:  s3err.GetAPIError(s3err.ErrNotImplemented),
 			},
 			wantErr:    false,
 			statusCode: 501,

--- a/s3api/middlewares/authentication.go
+++ b/s3api/middlewares/authentication.go
@@ -77,7 +77,7 @@ func VerifyV4Signature(root RootUserConfig, iam auth.IAMService, logger s3log.Au
 		}
 		// Credential variables validation
 		creds := strings.Split(credKv[1], "/")
-		if len(creds) < 5 {
+		if len(creds) != 5 {
 			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrCredMalformed), &controllers.MetaOpts{Logger: logger})
 		}
 		if creds[4] != "aws4_request" {

--- a/s3api/middlewares/authentication.go
+++ b/s3api/middlewares/authentication.go
@@ -124,14 +124,14 @@ func VerifyV4Signature(root RootUserConfig, iam auth.IAMService, logger s3log.Au
 			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrMissingDateHeader), &controllers.MetaOpts{Logger: logger})
 		}
 
-		if date[:8] != creds[1] {
-			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrSignatureDateDoesNotMatch), &controllers.MetaOpts{Logger: logger})
-		}
-
 		// Parse the date and check the date validity
 		tdate, err := time.Parse(iso8601Format, date)
 		if err != nil {
 			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrMalformedDate), &controllers.MetaOpts{Logger: logger})
+		}
+
+		if date[:8] != creds[1] {
+			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrSignatureDateDoesNotMatch), &controllers.MetaOpts{Logger: logger})
 		}
 
 		hashPayloadHeader := ctx.Get("X-Amz-Content-Sha256")

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -97,6 +97,9 @@ const (
 	ErrNegativeExpires
 	ErrMaximumExpires
 	ErrSignatureDoesNotMatch
+	ErrSignatureDateDoesNotMatch
+	ErrSignatureTerminationStr
+	ErrSignatureIncorrService
 	ErrContentSHA256Mismatch
 	ErrInvalidAccessKeyID
 	ErrRequestNotReadyYet
@@ -190,13 +193,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "We encountered an internal error, please try again.",
 		HTTPStatusCode: http.StatusInternalServerError,
 	},
-
 	ErrInvalidPart: {
 		Code:           "InvalidPart",
 		Description:    "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-
 	ErrInvalidCopyDest: {
 		Code:           "InvalidRequest",
 		Description:    "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes.",
@@ -287,7 +288,6 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "Signature header missing Signature field.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-
 	ErrUnsignedHeaders: {
 		Code:           "AccessDenied",
 		Description:    "There were headers present in the request which were not signed",
@@ -323,25 +323,36 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "X-Amz-Expires must be less than a week (in seconds); that is, the given X-Amz-Expires must be less than 604800 seconds",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-
 	ErrInvalidAccessKeyID: {
 		Code:           "InvalidAccessKeyId",
 		Description:    "The access key ID you provided does not exist in our records.",
 		HTTPStatusCode: http.StatusForbidden,
 	},
-
 	ErrRequestNotReadyYet: {
 		Code:           "AccessDenied",
 		Description:    "Request is not valid yet",
 		HTTPStatusCode: http.StatusForbidden,
 	},
-
 	ErrSignatureDoesNotMatch: {
 		Code:           "SignatureDoesNotMatch",
 		Description:    "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
 		HTTPStatusCode: http.StatusForbidden,
 	},
-
+	ErrSignatureDateDoesNotMatch: {
+		Code:           "SignatureDoesNotMatch",
+		Description:    "Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrSignatureTerminationStr: {
+		Code:           "SignatureDoesNotMatch",
+		Description:    "Credential should be scoped with a valid terminator: 'aws4_request'",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrSignatureIncorrService: {
+		Code:           "SignatureDoesNotMatch",
+		Description:    "Credential should be scoped to correct service: s3",
+		HTTPStatusCode: http.StatusForbidden,
+	},
 	ErrContentSHA256Mismatch: {
 		Code:           "XAmzContentSHA256Mismatch",
 		Description:    "The provided 'x-amz-content-sha256' header does not match what was computed.",


### PR DESCRIPTION
1. Added new error cases in the authentication to make it more compatible with aws.
2. Created integration test cases for authentication.
Here is the [resource](https://docs.aws.amazon.com/IAM/latest/UserGuide/signature-v4-troubleshooting.html#signature-v4-troubleshooting-credential-scope) for SigV4 errors.