### PR TITLE
Issue 246, tag maximum length check for PutObject and PutObjectTagging actions

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -948,6 +948,9 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (string, e
 			if len(p) != 2 {
 				return "", s3err.GetAPIError(s3err.ErrInvalidTag)
 			}
+			if len(p[0]) > 128 || len(p[1]) > 256 {
+				return "", s3err.GetAPIError(s3err.ErrInvalidTag)
+			}
 			tags[p[0]] = p[1]
 		}
 	}

--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -50,6 +50,7 @@ func TestPutObject(s *S3Conf) {
 	PutObject_special_chars(s)
 	PutObject_existing_dir_obj(s)
 	PutObject_obj_parent_is_file(s)
+	PutObject_invalid_long_tags(s)
 	PutObject_success(s)
 }
 
@@ -95,6 +96,7 @@ func TestCopyObject(s *S3Conf) {
 
 func TestPutObjectTagging(s *S3Conf) {
 	PutObjectTagging_non_existing_object(s)
+	PutObjectTagging_long_tags(s)
 	PutObjectTagging_success(s)
 }
 

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	rnd "math/rand"
 	"net/http"
 	"os"
 	"os/exec"
@@ -525,4 +526,16 @@ func changeBucketsOwner(s *S3Conf, buckets []string, owner string) error {
 	}
 
 	return nil
+}
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func genRandString(length int) string {
+	source := rnd.NewSource(time.Now().UnixNano())
+	random := rnd.New(source)
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = charset[random.Intn(len(charset))]
+	}
+	return string(result)
 }

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -446,6 +446,9 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		tags := make(map[string]string, len(objTagging.TagSet.Tags))
 
 		for _, tag := range objTagging.TagSet.Tags {
+			if len(tag.Key) > 128 || len(tag.Value) > 256 {
+				return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidTag), &MetaOpts{Logger: c.logger, Action: "PutObjectTagging", BucketOwner: parsedAcl.Owner})
+			}
 			tags[tag.Key] = tag.Value
 		}
 


### PR DESCRIPTION
Added maximum length check for tag keys and values in PutObject and PutObjectTagging.