### PR TITLE
fix: expose posix tmpfile fd to enable copy_file_range

### DIFF
--- a/backend/posix/with_otmpfile.go
+++ b/backend/posix/with_otmpfile.go
@@ -50,7 +50,7 @@ var (
 	defaultFilePerm uint32 = 0644
 )
 
-func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Account) (*tmpfile, error) {
+func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Account, dofalloc bool) (*tmpfile, error) {
 	uid, gid, doChown := p.getChownIDs(acct)
 
 	// O_TMPFILE allows for a file handle to an unnamed file in the filesystem.
@@ -81,7 +81,7 @@ func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Accou
 			gid:        gid,
 		}
 		// falloc is best effort, its fine if this fails
-		if size > 0 {
+		if size > 0 && dofalloc {
 			tmp.falloc()
 		}
 
@@ -111,7 +111,7 @@ func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Accou
 	}
 
 	// falloc is best effort, its fine if this fails
-	if size > 0 {
+	if size > 0 && dofalloc {
 		tmp.falloc()
 	}
 
@@ -220,4 +220,8 @@ func (tmp *tmpfile) Write(b []byte) (int, error) {
 
 func (tmp *tmpfile) cleanup() {
 	tmp.f.Close()
+}
+
+func (tmp *tmpfile) File() *os.File {
+	return tmp.f
 }

--- a/backend/posix/without_otmpfile.go
+++ b/backend/posix/without_otmpfile.go
@@ -36,7 +36,7 @@ type tmpfile struct {
 	size    int64
 }
 
-func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Account) (*tmpfile, error) {
+func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Account, _ bool) (*tmpfile, error) {
 	uid, gid, doChown := p.getChownIDs(acct)
 
 	// Create a temp file for upload while in progress (see link comments below).
@@ -111,4 +111,8 @@ func (tmp *tmpfile) Write(b []byte) (int, error) {
 
 func (tmp *tmpfile) cleanup() {
 	tmp.f.Close()
+}
+
+func (tmp *tmpfile) File() *os.File {
+	return tmp.f
 }


### PR DESCRIPTION
The complete multipart upload can be optimized in some cases to not need to copy the full data from parts to the final object file. If the filesystem supports it, there can be optimizations to just clone exent references and not have to actually copy the data.

For io.Copy() to make use of file_copy_range, we have to pass it the *os.File file handles from the filesystem for the source and destination. We were previously adding a layer of indirection that was causing io.Copy() to fallback to full data copy. This fixes the copy by exposing the underlying fd.

This also skips the falloc for the final object in complete mutlipart upload, because some filesystems will be able to use file_copy_range to optimize the copy and may not even need new data allocations in the final object file.

Note that this only affects posix mode as scoutfs has special handling for this case that is similar to but not compatible with copy_file_range using a special ioctl.