### PR TITLE
Type property support in bucket ACL

### DIFF
--- a/s3api/controllers/admin.go
+++ b/s3api/controllers/admin.go
@@ -145,6 +145,7 @@ func (c AdminController) ChangeBucketOwner(ctx *fiber.Ctx) error {
 			{
 				Permission: types.PermissionFullControl,
 				Access:     owner,
+				Type:       types.TypeCanonicalUser,
 			},
 		},
 	}

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -64,7 +64,9 @@ func New(
 
 	// Logging middlewares
 	if !server.quiet {
-		app.Use(logger.New())
+		app.Use(logger.New(logger.Config{
+			Format: "${time} | ${status} | ${latency} | ${ip} | ${method} | ${path} | ${error} | ${queryParams}\n",
+		}))
 	}
 	// Set up health endpoint if specified
 	if server.health != "" {

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -1807,25 +1807,29 @@ func CreateBucket_non_default_acl(s *S3Conf) error {
 	grants := []types.Grant{
 		{
 			Grantee: &types.Grantee{
-				ID: &s.awsID,
+				ID:   &s.awsID,
+				Type: types.TypeCanonicalUser,
 			},
 			Permission: types.PermissionFullControl,
 		},
 		{
 			Grantee: &types.Grantee{
-				ID: getPtr("grt1"),
+				ID:   getPtr("grt1"),
+				Type: types.TypeCanonicalUser,
 			},
 			Permission: types.PermissionFullControl,
 		},
 		{
 			Grantee: &types.Grantee{
-				ID: getPtr("grt2"),
+				ID:   getPtr("grt2"),
+				Type: types.TypeCanonicalUser,
 			},
 			Permission: types.PermissionReadAcp,
 		},
 		{
 			Grantee: &types.Grantee{
-				ID: getPtr("grt3"),
+				ID:   getPtr("grt3"),
+				Type: types.TypeCanonicalUser,
 			},
 			Permission: types.PermissionWrite,
 		},
@@ -6491,7 +6495,7 @@ func GetBucketAcl_translation_canned_public_read(s *S3Conf) error {
 			{
 				Grantee: &types.Grantee{
 					ID:   getPtr("all-users"),
-					Type: types.TypeCanonicalUser,
+					Type: types.TypeGroup,
 				},
 				Permission: types.PermissionRead,
 			},
@@ -6541,14 +6545,14 @@ func GetBucketAcl_translation_canned_public_read_write(s *S3Conf) error {
 			{
 				Grantee: &types.Grantee{
 					ID:   getPtr("all-users"),
-					Type: types.TypeCanonicalUser,
+					Type: types.TypeGroup,
 				},
 				Permission: types.PermissionRead,
 			},
 			{
 				Grantee: &types.Grantee{
 					ID:   getPtr("all-users"),
-					Type: types.TypeCanonicalUser,
+					Type: types.TypeGroup,
 				},
 				Permission: types.PermissionWrite,
 			},
@@ -6716,7 +6720,8 @@ func GetBucketAcl_success(s *S3Conf) error {
 		grants = append([]types.Grant{
 			{
 				Grantee: &types.Grantee{
-					ID: &s.awsID,
+					ID:   &s.awsID,
+					Type: types.TypeCanonicalUser,
 				},
 				Permission: types.PermissionFullControl,
 			},

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -398,6 +398,9 @@ func compareGrants(grts1, grts2 []types.Grant) bool {
 		if *grt.Grantee.ID != *grts2[i].Grantee.ID {
 			return false
 		}
+		if grt.Grantee.Type != grts2[i].Grantee.Type {
+			return false
+		}
 	}
 	return true
 }


### PR DESCRIPTION
Added the `Type` property support in the `Grantee` schema for bucket ACLs. Hardcoded `Type` to `CanonicalUser` for iam users and `Group` for `all-users`.

Fixes #651,
Fixes #664 
