### PR TITLE
Azure bug fixing

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -18,7 +18,6 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
-	"io/fs"
 	"strconv"
 	"strings"
 	"time"
@@ -61,9 +60,9 @@ var (
 
 // ParseRange parses input range header and returns startoffset, length, and
 // error. If no endoffset specified, then length is set to -1.
-func ParseRange(fi fs.FileInfo, acceptRange string) (int64, int64, error) {
+func ParseRange(size int64, acceptRange string) (int64, int64, error) {
 	if acceptRange == "" {
-		return 0, fi.Size(), nil
+		return 0, size, nil
 	}
 
 	rangeKv := strings.Split(acceptRange, "=")

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1199,7 +1199,7 @@ func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput)
 		return s3response.CopyObjectResult{}, fmt.Errorf("stat object: %w", err)
 	}
 
-	startOffset, length, err := backend.ParseRange(fi, *upi.CopySourceRange)
+	startOffset, length, err := backend.ParseRange(fi.Size(), *upi.CopySourceRange)
 	if err != nil {
 		return s3response.CopyObjectResult{}, err
 	}
@@ -1565,7 +1565,7 @@ func (p *Posix) GetObject(_ context.Context, input *s3.GetObjectInput, writer io
 	}
 
 	acceptRange := *input.Range
-	startOffset, length, err := backend.ParseRange(fi, acceptRange)
+	startOffset, length, err := backend.ParseRange(fi.Size(), acceptRange)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/scoutfs/scoutfs.go
+++ b/backend/scoutfs/scoutfs.go
@@ -611,7 +611,7 @@ func (s *ScoutFS) GetObject(_ context.Context, input *s3.GetObjectInput, writer 
 		return nil, fmt.Errorf("stat object: %w", err)
 	}
 
-	startOffset, length, err := backend.ParseRange(fi, acceptRange)
+	startOffset, length, err := backend.ParseRange(fi.Size(), acceptRange)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -236,6 +236,7 @@ func TestUploadPartCopy(s *S3Conf) {
 func TestListParts(s *S3Conf) {
 	ListParts_incorrect_uploadId(s)
 	ListParts_incorrect_object_key(s)
+	ListParts_truncated(s)
 	ListParts_success(s)
 }
 
@@ -605,6 +606,7 @@ func GetIntTests() IntTests {
 		"UploadPartCopy_by_range_success":                                     UploadPartCopy_by_range_success,
 		"ListParts_incorrect_uploadId":                                        ListParts_incorrect_uploadId,
 		"ListParts_incorrect_object_key":                                      ListParts_incorrect_object_key,
+		"ListParts_truncated":                                                 ListParts_truncated,
 		"ListParts_success":                                                   ListParts_success,
 		"ListMultipartUploads_non_existing_bucket":                            ListMultipartUploads_non_existing_bucket,
 		"ListMultipartUploads_empty_result":                                   ListMultipartUploads_empty_result,


### PR DESCRIPTION
Azure backend bug fixing.

Azure backend incompatible parts with AWS are listed below:

1.  `Multipart Upload`: Multipart upload starts with `UploadPart` action, which causes some tests to fail.
2. `UploadPartCopy`: `StageBlockFromURL` (azure sdk) method is used to handle `UploadPartCopy` action, which returns NotImplemented on azurite.
3. `ListObjects(V2)` doesn't support delimiter.
4. `ListBuckets` doesn't return all the buckets for admin/root users, only the ones owned by the requester.