### PR TITLE
fix: fixes #311 - disable cgo in release builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,6 +9,10 @@ builds:
       # windows is untested, we can start doing windows releases
       # if someone is interested in taking on testing
       # - windows
+    env:
+      # disable cgo to fix glibc issues: https://github.com/golang/go/issues/58550
+      # once we need to enable this, we will need to do per distro releases
+      - CGO_ENABLED=0
     main: ./cmd/versitygw
     binary: ./cmd/versitygw
     id: versitygw


### PR DESCRIPTION
We were getting the following error on el7:
$ ./versitygw -h
./versitygw: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./versitygw) ./versitygw: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ./versitygw)

The temporary fix is to disable cgo in the builds per this issue: https://github.com/golang/go/issues/58550

We will need to visit per distro builds once we need to re-enable cgo.