### PR TITLE
fix: remove body limit for admin app

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -250,7 +250,6 @@ func runGateway(ctx *cli.Context, be backend.Backend, s auth.Storer) error {
 	admApp := fiber.New(fiber.Config{
 		AppName:      "versitygw",
 		ServerHeader: "VERSITYGW",
-		BodyLimit:    5 * 1024 * 1024 * 1024,
 	})
 
 	var admOpts []s3api.AdminOpt


### PR DESCRIPTION
The BodyLimit is needed for large PUTs in the s3 api server, but the admin server requests are not expected to exceed the default 4MB limit.