### PR TITLE
fix: fix removal of the upload directory in posix CompleteMultipartUpload

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -656,7 +656,7 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 	}
 
 	// cleanup tmp dirs
-	os.RemoveAll(upiddir)
+	os.RemoveAll(filepath.Join(bucket, objdir, uploadID))
 	// use Remove for objdir in case there are still other uploads
 	// for same object name outstanding, this will fail if there are
 	os.Remove(filepath.Join(bucket, objdir))


### PR DESCRIPTION
In the posix backend, the path argument to os.RemoveAll() does not start with the bucket name. Since the path does not exist, os.RemoveAll() does nothing and uploaded parts are left in the ".sgwtmp" directory.

This commit prefixes the path with the bucket name.

Fixes issue #626.