### PR TITLE
fix: move auth internal UserAcc to auth.Account

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -20,6 +20,7 @@ import (
 
 // Account is a gateway IAM account
 type Account struct {
+	Access string `json:"access"`
 	Secret string `json:"secret"`
 	Role   string `json:"role"`
 }
@@ -31,7 +32,7 @@ type IAMService interface {
 	CreateAccount(access string, account Account) error
 	GetUserAccount(access string) (Account, error)
 	DeleteUserAccount(access string) error
-	ListUserAccounts() ([]UserAcc, error)
+	ListUserAccounts() ([]Account, error)
 }
 
 var ErrNoSuchUser = errors.New("user not found")

--- a/auth/iam_internal.go
+++ b/auth/iam_internal.go
@@ -41,12 +41,6 @@ type Storer interface {
 	StoreIAM(UpdateAcctFunc) error
 }
 
-type UserAcc struct {
-	Access string `json:"access"`
-	Secret string `json:"secret"`
-	Role   string `json:"role"`
-}
-
 // IAMConfig stores all internal IAM accounts
 type IAMConfig struct {
 	AccessAccounts map[string]Account `json:"accessAccounts"`
@@ -187,13 +181,13 @@ func (s *IAMServiceInternal) DeleteUserAccount(access string) error {
 }
 
 // ListUserAccounts lists all the user accounts stored.
-func (s *IAMServiceInternal) ListUserAccounts() (accs []UserAcc, err error) {
+func (s *IAMServiceInternal) ListUserAccounts() (accs []Account, err error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	data, err := s.storer.GetIAM()
 	if err != nil {
-		return []UserAcc{}, fmt.Errorf("get iam data: %w", err)
+		return []Account{}, fmt.Errorf("get iam data: %w", err)
 	}
 
 	serial := crc32.ChecksumIEEE(data)
@@ -202,12 +196,12 @@ func (s *IAMServiceInternal) ListUserAccounts() (accs []UserAcc, err error) {
 		err := s.updateCache()
 		s.mu.RLock()
 		if err != nil {
-			return []UserAcc{}, fmt.Errorf("refresh iam cache: %w", err)
+			return []Account{}, fmt.Errorf("refresh iam cache: %w", err)
 		}
 	}
 
 	for access, usr := range s.accts.AccessAccounts {
-		accs = append(accs, UserAcc{
+		accs = append(accs, Account{
 			Access: access,
 			Secret: usr.Secret,
 			Role:   usr.Role,

--- a/cmd/versitygw/admin.go
+++ b/cmd/versitygw/admin.go
@@ -230,7 +230,7 @@ func listUsers(ctx *cli.Context) error {
 	}
 	defer resp.Body.Close()
 
-	var accs []auth.UserAcc
+	var accs []auth.Account
 	if err := json.Unmarshal(body, &accs); err != nil {
 		return err
 	}

--- a/s3api/controllers/admin_test.go
+++ b/s3api/controllers/admin_test.go
@@ -180,16 +180,16 @@ func TestAdminController_ListUsers(t *testing.T) {
 
 	adminController := AdminController{
 		IAMService: &IAMServiceMock{
-			ListUserAccountsFunc: func() ([]auth.UserAcc, error) {
-				return []auth.UserAcc{}, nil
+			ListUserAccountsFunc: func() ([]auth.Account, error) {
+				return []auth.Account{}, nil
 			},
 		},
 	}
 
 	adminControllerErr := AdminController{
 		IAMService: &IAMServiceMock{
-			ListUserAccountsFunc: func() ([]auth.UserAcc, error) {
-				return []auth.UserAcc{}, fmt.Errorf("server error")
+			ListUserAccountsFunc: func() ([]auth.Account, error) {
+				return []auth.Account{}, fmt.Errorf("server error")
 			},
 		},
 	}

--- a/s3api/controllers/iam_moq_test.go
+++ b/s3api/controllers/iam_moq_test.go
@@ -27,7 +27,7 @@ var _ auth.IAMService = &IAMServiceMock{}
 //			GetUserAccountFunc: func(access string) (auth.Account, error) {
 //				panic("mock out the GetUserAccount method")
 //			},
-//			ListUserAccountsFunc: func() ([]auth.UserAcc, error) {
+//			ListUserAccountsFunc: func() ([]auth.Account, error) {
 //				panic("mock out the ListUserAccounts method")
 //			},
 //		}
@@ -47,7 +47,7 @@ type IAMServiceMock struct {
 	GetUserAccountFunc func(access string) (auth.Account, error)
 
 	// ListUserAccountsFunc mocks the ListUserAccounts method.
-	ListUserAccountsFunc func() ([]auth.UserAcc, error)
+	ListUserAccountsFunc func() ([]auth.Account, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -179,7 +179,7 @@ func (mock *IAMServiceMock) GetUserAccountCalls() []struct {
 }
 
 // ListUserAccounts calls ListUserAccountsFunc.
-func (mock *IAMServiceMock) ListUserAccounts() ([]auth.UserAcc, error) {
+func (mock *IAMServiceMock) ListUserAccounts() ([]auth.Account, error) {
 	if mock.ListUserAccountsFunc == nil {
 		panic("IAMServiceMock.ListUserAccountsFunc: method is nil but IAMService.ListUserAccounts was just called")
 	}


### PR DESCRIPTION
We don't want to expose the UserAcct in the interface, so we should just reuse the Account struct here.