### PR TITLE
feat: add s3err QuotaExceeded for posix/scoutfs

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -116,6 +116,7 @@ const (
 	ErrExistingObjectIsDirectory
 	ErrObjectParentIsFile
 	ErrDirectoryObjectContainsData
+	ErrQuotaExceeded
 )
 
 var errorCodeResponse = map[ErrorCode]APIError{
@@ -413,6 +414,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "DirectoryObjectContainsData",
 		Description:    "Directory object contains data payload.",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrQuotaExceeded: {
+		Code:           "QuotaExceeded",
+		Description:    "Your request was denied due to quota exceeded.",
+		HTTPStatusCode: http.StatusForbidden,
 	},
 }
 


### PR DESCRIPTION
When fileystem quota exceeded, the gateway will now return the error:
S3 error: 403 (QuotaExceeded):
Your request was denied due to quota exceeded.

This will help clients to better detect upload errors due to quota exceeded.

Fixes #483