### PR TITLE
Bucket tagging actions

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -65,6 +65,11 @@ type Backend interface {
 	RestoreObject(context.Context, *s3.RestoreObjectInput) error
 	SelectObjectContent(ctx context.Context, input *s3.SelectObjectContentInput) func(w *bufio.Writer)
 
+	// bucket tagging operations
+	GetBucketTagging(_ context.Context, bucket string) (map[string]string, error)
+	PutBucketTagging(_ context.Context, bucket string, tags map[string]string) error
+	DeleteBucketTagging(_ context.Context, bucket string) error
+
 	// object tags operations
 	GetObjectTagging(_ context.Context, bucket, object string) (map[string]string, error)
 	PutObjectTagging(_ context.Context, bucket, object string, tags map[string]string) error
@@ -177,6 +182,16 @@ func (BackendUnsupported) SelectObjectContent(ctx context.Context, input *s3.Sel
 		apiErr := s3err.GetAPIError(s3err.ErrNotImplemented)
 		mh.FinishWithError(apiErr.Code, apiErr.Description)
 	}
+}
+
+func (BackendUnsupported) GetBucketTagging(_ context.Context, bucket string) (map[string]string, error) {
+	return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
+}
+func (BackendUnsupported) PutBucketTagging(_ context.Context, bucket string, tags map[string]string) error {
+	return s3err.GetAPIError(s3err.ErrNotImplemented)
+}
+func (BackendUnsupported) DeleteBucketTagging(_ context.Context, bucket string) error {
+	return s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 
 func (BackendUnsupported) GetObjectTagging(_ context.Context, bucket, object string) (map[string]string, error) {

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1777,7 +1777,7 @@ func (p *Posix) GetBucketTagging(_ context.Context, bucket string) (map[string]s
 		return nil, err
 	}
 
-	acl, err := xattr.Get(bucket, "user."+tagHdr)
+	acl, err := xattr.Get(bucket, proxyBucketAclKey)
 	if isNoAttr(err) {
 		return tags, nil
 	}
@@ -1785,7 +1785,7 @@ func (p *Posix) GetBucketTagging(_ context.Context, bucket string) (map[string]s
 		return nil, fmt.Errorf("get tags: %w", err)
 	}
 
-	tags[aclkey] = string(acl)
+	tags[proxyAclKey] = string(acl)
 
 	return tags, nil
 }

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -60,8 +60,6 @@ const (
 	contentEncHdr       = "content-encoding"
 	emptyMD5            = "d41d8cd98f00b204e9800998ecf8427e"
 	aclkey              = "user.acl"
-	proxyAclKey         = "versitygwAcl"
-	proxyBucketAclKey   = "user.proxy.acl"
 	etagkey             = "user.etag"
 )
 
@@ -1731,17 +1729,6 @@ func (p *Posix) PutBucketTagging(_ context.Context, bucket string, tags map[stri
 		return fmt.Errorf("stat bucket: %w", err)
 	}
 
-	acl, ok := tags[proxyAclKey]
-	if ok {
-		// set proxy acl in a separate xattr key
-		err = xattr.Set(bucket, proxyBucketAclKey, []byte(acl))
-		if err != nil {
-			return fmt.Errorf("set proxy acl: %w", err)
-		}
-
-		return nil
-	}
-
 	if tags == nil {
 		err = xattr.Remove(bucket, "user."+tagHdr)
 		if err != nil {
@@ -1776,16 +1763,6 @@ func (p *Posix) GetBucketTagging(_ context.Context, bucket string) (map[string]s
 	if err != nil {
 		return nil, err
 	}
-
-	acl, err := xattr.Get(bucket, proxyBucketAclKey)
-	if isNoAttr(err) {
-		return tags, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("get tags: %w", err)
-	}
-
-	tags[proxyAclKey] = string(acl)
 
 	return tags, nil
 }

--- a/cmd/versitygw/test.go
+++ b/cmd/versitygw/test.go
@@ -268,9 +268,11 @@ func getAction(tf testFunc) func(*cli.Context) error {
 func extractIntTests() (commands []*cli.Command) {
 	tests := integration.GetIntTests()
 	for key, val := range tests {
+		testKey := key
+		testFunc := val
 		commands = append(commands, &cli.Command{
-			Name:  key,
-			Usage: fmt.Sprintf("Runs %v integration test", key),
+			Name:  testKey,
+			Usage: fmt.Sprintf("Runs %v integration test", testKey),
 			Action: func(ctx *cli.Context) error {
 				opts := []integration.Option{
 					integration.WithAccess(awsID),
@@ -283,7 +285,7 @@ func extractIntTests() (commands []*cli.Command) {
 				}
 
 				s := integration.NewS3Conf(opts...)
-				err := val(s)
+				err := testFunc(s)
 				return err
 			},
 		})

--- a/integration/group-tests.go
+++ b/integration/group-tests.go
@@ -48,6 +48,23 @@ func TestDeleteBucket(s *S3Conf) {
 	DeleteBucket_success_status_code(s)
 }
 
+func TestPutBucketTagging(s *S3Conf) {
+	PutBucketTagging_non_existing_bucket(s)
+	PutBucketTagging_long_tags(s)
+	PutBucketTagging_success(s)
+}
+
+func TestGetBucketTagging(s *S3Conf) {
+	GetBucketTagging_non_existing_bucket(s)
+	GetBucketTagging_success(s)
+}
+
+func TestDeleteBucketTagging(s *S3Conf) {
+	DeleteBucketTagging_non_existing_object(s)
+	DeleteBucketTagging_success_status(s)
+	DeleteBucketTagging_success(s)
+}
+
 func TestPutObject(s *S3Conf) {
 	PutObject_non_existing_bucket(s)
 	PutObject_special_chars(s)
@@ -199,6 +216,9 @@ func TestFullFlow(s *S3Conf) {
 	TestHeadBucket(s)
 	TestListBuckets(s)
 	TestDeleteBucket(s)
+	TestPutBucketTagging(s)
+	TestGetBucketTagging(s)
+	TestDeleteBucketTagging(s)
 	TestPutObject(s)
 	TestHeadObject(s)
 	TestGetObject(s)
@@ -263,6 +283,14 @@ func GetIntTests() IntTests {
 		"DeleteBucket_non_existing_bucket":                    DeleteBucket_non_existing_bucket,
 		"DeleteBucket_non_empty_bucket":                       DeleteBucket_non_empty_bucket,
 		"DeleteBucket_success_status_code":                    DeleteBucket_success_status_code,
+		"PutBucketTagging_non_existing_bucket":                PutBucketTagging_non_existing_bucket,
+		"PutBucketTagging_long_tags":                          PutBucketTagging_long_tags,
+		"PutBucketTagging_success":                            PutBucketTagging_success,
+		"GetBucketTagging_non_existing_bucket":                GetBucketTagging_non_existing_bucket,
+		"GetBucketTagging_success":                            GetBucketTagging_success,
+		"DeleteBucketTagging_non_existing_object":             DeleteBucketTagging_non_existing_object,
+		"DeleteBucketTagging_success_status":                  DeleteBucketTagging_success_status,
+		"DeleteBucketTagging_success":                         DeleteBucketTagging_success,
 		"PutObject_non_existing_bucket":                       PutObject_non_existing_bucket,
 		"PutObject_special_chars":                             PutObject_special_chars,
 		"PutObject_invalid_long_tags":                         PutObject_invalid_long_tags,

--- a/s3api/controllers/backend_moq_test.go
+++ b/s3api/controllers/backend_moq_test.go
@@ -44,6 +44,9 @@ var _ backend.Backend = &BackendMock{}
 //			DeleteBucketFunc: func(contextMoqParam context.Context, deleteBucketInput *s3.DeleteBucketInput) error {
 //				panic("mock out the DeleteBucket method")
 //			},
+//			DeleteBucketTaggingFunc: func(contextMoqParam context.Context, bucket string) error {
+//				panic("mock out the DeleteBucketTagging method")
+//			},
 //			DeleteObjectFunc: func(contextMoqParam context.Context, deleteObjectInput *s3.DeleteObjectInput) error {
 //				panic("mock out the DeleteObject method")
 //			},
@@ -55,6 +58,9 @@ var _ backend.Backend = &BackendMock{}
 //			},
 //			GetBucketAclFunc: func(contextMoqParam context.Context, getBucketAclInput *s3.GetBucketAclInput) ([]byte, error) {
 //				panic("mock out the GetBucketAcl method")
+//			},
+//			GetBucketTaggingFunc: func(contextMoqParam context.Context, bucket string) (map[string]string, error) {
+//				panic("mock out the GetBucketTagging method")
 //			},
 //			GetObjectFunc: func(contextMoqParam context.Context, getObjectInput *s3.GetObjectInput, writer io.Writer) (*s3.GetObjectOutput, error) {
 //				panic("mock out the GetObject method")
@@ -94,6 +100,9 @@ var _ backend.Backend = &BackendMock{}
 //			},
 //			PutBucketAclFunc: func(contextMoqParam context.Context, bucket string, data []byte) error {
 //				panic("mock out the PutBucketAcl method")
+//			},
+//			PutBucketTaggingFunc: func(contextMoqParam context.Context, bucket string, tags map[string]string) error {
+//				panic("mock out the PutBucketTagging method")
 //			},
 //			PutObjectFunc: func(contextMoqParam context.Context, putObjectInput *s3.PutObjectInput) (string, error) {
 //				panic("mock out the PutObject method")
@@ -150,6 +159,9 @@ type BackendMock struct {
 	// DeleteBucketFunc mocks the DeleteBucket method.
 	DeleteBucketFunc func(contextMoqParam context.Context, deleteBucketInput *s3.DeleteBucketInput) error
 
+	// DeleteBucketTaggingFunc mocks the DeleteBucketTagging method.
+	DeleteBucketTaggingFunc func(contextMoqParam context.Context, bucket string) error
+
 	// DeleteObjectFunc mocks the DeleteObject method.
 	DeleteObjectFunc func(contextMoqParam context.Context, deleteObjectInput *s3.DeleteObjectInput) error
 
@@ -161,6 +173,9 @@ type BackendMock struct {
 
 	// GetBucketAclFunc mocks the GetBucketAcl method.
 	GetBucketAclFunc func(contextMoqParam context.Context, getBucketAclInput *s3.GetBucketAclInput) ([]byte, error)
+
+	// GetBucketTaggingFunc mocks the GetBucketTagging method.
+	GetBucketTaggingFunc func(contextMoqParam context.Context, bucket string) (map[string]string, error)
 
 	// GetObjectFunc mocks the GetObject method.
 	GetObjectFunc func(contextMoqParam context.Context, getObjectInput *s3.GetObjectInput, writer io.Writer) (*s3.GetObjectOutput, error)
@@ -200,6 +215,9 @@ type BackendMock struct {
 
 	// PutBucketAclFunc mocks the PutBucketAcl method.
 	PutBucketAclFunc func(contextMoqParam context.Context, bucket string, data []byte) error
+
+	// PutBucketTaggingFunc mocks the PutBucketTagging method.
+	PutBucketTaggingFunc func(contextMoqParam context.Context, bucket string, tags map[string]string) error
 
 	// PutObjectFunc mocks the PutObject method.
 	PutObjectFunc func(contextMoqParam context.Context, putObjectInput *s3.PutObjectInput) (string, error)
@@ -283,6 +301,13 @@ type BackendMock struct {
 			// DeleteBucketInput is the deleteBucketInput argument value.
 			DeleteBucketInput *s3.DeleteBucketInput
 		}
+		// DeleteBucketTagging holds details about calls to the DeleteBucketTagging method.
+		DeleteBucketTagging []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// Bucket is the bucket argument value.
+			Bucket string
+		}
 		// DeleteObject holds details about calls to the DeleteObject method.
 		DeleteObject []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
@@ -312,6 +337,13 @@ type BackendMock struct {
 			ContextMoqParam context.Context
 			// GetBucketAclInput is the getBucketAclInput argument value.
 			GetBucketAclInput *s3.GetBucketAclInput
+		}
+		// GetBucketTagging holds details about calls to the GetBucketTagging method.
+		GetBucketTagging []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// Bucket is the bucket argument value.
+			Bucket string
 		}
 		// GetObject holds details about calls to the GetObject method.
 		GetObject []struct {
@@ -410,6 +442,15 @@ type BackendMock struct {
 			// Data is the data argument value.
 			Data []byte
 		}
+		// PutBucketTagging holds details about calls to the PutBucketTagging method.
+		PutBucketTagging []struct {
+			// ContextMoqParam is the contextMoqParam argument value.
+			ContextMoqParam context.Context
+			// Bucket is the bucket argument value.
+			Bucket string
+			// Tags is the tags argument value.
+			Tags map[string]string
+		}
 		// PutObject holds details about calls to the PutObject method.
 		PutObject []struct {
 			// ContextMoqParam is the contextMoqParam argument value.
@@ -477,10 +518,12 @@ type BackendMock struct {
 	lockCreateBucket            sync.RWMutex
 	lockCreateMultipartUpload   sync.RWMutex
 	lockDeleteBucket            sync.RWMutex
+	lockDeleteBucketTagging     sync.RWMutex
 	lockDeleteObject            sync.RWMutex
 	lockDeleteObjectTagging     sync.RWMutex
 	lockDeleteObjects           sync.RWMutex
 	lockGetBucketAcl            sync.RWMutex
+	lockGetBucketTagging        sync.RWMutex
 	lockGetObject               sync.RWMutex
 	lockGetObjectAcl            sync.RWMutex
 	lockGetObjectAttributes     sync.RWMutex
@@ -494,6 +537,7 @@ type BackendMock struct {
 	lockListObjectsV2           sync.RWMutex
 	lockListParts               sync.RWMutex
 	lockPutBucketAcl            sync.RWMutex
+	lockPutBucketTagging        sync.RWMutex
 	lockPutObject               sync.RWMutex
 	lockPutObjectAcl            sync.RWMutex
 	lockPutObjectTagging        sync.RWMutex
@@ -765,6 +809,42 @@ func (mock *BackendMock) DeleteBucketCalls() []struct {
 	return calls
 }
 
+// DeleteBucketTagging calls DeleteBucketTaggingFunc.
+func (mock *BackendMock) DeleteBucketTagging(contextMoqParam context.Context, bucket string) error {
+	if mock.DeleteBucketTaggingFunc == nil {
+		panic("BackendMock.DeleteBucketTaggingFunc: method is nil but Backend.DeleteBucketTagging was just called")
+	}
+	callInfo := struct {
+		ContextMoqParam context.Context
+		Bucket          string
+	}{
+		ContextMoqParam: contextMoqParam,
+		Bucket:          bucket,
+	}
+	mock.lockDeleteBucketTagging.Lock()
+	mock.calls.DeleteBucketTagging = append(mock.calls.DeleteBucketTagging, callInfo)
+	mock.lockDeleteBucketTagging.Unlock()
+	return mock.DeleteBucketTaggingFunc(contextMoqParam, bucket)
+}
+
+// DeleteBucketTaggingCalls gets all the calls that were made to DeleteBucketTagging.
+// Check the length with:
+//
+//	len(mockedBackend.DeleteBucketTaggingCalls())
+func (mock *BackendMock) DeleteBucketTaggingCalls() []struct {
+	ContextMoqParam context.Context
+	Bucket          string
+} {
+	var calls []struct {
+		ContextMoqParam context.Context
+		Bucket          string
+	}
+	mock.lockDeleteBucketTagging.RLock()
+	calls = mock.calls.DeleteBucketTagging
+	mock.lockDeleteBucketTagging.RUnlock()
+	return calls
+}
+
 // DeleteObject calls DeleteObjectFunc.
 func (mock *BackendMock) DeleteObject(contextMoqParam context.Context, deleteObjectInput *s3.DeleteObjectInput) error {
 	if mock.DeleteObjectFunc == nil {
@@ -910,6 +990,42 @@ func (mock *BackendMock) GetBucketAclCalls() []struct {
 	mock.lockGetBucketAcl.RLock()
 	calls = mock.calls.GetBucketAcl
 	mock.lockGetBucketAcl.RUnlock()
+	return calls
+}
+
+// GetBucketTagging calls GetBucketTaggingFunc.
+func (mock *BackendMock) GetBucketTagging(contextMoqParam context.Context, bucket string) (map[string]string, error) {
+	if mock.GetBucketTaggingFunc == nil {
+		panic("BackendMock.GetBucketTaggingFunc: method is nil but Backend.GetBucketTagging was just called")
+	}
+	callInfo := struct {
+		ContextMoqParam context.Context
+		Bucket          string
+	}{
+		ContextMoqParam: contextMoqParam,
+		Bucket:          bucket,
+	}
+	mock.lockGetBucketTagging.Lock()
+	mock.calls.GetBucketTagging = append(mock.calls.GetBucketTagging, callInfo)
+	mock.lockGetBucketTagging.Unlock()
+	return mock.GetBucketTaggingFunc(contextMoqParam, bucket)
+}
+
+// GetBucketTaggingCalls gets all the calls that were made to GetBucketTagging.
+// Check the length with:
+//
+//	len(mockedBackend.GetBucketTaggingCalls())
+func (mock *BackendMock) GetBucketTaggingCalls() []struct {
+	ContextMoqParam context.Context
+	Bucket          string
+} {
+	var calls []struct {
+		ContextMoqParam context.Context
+		Bucket          string
+	}
+	mock.lockGetBucketTagging.RLock()
+	calls = mock.calls.GetBucketTagging
+	mock.lockGetBucketTagging.RUnlock()
 	return calls
 }
 
@@ -1390,6 +1506,46 @@ func (mock *BackendMock) PutBucketAclCalls() []struct {
 	mock.lockPutBucketAcl.RLock()
 	calls = mock.calls.PutBucketAcl
 	mock.lockPutBucketAcl.RUnlock()
+	return calls
+}
+
+// PutBucketTagging calls PutBucketTaggingFunc.
+func (mock *BackendMock) PutBucketTagging(contextMoqParam context.Context, bucket string, tags map[string]string) error {
+	if mock.PutBucketTaggingFunc == nil {
+		panic("BackendMock.PutBucketTaggingFunc: method is nil but Backend.PutBucketTagging was just called")
+	}
+	callInfo := struct {
+		ContextMoqParam context.Context
+		Bucket          string
+		Tags            map[string]string
+	}{
+		ContextMoqParam: contextMoqParam,
+		Bucket:          bucket,
+		Tags:            tags,
+	}
+	mock.lockPutBucketTagging.Lock()
+	mock.calls.PutBucketTagging = append(mock.calls.PutBucketTagging, callInfo)
+	mock.lockPutBucketTagging.Unlock()
+	return mock.PutBucketTaggingFunc(contextMoqParam, bucket, tags)
+}
+
+// PutBucketTaggingCalls gets all the calls that were made to PutBucketTagging.
+// Check the length with:
+//
+//	len(mockedBackend.PutBucketTaggingCalls())
+func (mock *BackendMock) PutBucketTaggingCalls() []struct {
+	ContextMoqParam context.Context
+	Bucket          string
+	Tags            map[string]string
+} {
+	var calls []struct {
+		ContextMoqParam context.Context
+		Bucket          string
+		Tags            map[string]string
+	}
+	mock.lockPutBucketTagging.RLock()
+	calls = mock.calls.PutBucketTagging
+	mock.lockPutBucketTagging.RUnlock()
 	return calls
 }
 

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -764,7 +764,7 @@ func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 		}
 
 		err := c.be.DeleteBucketTagging(ctx.Context(), bucket)
-		return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucketTagging", BucketOwner: parsedAcl.Owner})
+		return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucketTagging", BucketOwner: parsedAcl.Owner, Status: http.StatusNoContent})
 	}
 
 	if err := auth.VerifyACL(parsedAcl, acct.Access, "WRITE", isRoot); err != nil {
@@ -774,7 +774,7 @@ func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 	err := c.be.DeleteBucket(ctx.Context(), &s3.DeleteBucketInput{
 		Bucket: &bucket,
 	})
-	return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucket", BucketOwner: parsedAcl.Owner, Status: 204})
+	return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucket", BucketOwner: parsedAcl.Owner, Status: http.StatusNoContent})
 }
 
 func (c S3ApiController) DeleteObjects(ctx *fiber.Ctx) error {

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -246,6 +246,24 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 	isRoot := ctx.Locals("isRoot").(bool)
 	parsedAcl := ctx.Locals("parsedAcl").(auth.ACL)
 
+	if ctx.Request().URI().QueryArgs().Has("tagging") {
+		if err := auth.VerifyACL(parsedAcl, acct.Access, "READ", isRoot); err != nil {
+			return SendXMLResponse(ctx, nil, err, &MetaOpts{Logger: c.logger, Action: "GetBucketTagging", BucketOwner: parsedAcl.Owner})
+		}
+
+		tags, err := c.be.GetBucketTagging(ctx.Context(), bucket)
+		if err != nil {
+			return SendXMLResponse(ctx, nil, err, &MetaOpts{Logger: c.logger, Action: "GetBucketTagging", BucketOwner: parsedAcl.Owner})
+		}
+		resp := s3response.Tagging{TagSet: s3response.TagSet{Tags: []s3response.Tag{}}}
+
+		for key, val := range tags {
+			resp.TagSet.Tags = append(resp.TagSet.Tags, s3response.Tag{Key: key, Value: val})
+		}
+
+		return SendXMLResponse(ctx, resp, nil, &MetaOpts{Logger: c.logger, Action: "GetBucketTagging", BucketOwner: parsedAcl.Owner})
+	}
+
 	if ctx.Request().URI().QueryArgs().Has("acl") {
 		if err := auth.VerifyACL(parsedAcl, acct.Access, "READ_ACP", isRoot); err != nil {
 			return SendXMLResponse(ctx, nil, err, &MetaOpts{Logger: c.logger, Action: "GetBucketAcl", BucketOwner: parsedAcl.Owner})
@@ -339,6 +357,32 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 		ctx.Get("X-Amz-Grant-Write-Acp"),
 		ctx.Locals("account").(auth.Account),
 		ctx.Locals("isRoot").(bool)
+
+	if ctx.Request().URI().QueryArgs().Has("tagging") {
+		parsedAcl := ctx.Locals("parsedAcl").(auth.ACL)
+
+		var bucketTagging s3response.Tagging
+		err := xml.Unmarshal(ctx.Body(), &bucketTagging)
+		if err != nil {
+			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidRequest), &MetaOpts{Logger: c.logger, Action: "PutBucketTagging", BucketOwner: parsedAcl.Owner})
+		}
+
+		tags := make(map[string]string, len(bucketTagging.TagSet.Tags))
+
+		for _, tag := range bucketTagging.TagSet.Tags {
+			if len(tag.Key) > 128 || len(tag.Value) > 256 {
+				return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidTag), &MetaOpts{Logger: c.logger, Action: "PutBucketTagging", BucketOwner: parsedAcl.Owner})
+			}
+			tags[tag.Key] = tag.Value
+		}
+
+		if err := auth.VerifyACL(parsedAcl, acct.Access, "WRITE", isRoot); err != nil {
+			return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "PutBucketTagging", BucketOwner: parsedAcl.Owner})
+		}
+
+		err = c.be.PutBucketTagging(ctx.Context(), bucket, tags)
+		return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "PutBucketTagging", BucketOwner: parsedAcl.Owner})
+	}
 
 	grants := grantFullControl + grantRead + grantReadACP + granWrite + grantWriteACP
 
@@ -713,6 +757,15 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 
 func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 	bucket, acct, isRoot, parsedAcl := ctx.Params("bucket"), ctx.Locals("account").(auth.Account), ctx.Locals("isRoot").(bool), ctx.Locals("parsedAcl").(auth.ACL)
+
+	if ctx.Request().URI().QueryArgs().Has("tagging") {
+		if err := auth.VerifyACL(parsedAcl, acct.Access, "WRITE", isRoot); err != nil {
+			return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucketTagging", BucketOwner: parsedAcl.Owner})
+		}
+
+		err := c.be.DeleteBucketTagging(ctx.Context(), bucket)
+		return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucketTagging", BucketOwner: parsedAcl.Owner})
+	}
 
 	if err := auth.VerifyACL(parsedAcl, acct.Access, "WRITE", isRoot); err != nil {
 		return SendResponse(ctx, err, &MetaOpts{Logger: c.logger, Action: "DeleteBucket", BucketOwner: parsedAcl.Owner})

--- a/s3api/middlewares/acl-parser.go
+++ b/s3api/middlewares/acl-parser.go
@@ -38,7 +38,7 @@ func AclParser(be backend.Backend, logger s3log.AuditLogger) fiber.Handler {
 		if ctx.Method() == http.MethodPatch {
 			return ctx.Next()
 		}
-		if len(pathParts) == 2 && pathParts[1] != "" && ctx.Method() == http.MethodPut && !ctx.Request().URI().QueryArgs().Has("acl") {
+		if len(pathParts) == 2 && pathParts[1] != "" && ctx.Method() == http.MethodPut && !ctx.Request().URI().QueryArgs().Has("acl") && !ctx.Request().URI().QueryArgs().Has("tagging") {
 			if err := auth.IsAdmin(acct, isRoot); err != nil {
 				return controllers.SendXMLResponse(ctx, nil, err, &controllers.MetaOpts{Logger: logger, Action: "CreateBucket"})
 			}


### PR DESCRIPTION
Added support for the following actions in posix backend
1. PutBucketTagging
2. GetBucketTagging
3. DeleteBucketTagging

proxy acl is stored in a separate xattr key, to differentiate the tags from acl.