### PR TITLE
fix: restore object requesting handler and scoutfs glacier enable

### DIFF
--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -50,12 +50,13 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 	}
 
 	return &ScoutFS{
-		Posix:    p,
-		rootfd:   f,
-		rootdir:  rootdir,
-		meta:     metastore,
-		chownuid: opts.ChownUID,
-		chowngid: opts.ChownGID,
+		Posix:       p,
+		rootfd:      f,
+		rootdir:     rootdir,
+		meta:        metastore,
+		chownuid:    opts.ChownUID,
+		chowngid:    opts.ChownGID,
+		glaciermode: opts.GlacierMode,
 	}, nil
 }
 

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -2548,23 +2548,8 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 		key = key + "/"
 	}
 
-	var restoreRequest s3.RestoreObjectInput
 	if ctx.Request().URI().QueryArgs().Has("restore") {
-		err := xml.Unmarshal(ctx.Body(), &restoreRequest)
-		if err != nil {
-			if c.debug {
-				log.Printf("error unmarshalling restore object: %v", err)
-			}
-			return SendResponse(ctx, err,
-				&MetaOpts{
-					Logger:      c.logger,
-					MetricsMng:  c.mm,
-					Action:      metrics.ActionRestoreObject,
-					BucketOwner: parsedAcl.Owner,
-				})
-		}
-
-		err = auth.VerifyAccess(ctx.Context(), c.be,
+		err := auth.VerifyAccess(ctx.Context(), c.be,
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
@@ -2585,8 +2570,10 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 				})
 		}
 
-		restoreRequest.Bucket = &bucket
-		restoreRequest.Key = &key
+		restoreRequest := s3.RestoreObjectInput{
+			Bucket: &bucket,
+			Key:    &key,
+		}
 
 		err = c.be.RestoreObject(ctx.Context(), &restoreRequest)
 		return SendResponse(ctx, err,


### PR DESCRIPTION
The restore object api request handler was incorrectly trying to unmarshal the request body, but for the stadnard (all?) case the request body is emtpy. We only need the bucket and opbject params for now.

This also adds a fix to actually honor the enable glacier mode in scoutfs.