### PR TITLE
Issue 244, Destination bucket ACL check for CopyObject action

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1238,6 +1238,7 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 	}
 	dstBucket := *input.Bucket
 	dstObject := *input.Key
+	owner := *input.ExpectedBucketOwner
 
 	_, err := os.Stat(srcBucket)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -1253,6 +1254,22 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 	}
 	if err != nil {
 		return nil, fmt.Errorf("stat bucket: %w", err)
+	}
+
+	dstBucketACLBytes, err := xattr.Get(dstBucket, aclkey)
+	if err != nil {
+		return nil, fmt.Errorf("get dst bucket acl tag: %w", err)
+	}
+
+	var dstBucketACL auth.ACL
+	err = json.Unmarshal(dstBucketACLBytes, &dstBucketACL)
+	if err != nil {
+		return nil, fmt.Errorf("parse dst bucket acl: %w", err)
+	}
+
+	err = auth.VerifyACL(dstBucketACL, dstBucket, owner, types.PermissionWrite, false)
+	if err != nil {
+		return nil, err
 	}
 
 	objPath := filepath.Join(srcBucket, srcObject)

--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -88,6 +88,7 @@ func TestDeleteObjects(s *S3Conf) {
 
 func TestCopyObject(s *S3Conf) {
 	CopyObject_non_existing_dst_bucket(s)
+	CopyObject_not_owned_source_bucket(s)
 	CopyObject_success(s)
 }
 

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -598,6 +598,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			CopySourceIfNoneMatch:       &copySrcIfNoneMatch,
 			CopySourceIfModifiedSince:   &mtime,
 			CopySourceIfUnmodifiedSince: &umtime,
+			ExpectedBucketOwner:         &access,
 		})
 		if err == nil {
 			return SendXMLResponse(ctx, res, err, &MetaOpts{


### PR DESCRIPTION
Added destination bucket ACL check for CopyObject action. It return 403 Forbidden if the requester's access isn't included in the ACL.