### PR TITLE
fix: copy-object with replace metadata-directive

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -1533,6 +1533,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 	copySrcModifSince := ctx.Get("X-Amz-Copy-Source-If-Modified-Since")
 	copySrcUnmodifSince := ctx.Get("X-Amz-Copy-Source-If-Unmodified-Since")
 	copySrcRange := ctx.Get("X-Amz-Copy-Source-Range")
+	directive := ctx.Get("X-Amz-Metadata-Directive")
 
 	// Permission headers
 	acl := ctx.Get("X-Amz-Acl")
@@ -2054,6 +2055,22 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 
 		metadata := utils.GetUserMetaData(&ctx.Request().Header)
 
+		if directive != "" && directive != "COPY" && directive != "REPLACE" {
+			return SendXMLResponse(ctx, nil,
+				s3err.GetAPIError(s3err.ErrInvalidMetadataDirective),
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionCopyObject,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
+		metaDirective := types.MetadataDirectiveCopy
+		if directive == "REPLACE" {
+			metaDirective = types.MetadataDirectiveReplace
+		}
+
 		res, err := c.be.CopyObject(ctx.Context(),
 			&s3.CopyObjectInput{
 				Bucket:                      &bucket,
@@ -2065,6 +2082,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 				CopySourceIfUnmodifiedSince: umtime,
 				ExpectedBucketOwner:         &acct.Access,
 				Metadata:                    metadata,
+				MetadataDirective:           metaDirective,
 				StorageClass:                types.StorageClass(storageClass),
 			})
 		if err == nil {

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -130,6 +130,7 @@ const (
 	ErrMalformedACL
 	ErrUnexpectedContent
 	ErrMissingSecurityHeader
+	ErrInvalidMetadataDirective
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -513,6 +514,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "MissingSecurityHeader",
 		Description:    "Your request was missing a required header",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrInvalidMetadataDirective: {
+		Code:           "InvalidArgument",
+		Description:    "Unknown metadata directive.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 
 	// non aws errors

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -199,6 +199,7 @@ func TestCopyObject(s *S3Conf) {
 	CopyObject_non_existing_dst_bucket(s)
 	CopyObject_not_owned_source_bucket(s)
 	CopyObject_copy_to_itself(s)
+	CopyObject_copy_to_itself_invalid_directive(s)
 	CopyObject_to_itself_with_new_metadata(s)
 	CopyObject_CopySource_starting_with_slash(s)
 	CopyObject_non_existing_dir_object(s)
@@ -620,6 +621,7 @@ func GetIntTests() IntTests {
 		"CopyObject_non_existing_dst_bucket":                                  CopyObject_non_existing_dst_bucket,
 		"CopyObject_not_owned_source_bucket":                                  CopyObject_not_owned_source_bucket,
 		"CopyObject_copy_to_itself":                                           CopyObject_copy_to_itself,
+		"CopyObject_copy_to_itself_invalid_directive":                         CopyObject_copy_to_itself_invalid_directive,
 		"CopyObject_to_itself_with_new_metadata":                              CopyObject_to_itself_with_new_metadata,
 		"CopyObject_CopySource_starting_with_slash":                           CopyObject_CopySource_starting_with_slash,
 		"CopyObject_non_existing_dir_object":                                  CopyObject_non_existing_dir_object,


### PR DESCRIPTION
In copy-object, if the source and destination are the same then X-Amz-Metadata-Directive must be set to "REPLACE" in order to use this api call to update the metadata of the object in place.

The default X-Amz-Metadata-Directive is "COPY" if not specified. "COPY" is only valid if source and destination are not the same object.

When "REPLACE" selected, metadata does not have to differ for the call to be successful. The "REPLACE" always sets the incoming metadata (even if empty or the same as the source).

Fixes #734