### PR TITLE
fix: auth iam single error for GetUserAccount()

### DIFF
--- a/auth/iam_single.go
+++ b/auth/iam_single.go
@@ -32,7 +32,7 @@ func (IAMServiceSingle) CreateAccount(account Account) error {
 
 // GetUserAccount no accounts in single tenant mode
 func (IAMServiceSingle) GetUserAccount(access string) (Account, error) {
-	return Account{}, ErrNotSupported
+	return Account{}, ErrNoSuchUser
 }
 
 // DeleteUserAccount no accounts in single tenant mode


### PR DESCRIPTION
Fixes #524. The iam single needs to return ErrNoSuchUser instead of ErrNotSupported in GetUserAccount to return the correct error when the client access is not done by the single user account.

This fixes the internal error when accessing the gateway in iam single user mode with incorrect access keys.