### PR TITLE
IAM account interface cleanup

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -29,7 +29,7 @@ type Account struct {
 //
 //go:generate moq -out ../s3api/controllers/iam_moq_test.go -pkg controllers . IAMService
 type IAMService interface {
-	CreateAccount(access string, account Account) error
+	CreateAccount(account Account) error
 	GetUserAccount(access string) (Account, error)
 	DeleteUserAccount(access string) error
 	ListUserAccounts() ([]Account, error)

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1664,7 +1664,7 @@ func (p *Posix) InitIAM() error {
 
 	_, err := os.ReadFile(iamFile)
 	if errors.Is(err, fs.ErrNotExist) {
-		b, err := json.Marshal(auth.IAMConfig{AccessAccounts: map[string]auth.Account{}})
+		b, err := json.Marshal(auth.IAMConfig{AccessAccounts: map[string]auth.InternalAcct{}})
 		if err != nil {
 			return fmt.Errorf("marshal default iam: %w", err)
 		}

--- a/s3api/controllers/admin.go
+++ b/s3api/controllers/admin.go
@@ -42,9 +42,9 @@ func (c AdminController) CreateUser(ctx *fiber.Ctx) error {
 		return fmt.Errorf("invalid parameters: user role have to be one of the following: 'user', 'admin'")
 	}
 
-	user := auth.Account{Secret: secret, Role: role}
+	user := auth.Account{Secret: secret, Role: role, Access: access}
 
-	err := c.iam.CreateAccount(access, user)
+	err := c.iam.CreateAccount(user)
 	if err != nil {
 		return fmt.Errorf("failed to create a user: %w", err)
 	}

--- a/s3api/controllers/admin_test.go
+++ b/s3api/controllers/admin_test.go
@@ -33,7 +33,7 @@ func TestAdminController_CreateUser(t *testing.T) {
 
 	adminController := AdminController{
 		iam: &IAMServiceMock{
-			CreateAccountFunc: func(access string, account auth.Account) error {
+			CreateAccountFunc: func(account auth.Account) error {
 				return nil
 			},
 		},

--- a/s3api/controllers/iam_moq_test.go
+++ b/s3api/controllers/iam_moq_test.go
@@ -18,7 +18,7 @@ var _ auth.IAMService = &IAMServiceMock{}
 //
 //		// make and configure a mocked auth.IAMService
 //		mockedIAMService := &IAMServiceMock{
-//			CreateAccountFunc: func(access string, account auth.Account) error {
+//			CreateAccountFunc: func(account auth.Account) error {
 //				panic("mock out the CreateAccount method")
 //			},
 //			DeleteUserAccountFunc: func(access string) error {
@@ -38,7 +38,7 @@ var _ auth.IAMService = &IAMServiceMock{}
 //	}
 type IAMServiceMock struct {
 	// CreateAccountFunc mocks the CreateAccount method.
-	CreateAccountFunc func(access string, account auth.Account) error
+	CreateAccountFunc func(account auth.Account) error
 
 	// DeleteUserAccountFunc mocks the DeleteUserAccount method.
 	DeleteUserAccountFunc func(access string) error
@@ -53,8 +53,6 @@ type IAMServiceMock struct {
 	calls struct {
 		// CreateAccount holds details about calls to the CreateAccount method.
 		CreateAccount []struct {
-			// Access is the access argument value.
-			Access string
 			// Account is the account argument value.
 			Account auth.Account
 		}
@@ -79,21 +77,19 @@ type IAMServiceMock struct {
 }
 
 // CreateAccount calls CreateAccountFunc.
-func (mock *IAMServiceMock) CreateAccount(access string, account auth.Account) error {
+func (mock *IAMServiceMock) CreateAccount(account auth.Account) error {
 	if mock.CreateAccountFunc == nil {
 		panic("IAMServiceMock.CreateAccountFunc: method is nil but IAMService.CreateAccount was just called")
 	}
 	callInfo := struct {
-		Access  string
 		Account auth.Account
 	}{
-		Access:  access,
 		Account: account,
 	}
 	mock.lockCreateAccount.Lock()
 	mock.calls.CreateAccount = append(mock.calls.CreateAccount, callInfo)
 	mock.lockCreateAccount.Unlock()
-	return mock.CreateAccountFunc(access, account)
+	return mock.CreateAccountFunc(account)
 }
 
 // CreateAccountCalls gets all the calls that were made to CreateAccount.
@@ -101,11 +97,9 @@ func (mock *IAMServiceMock) CreateAccount(access string, account auth.Account) e
 //
 //	len(mockedIAMService.CreateAccountCalls())
 func (mock *IAMServiceMock) CreateAccountCalls() []struct {
-	Access  string
 	Account auth.Account
 } {
 	var calls []struct {
-		Access  string
 		Account auth.Account
 	}
 	mock.lockCreateAccount.RLock()


### PR DESCRIPTION
Add a new type `InternalAcct` for internal IAM storage. Didn't change IAMService interface to make it more usable for other IAM options(LDAP...)