### PR TITLE
Walk function last object check panic fix

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -64,9 +64,7 @@ func Walk(fileSystem fs.FS, prefix, delimiter, marker string, max int32, getObj 
 		}
 
 		if pastMax {
-			if max < 1 {
-				truncated = true
-			} else {
+			if len(objects) != 0 {
 				newMarker = *objects[len(objects)-1].Key
 				truncated = true
 			}


### PR DESCRIPTION
There's a case when it finds an object but it's saved as delimiter and objects slice is empty, which causes the app panic. Just changed the implementation of checking the last element existence.