### PR TITLE
fix: remove unused project id in account info

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -30,12 +30,11 @@ const (
 
 // Account is a gateway IAM account
 type Account struct {
-	Access    string `json:"access"`
-	Secret    string `json:"secret"`
-	Role      Role   `json:"role"`
-	UserID    int    `json:"userID"`
-	GroupID   int    `json:"groupID"`
-	ProjectID int    `json:"projectID"`
+	Access  string `json:"access"`
+	Secret  string `json:"secret"`
+	Role    Role   `json:"role"`
+	UserID  int    `json:"userID"`
+	GroupID int    `json:"groupID"`
 }
 
 // IAMService is the interface for all IAM service implementations

--- a/auth/iam_internal.go
+++ b/auth/iam_internal.go
@@ -135,12 +135,11 @@ func (s *IAMServiceInternal) ListUserAccounts() ([]Account, error) {
 	var accs []Account
 	for _, k := range keys {
 		accs = append(accs, Account{
-			Access:    k,
-			Secret:    conf.AccessAccounts[k].Secret,
-			Role:      conf.AccessAccounts[k].Role,
-			UserID:    conf.AccessAccounts[k].UserID,
-			GroupID:   conf.AccessAccounts[k].GroupID,
-			ProjectID: conf.AccessAccounts[k].ProjectID,
+			Access:  k,
+			Secret:  conf.AccessAccounts[k].Secret,
+			Role:    conf.AccessAccounts[k].Role,
+			UserID:  conf.AccessAccounts[k].UserID,
+			GroupID: conf.AccessAccounts[k].GroupID,
 		})
 	}
 

--- a/auth/iam_s3_object.go
+++ b/auth/iam_s3_object.go
@@ -148,12 +148,11 @@ func (s *IAMServiceS3) ListUserAccounts() ([]Account, error) {
 	var accs []Account
 	for _, k := range keys {
 		accs = append(accs, Account{
-			Access:    k,
-			Secret:    conf.AccessAccounts[k].Secret,
-			Role:      conf.AccessAccounts[k].Role,
-			UserID:    conf.AccessAccounts[k].UserID,
-			GroupID:   conf.AccessAccounts[k].GroupID,
-			ProjectID: conf.AccessAccounts[k].ProjectID,
+			Access:  k,
+			Secret:  conf.AccessAccounts[k].Secret,
+			Role:    conf.AccessAccounts[k].Role,
+			UserID:  conf.AccessAccounts[k].UserID,
+			GroupID: conf.AccessAccounts[k].GroupID,
 		})
 	}
 

--- a/cmd/versitygw/admin.go
+++ b/cmd/versitygw/admin.go
@@ -80,11 +80,6 @@ func adminCommand() *cli.Command {
 						Usage:   "groupID for the new user",
 						Aliases: []string{"gi"},
 					},
-					&cli.IntFlag{
-						Name:    "project-id",
-						Usage:   "projectID for the new user",
-						Aliases: []string{"pi"},
-					},
 				},
 			},
 			{
@@ -176,7 +171,7 @@ func initHTTPClient() *http.Client {
 
 func createUser(ctx *cli.Context) error {
 	access, secret, role := ctx.String("access"), ctx.String("secret"), ctx.String("role")
-	userID, groupID, projectID := ctx.Int("user-id"), ctx.Int("group-id"), ctx.Int("projectID")
+	userID, groupID := ctx.Int("user-id"), ctx.Int("group-id")
 	if access == "" || secret == "" {
 		return fmt.Errorf("invalid input parameters for the new user access/secret keys")
 	}
@@ -185,12 +180,11 @@ func createUser(ctx *cli.Context) error {
 	}
 
 	acc := auth.Account{
-		Access:    access,
-		Secret:    secret,
-		Role:      auth.Role(role),
-		UserID:    userID,
-		GroupID:   groupID,
-		ProjectID: projectID,
+		Access:  access,
+		Secret:  secret,
+		Role:    auth.Role(role),
+		UserID:  userID,
+		GroupID: groupID,
 	}
 
 	accJson, err := json.Marshal(acc)
@@ -339,10 +333,10 @@ const (
 func printAcctTable(accs []auth.Account) {
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, minwidth, tabwidth, padding, padchar, flags)
-	fmt.Fprintln(w, "Account\tRole\tUserID\tGroupID\tProjectID")
-	fmt.Fprintln(w, "-------\t----\t------\t-------\t---------")
+	fmt.Fprintln(w, "Account\tRole\tUserID\tGroupID")
+	fmt.Fprintln(w, "-------\t----\t------\t-------")
 	for _, acc := range accs {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", acc.Access, acc.Role, acc.UserID, acc.GroupID, acc.ProjectID)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", acc.Access, acc.Role, acc.UserID, acc.GroupID)
 	}
 	fmt.Fprintln(w)
 	w.Flush()


### PR DESCRIPTION
The intent was to have a project id that could be set along with user and group ids for new files/objects in the backend. However, most filesystems don't actually associate a project with a user, and instead have the project id inherited from parent directories.

Let's remove the project id for now, and we can always bring it back if we have a backend that will be able to make use of it.