### PR TITLE
Issue 179, 180

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -64,8 +64,12 @@ func Walk(fileSystem fs.FS, prefix, delimiter, marker string, max int32, getObj 
 		}
 
 		if pastMax {
-			newMarker = path
-			truncated = true
+			if max < 1 {
+				truncated = true
+			} else {
+				newMarker = *objects[len(objects)-1].Key
+				truncated = true
+			}
 			return fs.SkipAll
 		}
 
@@ -75,8 +79,8 @@ func Walk(fileSystem fs.FS, prefix, delimiter, marker string, max int32, getObj 
 			// match this prefix. Make sure to append the / at the end of
 			// directories since this is implied as a directory path name.
 			// If path is a prefix of prefix, then path could still be
-			// building to match. So only skip if path isnt a prefix of prefix
-			// and prefix isnt a prefix of path.
+			// building to match. So only skip if path isn't a prefix of prefix
+			// and prefix isn't a prefix of path.
 			if prefix != "" &&
 				!strings.HasPrefix(path+string(os.PathSeparator), prefix) &&
 				!strings.HasPrefix(prefix, path+string(os.PathSeparator)) {
@@ -104,10 +108,10 @@ func Walk(fileSystem fs.FS, prefix, delimiter, marker string, max int32, getObj 
 		}
 
 		if !pastMarker {
-			if path != marker {
-				return nil
+			if path == marker {
+				pastMarker = true
 			}
-			pastMarker = true
+			return nil
 		}
 
 		// If object doesn't have prefix, don't include in results.

--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -72,6 +72,7 @@ func TestListObjects(s *S3Conf) {
 	ListObject_truncated(s)
 	ListObjects_invalid_max_keys(s)
 	ListObjects_max_keys_0(s)
+	ListObjects_delimiter(s)
 }
 
 func TestDeleteObject(s *S3Conf) {

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -401,6 +401,26 @@ func compareObjects(list1 []string, list2 []types.Object) bool {
 	return true
 }
 
+func comparePrefixes(list1 []string, list2 []types.CommonPrefix) bool {
+	if len(list1) != len(list2) {
+		return false
+	}
+
+	elementMap := make(map[string]bool)
+
+	for _, elem := range list1 {
+		elementMap[elem] = true
+	}
+
+	for _, elem := range list2 {
+		if _, found := elementMap[*elem.Prefix]; !found {
+			return false
+		}
+	}
+
+	return true
+}
+
 func compareDelObjects(list1 []string, list2 []types.DeletedObject) bool {
 	if len(list1) != len(list2) {
 		return false


### PR DESCRIPTION
1. Fixed marker bug, when specifying max-items next-marker should be the last object key in the list
2. When listing the objects with marker, the listing has to start after the specified marker object not including the one