### PR TITLE
feat: add metadata storage abstraction layer

### DIFF
--- a/backend/meta/meta.go
+++ b/backend/meta/meta.go
@@ -1,0 +1,26 @@
+package meta
+
+// MetadataStorer defines the interface for managing metadata.
+// When object == "", the operation is on the bucket.
+type MetadataStorer interface {
+	// RetrieveAttribute retrieves the value of a specific attribute for an object or a bucket.
+	// Returns the value of the attribute, or an error if the attribute does not exist.
+	RetrieveAttribute(bucket, object, attribute string) ([]byte, error)
+
+	// StoreAttribute stores the value of a specific attribute for an object or a bucket.
+	// If attribute already exists, new attribute should replace existing.
+	// Returns an error if the operation fails.
+	StoreAttribute(bucket, object, attribute string, value []byte) error
+
+	// DeleteAttribute removes the value of a specific attribute for an object or a bucket.
+	// Returns an error if the operation fails.
+	DeleteAttribute(bucket, object, attribute string) error
+
+	// ListAttributes lists all attributes for an object or a bucket.
+	// Returns list of attribute names, or an error if the operation fails.
+	ListAttributes(bucket, object string) ([]string, error)
+
+	// DeleteAttributes removes all attributes for an object or a bucket.
+	// Returns an error if the operation fails.
+	DeleteAttributes(bucket, object string) error
+}

--- a/backend/meta/xattr.go
+++ b/backend/meta/xattr.go
@@ -1,0 +1,76 @@
+package meta
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/pkg/xattr"
+)
+
+const (
+	xattrPrefix = "user."
+)
+
+var (
+	// ErrNoSuchKey is returned when the key does not exist.
+	ErrNoSuchKey = errors.New("no such key")
+)
+
+type XattrMeta struct{}
+
+// RetrieveAttribute retrieves the value of a specific attribute for an object in a bucket.
+func (x XattrMeta) RetrieveAttribute(bucket, object, attribute string) ([]byte, error) {
+	b, err := xattr.Get(filepath.Join(bucket, object), xattrPrefix+attribute)
+	if errors.Is(err, errNoData) {
+		return nil, ErrNoSuchKey
+	}
+	return b, err
+}
+
+// StoreAttribute stores the value of a specific attribute for an object in a bucket.
+func (x XattrMeta) StoreAttribute(bucket, object, attribute string, value []byte) error {
+	return xattr.Set(filepath.Join(bucket, object), xattrPrefix+attribute, value)
+}
+
+// DeleteAttribute removes the value of a specific attribute for an object in a bucket.
+func (x XattrMeta) DeleteAttribute(bucket, object, attribute string) error {
+	err := xattr.Remove(filepath.Join(bucket, object), xattrPrefix+attribute)
+	if errors.Is(err, errNoData) {
+		return ErrNoSuchKey
+	}
+	return err
+}
+
+// DeleteAttributes is not implemented for xattr since xattrs
+// are automatically removed when the file is deleted.
+func (x XattrMeta) DeleteAttributes(bucket, object string) error {
+	return nil
+}
+
+// ListAttributes lists all attributes for an object in a bucket.
+func (x XattrMeta) ListAttributes(bucket, object string) ([]string, error) {
+	attrs, err := xattr.List(filepath.Join(bucket, object))
+	if err != nil {
+		return nil, err
+	}
+	attributes := make([]string, 0, len(attrs))
+	for _, attr := range attrs {
+		if !isUserAttr(attr) {
+			continue
+		}
+		attributes = append(attributes, strings.TrimPrefix(attr, xattrPrefix))
+	}
+	return attributes, nil
+}
+
+func isUserAttr(attr string) bool {
+	return strings.HasPrefix(attr, xattrPrefix)
+}
+
+// Test is a helper function to test if xattrs are supported.
+func (x XattrMeta) Test(path string) bool {
+	_, err := xattr.Get(path, "user.test")
+	return !errors.Is(err, syscall.ENOTSUP)
+}

--- a/backend/meta/xattr_with_enodata.go
+++ b/backend/meta/xattr_with_enodata.go
@@ -15,7 +15,7 @@
 //go:build !freebsd && !openbsd && !netbsd
 // +build !freebsd,!openbsd,!netbsd
 
-package posix
+package meta
 
 import "syscall"
 

--- a/backend/meta/xattr_without_enodata.go
+++ b/backend/meta/xattr_without_enodata.go
@@ -15,7 +15,7 @@
 //go:build freebsd || openbsd || netbsd
 // +build freebsd openbsd netbsd
 
-package posix
+package meta
 
 import "syscall"
 

--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -30,11 +30,12 @@ import (
 	"github.com/versity/scoutfs-go"
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/backend/meta"
 	"github.com/versity/versitygw/backend/posix"
 )
 
 func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
-	p, err := posix.New(rootdir, posix.PosixOpts{
+	p, err := posix.New(rootdir, meta.XattrMeta{}, posix.PosixOpts{
 		ChownUID: opts.ChownUID,
 		ChownGID: opts.ChownGID,
 	})

--- a/cmd/versitygw/gateway_test.go
+++ b/cmd/versitygw/gateway_test.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/versity/versitygw/backend/meta"
 	"github.com/versity/versitygw/backend/posix"
 	"github.com/versity/versitygw/tests/integration"
 )
@@ -56,7 +57,7 @@ func initPosix(ctx context.Context) {
 		log.Fatalf("make temp directory: %v", err)
 	}
 
-	be, err := posix.New(tempdir, posix.PosixOpts{})
+	be, err := posix.New(tempdir, meta.XattrMeta{}, posix.PosixOpts{})
 	if err != nil {
 		log.Fatalf("init posix: %v", err)
 	}

--- a/cmd/versitygw/posix.go
+++ b/cmd/versitygw/posix.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/urfave/cli/v2"
+	"github.com/versity/versitygw/backend/meta"
 	"github.com/versity/versitygw/backend/posix"
 )
 
@@ -62,7 +63,13 @@ func runPosix(ctx *cli.Context) error {
 		return fmt.Errorf("no directory provided for operation")
 	}
 
-	be, err := posix.New(ctx.Args().Get(0), posix.PosixOpts{
+	gwroot := (ctx.Args().Get(0))
+	ok := meta.XattrMeta{}.Test(gwroot)
+	if !ok {
+		return fmt.Errorf("posix backend requires extended attributes support")
+	}
+
+	be, err := posix.New(gwroot, meta.XattrMeta{}, posix.PosixOpts{
 		ChownUID: chownuid,
 		ChownGID: chowngid,
 	})


### PR DESCRIPTION
Closes #511. This adds an abstraction layer to the metadata storage to allow for future non-xattr metadata storage implementations.