### PR TITLE
fix: init auth config accounts map

### DIFF
--- a/auth/iam_internal.go
+++ b/auth/iam_internal.go
@@ -188,6 +188,10 @@ func parseIAM(b []byte) (iAMConfig, error) {
 		return iAMConfig{}, fmt.Errorf("failed to parse the config file: %w", err)
 	}
 
+	if conf.AccessAccounts == nil {
+		conf.AccessAccounts = make(map[string]Account)
+	}
+
 	return conf, nil
 }
 

--- a/auth/iam_s3_object.go
+++ b/auth/iam_s3_object.go
@@ -204,12 +204,12 @@ func (s *IAMServiceS3) getAccounts() (iAMConfig, error) {
 		// init empty accounts stuct and return that
 		var nsk *types.NoSuchKey
 		if errors.As(err, &nsk) {
-			return iAMConfig{}, nil
+			return iAMConfig{AccessAccounts: map[string]Account{}}, nil
 		}
 		var apiErr smithy.APIError
 		if errors.As(err, &apiErr) {
 			if apiErr.ErrorCode() == "NotFound" {
-				return iAMConfig{}, nil
+				return iAMConfig{AccessAccounts: map[string]Account{}}, nil
 			}
 		}
 


### PR DESCRIPTION
There were a couple of cases where parsing the stored IAM info could return a config with a nil map that would panic in a future assignment. So we just need to make sure there is an initialized map when we return the config with no error set.