### PR TITLE
CopyObject response body type

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -1747,7 +1747,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 				Metadata:                    metadata,
 			})
 		if err == nil {
-			return SendXMLResponse(ctx, res, err,
+			return SendXMLResponse(ctx, res.CopyObjectResult, err,
 				&MetaOpts{
 					Logger:      c.logger,
 					EvSender:    c.evSender,


### PR DESCRIPTION
CopyObject action response body has `CopyObjectResult` type.
In terms of Go SDK it's `s3.CopyObjectOutput.CopyObjectResult`.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_CopyObject.html#AmazonS3-CopyObject-response-CopyObjectResult