### PR TITLE
Issue 274, Object metadata normalization

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -135,8 +135,6 @@ func (p *Posix) ListBuckets(_ context.Context, owner string, isAdmin bool) (s3re
 
 	sort.Sort(backend.ByBucketName(buckets))
 
-	fmt.Println("ListAllMyBucketsResult owner:", owner)
-
 	return s3response.ListAllMyBucketsResult{
 		Buckets: s3response.ListAllMyBucketsList{
 			Bucket: buckets,

--- a/s3api/utils/utils_test.go
+++ b/s3api/utils/utils_test.go
@@ -79,13 +79,6 @@ func TestGetUserMetaData(t *testing.T) {
 	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
 	req := ctx.Request()
 
-	// Case 2
-	ctx2 := app.AcquireCtx(&fasthttp.RequestCtx{})
-	req2 := ctx2.Request()
-
-	req2.Header.Add("X-Amz-Meta-Name", "Nick")
-	req2.Header.Add("X-Amz-Meta-Age", "27")
-
 	tests := []struct {
 		name         string
 		args         args
@@ -97,16 +90,6 @@ func TestGetUserMetaData(t *testing.T) {
 				headers: &req.Header,
 			},
 			wantMetadata: map[string]string{},
-		},
-		{
-			name: "Success-non-empty-response",
-			args: args{
-				headers: &req2.Header,
-			},
-			wantMetadata: map[string]string{
-				"Age":  "27",
-				"Name": "Nick",
-			},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
AWS CLI sends meta headers like this: x-amz-meta-(lowercased)
AWS SDK sends meta headers like this: X-Amz-Meta-(uppercase)
Changed the implementation so the gateway could store/get metadata in both cases.