### PR TITLE
Bucket ACL owner check for admin/root users

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -118,11 +118,11 @@ func ParseACLOutput(data []byte) (GetBucketAclOutput, error) {
 	}, nil
 }
 
-func UpdateACL(input *PutBucketAclInput, acl ACL, iam IAMService) ([]byte, error) {
+func UpdateACL(input *PutBucketAclInput, acl ACL, iam IAMService, isAdmin bool) ([]byte, error) {
 	if input == nil {
 		return nil, s3err.GetAPIError(s3err.ErrInvalidRequest)
 	}
-	if acl.Owner != *input.AccessControlPolicy.Owner.ID {
+	if !isAdmin && acl.Owner != *input.AccessControlPolicy.Owner.ID {
 		return nil, s3err.GetAPIError(s3err.ErrAccessDenied)
 	}
 

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -1361,7 +1361,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 			}
 		}
 
-		updAcl, err := auth.UpdateACL(input, parsedAcl, c.iam)
+		updAcl, err := auth.UpdateACL(input, parsedAcl, c.iam, acct.Role == auth.RoleAdmin)
 		if err != nil {
 			return SendResponse(ctx, err,
 				&MetaOpts{
@@ -1448,7 +1448,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 				ID: &acct.Access,
 			}},
 		ACL: types.BucketCannedACL(acl),
-	}, defACL, c.iam)
+	}, defACL, c.iam, acct.Role == auth.RoleAdmin)
 	if err != nil {
 		return SendResponse(ctx, err,
 			&MetaOpts{

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -481,6 +481,7 @@ func TestAccessControl(s *S3Conf) {
 	AccessControl_single_object_resource_actions(s)
 	AccessControl_multi_statement_policy(s)
 	AccessControl_bucket_ownership_to_user(s)
+	AccessControl_root_PutBucketAcl(s)
 }
 
 type IntTests map[string]func(s *S3Conf) error
@@ -771,5 +772,6 @@ func GetIntTests() IntTests {
 		"AccessControl_single_object_resource_actions":                        AccessControl_single_object_resource_actions,
 		"AccessControl_multi_statement_policy":                                AccessControl_multi_statement_policy,
 		"AccessControl_bucket_ownership_to_user":                              AccessControl_bucket_ownership_to_user,
+		"AccessControl_root_PutBucketAcl":                                     AccessControl_root_PutBucketAcl,
 	}
 }


### PR DESCRIPTION
Removed the bucket ACL owner check for admin/root users.

Fixes #680 