### PR TITLE
feat: add option to allow symlinked directories as buckets

### DIFF
--- a/backend/scoutfs/scoutfs.go
+++ b/backend/scoutfs/scoutfs.go
@@ -42,6 +42,7 @@ type ScoutfsOpts struct {
 	ChownUID    bool
 	ChownGID    bool
 	GlacierMode bool
+	BucketLinks bool
 }
 
 type ScoutFS struct {

--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -37,8 +37,9 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 	metastore := meta.XattrMeta{}
 
 	p, err := posix.New(rootdir, metastore, posix.PosixOpts{
-		ChownUID: opts.ChownUID,
-		ChownGID: opts.ChownGID,
+		ChownUID:    opts.ChownUID,
+		ChownGID:    opts.ChownGID,
+		BucketLinks: opts.BucketLinks,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/versitygw/posix.go
+++ b/cmd/versitygw/posix.go
@@ -24,6 +24,7 @@ import (
 
 var (
 	chownuid, chowngid bool
+	bucketlinks        bool
 )
 
 func posixCommand() *cli.Command {
@@ -54,6 +55,12 @@ will be translated into the file /mnt/fs/gwroot/mybucket/a/b/c/myobject`,
 				EnvVars:     []string{"VGW_CHOWN_GID"},
 				Destination: &chowngid,
 			},
+			&cli.BoolFlag{
+				Name:        "bucketlinks",
+				Usage:       "allow symlinked directories at bucket level to be treated as buckets",
+				EnvVars:     []string{"VGW_BUCKET_LINKS"},
+				Destination: &bucketlinks,
+			},
 		},
 	}
 }
@@ -70,8 +77,9 @@ func runPosix(ctx *cli.Context) error {
 	}
 
 	be, err := posix.New(gwroot, meta.XattrMeta{}, posix.PosixOpts{
-		ChownUID: chownuid,
-		ChownGID: chowngid,
+		ChownUID:    chownuid,
+		ChownGID:    chowngid,
+		BucketLinks: bucketlinks,
 	})
 	if err != nil {
 		return fmt.Errorf("init posix: %v", err)

--- a/cmd/versitygw/scoutfs.go
+++ b/cmd/versitygw/scoutfs.go
@@ -63,6 +63,12 @@ move interfaces as well as support for tiered filesystems.`,
 				EnvVars:     []string{"VGW_CHOWN_GID"},
 				Destination: &chowngid,
 			},
+			&cli.BoolFlag{
+				Name:        "bucketlinks",
+				Usage:       "allow symlinked directories at bucket level to be treated as buckets",
+				EnvVars:     []string{"VGW_BUCKET_LINKS"},
+				Destination: &bucketlinks,
+			},
 		},
 	}
 }
@@ -76,6 +82,7 @@ func runScoutfs(ctx *cli.Context) error {
 	opts.GlacierMode = glacier
 	opts.ChownUID = chownuid
 	opts.ChownGID = chowngid
+	opts.BucketLinks = bucketlinks
 
 	be, err := scoutfs.New(ctx.Args().Get(0), opts)
 	if err != nil {

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -305,6 +305,10 @@ ROOT_SECRET_ACCESS_KEY=
 #VGW_CHOWN_UID=false
 #VGW_CHOWN_GID=false
 
+# The VGW_BUCKET_LINKS option will enable the gateway to treat symbolic links
+# to directories at the top level gateway directory as buckets.
+#VGW_BUCKET_LINKS=false
+
 ###########
 # scoutfs #
 ###########
@@ -335,6 +339,10 @@ ROOT_SECRET_ACCESS_KEY=
 # account UID/GID.
 #VGW_CHOWN_UID=false
 #VGW_CHOWN_GID=false
+
+# The VGW_BUCKET_LINKS option will enable the gateway to treat symbolic links
+# to directories at the top level gateway directory as buckets.
+#VGW_BUCKET_LINKS=false
 
 ######
 # s3 #


### PR DESCRIPTION
This adds the ability to treat symlinks to directories at the top level gateway directory as buckets the same as normal directories.

This could be a potential security issue allowing traversal into other filesystems within the system, so is defaulted to off. This can be enabled when specifically needed for both posix and scoutfs backend systems.

Fixes #644