### PR TITLE
fix: s3 backend performance increase with client reuse

### DIFF
--- a/backend/s3proxy/client.go
+++ b/backend/s3proxy/client.go
@@ -27,7 +27,7 @@ import (
 	"github.com/aws/smithy-go/middleware"
 )
 
-func (s *S3Proxy) getClientFromCtx(ctx context.Context) (*s3.Client, error) {
+func (s *S3Proxy) getClientWithCtx(ctx context.Context) (*s3.Client, error) {
 	cfg, err := s.getConfig(ctx, s.access, s.secret)
 	if err != nil {
 		return nil, err

--- a/cmd/versitygw/s3.go
+++ b/cmd/versitygw/s3.go
@@ -15,6 +15,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/urfave/cli/v2"
 	"github.com/versity/versitygw/backend/s3proxy"
 )
@@ -88,7 +90,10 @@ to an s3 storage backend service.`,
 }
 
 func runS3(ctx *cli.Context) error {
-	be := s3proxy.New(s3proxyAccess, s3proxySecret, s3proxyEndpoint, s3proxyRegion,
+	be, err := s3proxy.New(s3proxyAccess, s3proxySecret, s3proxyEndpoint, s3proxyRegion,
 		s3proxyDisableChecksum, s3proxySslSkipVerify, s3proxyDebug)
+	if err != nil {
+		return fmt.Errorf("init s3 backend: %w", err)
+	}
 	return runGateway(ctx.Context, be)
 }


### PR DESCRIPTION
The previous way of initializing the s3 client in each call was adding a lot of overhead and would tank performance beyond about 20 simultaneous requests.

Since the backend access is through a single account, we can init and store this client for use from each api call.