### PR TITLE
fix: use json.MarshalIndent to format event_config.json

### DIFF
--- a/cmd/versitygw/utils.go
+++ b/cmd/versitygw/utils.go
@@ -71,7 +71,7 @@ func generateEventFiltersConfig(ctx *cli.Context) error {
 		s3event.EventObjectRestoreCompleted:     true,
 	}
 
-	configBytes, err := json.Marshal(config)
+	configBytes, err := json.MarshalIndent(config, "", "  ")
 	if err != nil {
 		return fmt.Errorf("parse event config: %w", err)
 	}


### PR DESCRIPTION
This adds indent fomratting to the generated event_config.json for easier reading/editing.