### PR TITLE
fix: remove namespace restrictions on tag xml input

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -615,7 +615,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 	if ctx.Request().URI().QueryArgs().Has("tagging") {
 		parsedAcl := ctx.Locals("parsedAcl").(auth.ACL)
 
-		var bucketTagging s3response.Tagging
+		var bucketTagging s3response.TaggingInput
 		err := xml.Unmarshal(ctx.Body(), &bucketTagging)
 		if err != nil {
 			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidRequest),
@@ -922,7 +922,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 	}
 
 	if ctx.Request().URI().QueryArgs().Has("tagging") {
-		var objTagging s3response.Tagging
+		var objTagging s3response.TaggingInput
 		err := xml.Unmarshal(ctx.Body(), &objTagging)
 		if err != nil {
 			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidRequest),

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -112,6 +112,10 @@ type Tagging struct {
 	TagSet  TagSet   `xml:"TagSet"`
 }
 
+type TaggingInput struct {
+	TagSet TagSet `xml:"TagSet"`
+}
+
 type DeleteObjects struct {
 	Objects []types.ObjectIdentifier `xml:"Object"`
 }


### PR DESCRIPTION
Fixes #447. Previously we required XML namespace and got these errors with this input:
DEBUG:  <Tagging><TagSet><Tag><Key>mykey</Key><Value>myvalue</Value></Tag></TagSet></Tagging>
DEBUG: expected element <Tagging> in name space http://s3.amazonaws.com/doc/2006-03-01/ but have no name space