### PR TITLE
AWS error refactoring

### DIFF
--- a/auth/bucket_policy.go
+++ b/auth/bucket_policy.go
@@ -117,7 +117,7 @@ func ValidatePolicyDocument(policyBin []byte, bucket string, iam IAMService) err
 
 func verifyBucketPolicy(policy []byte, access, bucket, object string, action Action) error {
 	// If bucket policy is not set
-	if len(policy) == 0 {
+	if policy == nil {
 		return nil
 	}
 

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -116,6 +116,9 @@ const (
 	ErrInvalidBucketObjectLockConfiguration
 	ErrObjectLocked
 	ErrPastObjectLockRetainDate
+	ErrNoSuchBucketPolicy
+	ErrBucketTaggingNotFound
+	ErrObjectLockInvalidHeaders
 	ErrRequestTimeTooSkewed
 
 	// Non-AWS errors
@@ -429,6 +432,21 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrPastObjectLockRetainDate: {
 		Code:           "InvalidRequest",
 		Description:    "the retain until date must be in the future",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrNoSuchBucketPolicy: {
+		Code:           "NoSuchBucketPolicy",
+		Description:    "The bucket policy does not exist",
+		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrBucketTaggingNotFound: {
+		Code:           "NoSuchTagSet",
+		Description:    "The TagSet does not exist",
+		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrObjectLockInvalidHeaders: {
+		Code:           "InvalidRequest",
+		Description:    "x-amz-object-lock-retain-until-date and x-amz-object-lock-mode must both be supplied",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrRequestTimeTooSkewed: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -54,6 +54,7 @@ func TestCreateBucket(s *S3Conf) {
 	CreateBucket_default_acl(s)
 	CreateBucket_non_default_acl(s)
 	CreateDeleteBucket_success(s)
+	CreateBucket_default_object_lock(s)
 }
 
 func TestHeadBucket(s *S3Conf) {
@@ -81,6 +82,7 @@ func TestPutBucketTagging(s *S3Conf) {
 
 func TestGetBucketTagging(s *S3Conf) {
 	GetBucketTagging_non_existing_bucket(s)
+	GetBucketTagging_unset_tags(s)
 	GetBucketTagging_success(s)
 }
 
@@ -94,6 +96,8 @@ func TestPutObject(s *S3Conf) {
 	PutObject_non_existing_bucket(s)
 	PutObject_special_chars(s)
 	PutObject_invalid_long_tags(s)
+	PutObject_missing_object_lock_retention_config(s)
+	PutObject_with_object_lock(s)
 	PutObject_success(s)
 	PutObject_invalid_credentials(s)
 }
@@ -165,6 +169,7 @@ func TestPutObjectTagging(s *S3Conf) {
 
 func TestGetObjectTagging(s *S3Conf) {
 	GetObjectTagging_non_existing_object(s)
+	GetObjectTagging_unset_tags(s)
 	GetObjectTagging_success(s)
 }
 
@@ -275,7 +280,7 @@ func TestPutBucketPolicy(s *S3Conf) {
 
 func TestGetBucketPolicy(s *S3Conf) {
 	GetBucketPolicy_non_existing_bucket(s)
-	GetBucketPolicy_default_empty_policy(s)
+	GetBucketPolicy_not_set(s)
 	GetBucketPolicy_success(s)
 }
 
@@ -449,6 +454,8 @@ func GetIntTests() IntTests {
 		"PresignedAuth_expired_request":                                      PresignedAuth_expired_request,
 		"PresignedAuth_incorrect_secret_key":                                 PresignedAuth_incorrect_secret_key,
 		"PresignedAuth_PutObject_success":                                    PresignedAuth_PutObject_success,
+		"PutObject_missing_object_lock_retention_config":                     PutObject_missing_object_lock_retention_config,
+		"PutObject_with_object_lock":                                         PutObject_with_object_lock,
 		"PresignedAuth_Put_GetObject_with_data":                              PresignedAuth_Put_GetObject_with_data,
 		"PresignedAuth_Put_GetObject_with_UTF8_chars":                        PresignedAuth_Put_GetObject_with_UTF8_chars,
 		"PresignedAuth_UploadPart":                                           PresignedAuth_UploadPart,
@@ -458,6 +465,7 @@ func GetIntTests() IntTests {
 		"CreateDeleteBucket_success":                                         CreateDeleteBucket_success,
 		"CreateBucket_default_acl":                                           CreateBucket_default_acl,
 		"CreateBucket_non_default_acl":                                       CreateBucket_non_default_acl,
+		"CreateBucket_default_object_lock":                                   CreateBucket_default_object_lock,
 		"HeadBucket_non_existing_bucket":                                     HeadBucket_non_existing_bucket,
 		"HeadBucket_success":                                                 HeadBucket_success,
 		"ListBuckets_as_user":                                                ListBuckets_as_user,
@@ -470,6 +478,7 @@ func GetIntTests() IntTests {
 		"PutBucketTagging_long_tags":                                         PutBucketTagging_long_tags,
 		"PutBucketTagging_success":                                           PutBucketTagging_success,
 		"GetBucketTagging_non_existing_bucket":                               GetBucketTagging_non_existing_bucket,
+		"GetBucketTagging_unset_tags":                                        GetBucketTagging_unset_tags,
 		"GetBucketTagging_success":                                           GetBucketTagging_success,
 		"DeleteBucketTagging_non_existing_object":                            DeleteBucketTagging_non_existing_object,
 		"DeleteBucketTagging_success_status":                                 DeleteBucketTagging_success_status,
@@ -517,6 +526,7 @@ func GetIntTests() IntTests {
 		"PutObjectTagging_long_tags":                                         PutObjectTagging_long_tags,
 		"PutObjectTagging_success":                                           PutObjectTagging_success,
 		"GetObjectTagging_non_existing_object":                               GetObjectTagging_non_existing_object,
+		"GetObjectTagging_unset_tags":                                        GetObjectTagging_unset_tags,
 		"GetObjectTagging_success":                                           GetObjectTagging_success,
 		"DeleteObjectTagging_non_existing_object":                            DeleteObjectTagging_non_existing_object,
 		"DeleteObjectTagging_success_status":                                 DeleteObjectTagging_success_status,
@@ -591,7 +601,7 @@ func GetIntTests() IntTests {
 		"PutBucketPolicy_bucket_action_on_object_resource":                   PutBucketPolicy_bucket_action_on_object_resource,
 		"PutBucketPolicy_success":                                            PutBucketPolicy_success,
 		"GetBucketPolicy_non_existing_bucket":                                GetBucketPolicy_non_existing_bucket,
-		"GetBucketPolicy_default_empty_policy":                               GetBucketPolicy_default_empty_policy,
+		"GetBucketPolicy_not_set":                                            GetBucketPolicy_not_set,
 		"GetBucketPolicy_success":                                            GetBucketPolicy_success,
 		"DeleteBucketPolicy_non_existing_bucket":                             DeleteBucketPolicy_non_existing_bucket,
 		"DeleteBucketPolicy_remove_before_setting":                           DeleteBucketPolicy_remove_before_setting,

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -239,8 +239,8 @@ test_common_set_get_object_tags() {
   [[ $get_result -eq 0 ]] || fail "Error getting object tags"
   if [[ $1 == 'aws' ]]; then
     tag_set=$(echo "$tags" | jq '.TagSet')
-    [[ $tag_set == "[]" ]] || fail "Error:  tags not empty"
-  elif [[ ! $tags == *"No tags found"* ]]; then
+    [[ $tag_set == "[]" ]] || [[ $tag_set == "" ]] || fail "Error:  tags not empty"
+  elif [[ $tags != *"No tags found"* ]] && [[ $tags != "" ]]; then
     fail "no tags found (tags: $tags)"
   fi
 
@@ -397,7 +397,7 @@ EOF
   put_bucket_policy "$1" "$BUCKET_ONE_NAME" "$test_file_folder"/"$policy_file" || put_result=$?
   [[ $put_result -eq 0 ]] || fail "error putting bucket"
 
-  get_bucket_policy "$1" "$BUCKET_ONE_NAME" || get_result=$?
+  get_bucket_policy "$1" "$BUCKET_ONE_NAME" || local get_result=$?
   [[ $get_result -eq 0 ]] || fail "error getting bucket policy after setting"
 
   returned_effect=$(echo "$bucket_policy" | jq -r '.Statement[0].Effect')

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -710,11 +710,16 @@ get_object_tags() {
     return 1
   fi
   if [[ $result -ne 0 ]]; then
-    echo "error getting object tags: $tags"
-    return 1
+    if [[ "$tags" == *"NoSuchTagSet"* ]] || [[ "$tags" == *"No tags found"* ]]; then
+      tags=
+    else
+      echo "error getting object tags: $tags"
+      return 1
+    fi
+  else
+    log 5 "$tags"
+    tags=$(echo "$tags" | grep -v "InsecureRequestWarning")
   fi
-  log 5 "$tags"
-  tags=$(echo "$tags" | grep -v "InsecureRequestWarning")
   export tags
 }
 

--- a/tests/util_policy.sh
+++ b/tests/util_policy.sh
@@ -6,6 +6,7 @@ check_for_empty_policy() {
     return 1
   fi
 
+  local get_result=0
   get_bucket_policy "$1" "$2" || get_result=$?
   if [[ $get_result -ne 0 ]]; then
     echo "error getting bucket policy"
@@ -13,6 +14,10 @@ check_for_empty_policy() {
   fi
 
   # shellcheck disable=SC2154
+  if [[ $bucket_policy == "" ]]; then
+    return 0
+  fi
+
   policy=$(echo "$bucket_policy" | jq -r '.Policy')
   statement=$(echo "$policy" | jq -r '.Statement[0]')
   if [[ "" != "$statement" ]] && [[ "null" != "$statement" ]]; then


### PR DESCRIPTION
1. AWS error refactoring
2. Added support to enable object lock on bucket creation in posix and azure backends.
3. Implemented the logic to add object legal hold and retention on object creation in azure and posix backends.
4. Added the functionality for HeadObject to return object lock related headers in posix.
5. Added couple of integration tests for these features.