### PR TITLE
Issue 250, ListObjects(V2) marker not from objects list.

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -108,8 +108,11 @@ func Walk(fileSystem fs.FS, prefix, delimiter, marker string, max int32, getObj 
 		if !pastMarker {
 			if path == marker {
 				pastMarker = true
+				return nil
 			}
-			return nil
+			if path < marker {
+				return nil
+			}
 		}
 
 		// If object doesn't have prefix, don't include in results.

--- a/integration/action-tests.go
+++ b/integration/action-tests.go
@@ -75,6 +75,7 @@ func TestListObjects(s *S3Conf) {
 	ListObjects_max_keys_0(s)
 	ListObjects_delimiter(s)
 	ListObjects_max_keys_none(s)
+	ListObjects_marker_not_from_obj_list(s)
 }
 
 func TestDeleteObject(s *S3Conf) {


### PR DESCRIPTION
1. Changed ListObjects(V2) implementation, so if user provides a marker that is not included in the existing objects list, action returns the objects keys, which are lexicographically higher than the provided