### PR TITLE
fix: zero len put error when content length value not defined

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -909,6 +909,9 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 
 	// Other headers
 	contentLengthStr := ctx.Get("Content-Length")
+	if contentLengthStr == "" {
+		contentLengthStr = "0"
+	}
 	bucketOwner := ctx.Get("X-Amz-Expected-Bucket-Owner")
 
 	grants := grantFullControl + grantRead + grantReadACP + granWrite + grantWriteACP


### PR DESCRIPTION
Fixes #444. For some clients using chunked uploads with a zero length file, the content length value from the request headers was coming back as an empty string. If this happens, just set it to "0" so that we can successfully parse this to int value.