### PR TITLE
Set the media type for directories

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1596,6 +1596,11 @@ func (p *Posix) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.
 	userMetaData := make(map[string]string)
 	contentType, contentEncoding := p.loadUserMetaData(bucket, object, userMetaData)
 
+	if fi.IsDir() {
+		// this is the media type for directories in AWS and Nextcloud
+		contentType = "application/x-directory"
+	}
+
 	b, err := p.meta.RetrieveAttribute(bucket, object, etagkey)
 	etag := string(b)
 	if err != nil {


### PR DESCRIPTION
This fixes a bug where s3fs-fuse doesn't recognize directories served by versitygw

versitygw is sending back (at least on my filesystem) a media type of text/plain and a size of 4096.  s3fs is looking for one of these:
* media type "application/x-directory"  (which I believe is used by AWS and Nextcloud)
* media type "httpd/unix-directory"
* a non-empty string ending with "/" and
  * media type "binary/octect-stream" or "application/octet-stream"  or
  * media type "text/plain" and size == 0 or 1

Since none of those match, directories are returned as regular files and can't be used.

This patch sets the media type to "application/x-directory" to ensure directories are recognized.