### PR TITLE
feat: add more debug logging for api handler errors

### DIFF
--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -77,7 +77,8 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.args.be, tt.args.iam, nil, nil); !reflect.DeepEqual(got, tt.want) {
+			got := New(tt.args.be, tt.args.iam, nil, nil, false)
+			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("New() = %v, want %v", got, tt.want)
 			}
 		})

--- a/s3api/router.go
+++ b/s3api/router.go
@@ -27,8 +27,8 @@ type S3ApiRouter struct {
 	WithAdmSrv bool
 }
 
-func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMService, logger s3log.AuditLogger, evs s3event.S3EventSender) {
-	s3ApiController := controllers.New(be, iam, logger, evs)
+func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMService, logger s3log.AuditLogger, evs s3event.S3EventSender, debug bool) {
+	s3ApiController := controllers.New(be, iam, logger, evs, debug)
 
 	if sa.WithAdmSrv {
 		adminController := controllers.NewAdminController(iam, be)

--- a/s3api/router_test.go
+++ b/s3api/router_test.go
@@ -45,7 +45,7 @@ func TestS3ApiRouter_Init(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.sa.Init(tt.args.app, tt.args.be, tt.args.iam, nil, nil)
+			tt.sa.Init(tt.args.app, tt.args.be, tt.args.iam, nil, nil, false)
 		})
 	}
 }

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -70,7 +70,7 @@ func New(app *fiber.App, be backend.Backend, root middlewares.RootUserConfig, po
 	app.Use(middlewares.VerifyMD5Body(l))
 	app.Use(middlewares.AclParser(be, l))
 
-	server.router.Init(app, be, iam, l, evs)
+	server.router.Init(app, be, iam, l, evs, server.debug)
 
 	return server, nil
 }


### PR DESCRIPTION
There are a few cases where parsing, validations checks, etc error details are getting lost with the more generic error responses. This add some opt-in debug logging to log more info for these various error cases.