### PR TITLE
fix: as of Go 1.21, toolchain versions must use the 1.N.P syntax

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/versity/versitygw
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1


### PR DESCRIPTION
Setting min toolchain to 1.21.0 for the gateway.
see: https://go.dev/doc/toolchain#version