### PR TITLE
feat: enable ipv6 support for listening socket

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -522,6 +522,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		ServerHeader:      "VERSITYGW",
 		StreamRequestBody: true,
 		DisableKeepalive:  true,
+		Network:           fiber.NetworkTCP,
 	})
 
 	var opts []s3api.Option
@@ -559,6 +560,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 	admApp := fiber.New(fiber.Config{
 		AppName:      "versitygw",
 		ServerHeader: "VERSITYGW",
+		Network:      fiber.NetworkTCP,
 	})
 
 	var admOpts []s3api.AdminOpt


### PR DESCRIPTION
Fiber allows for dual stack ipv4/ipv6 by setting Network setting to fiber.NetworkTCP. The default is fiber.NetworkTCP4 which is ipv4 only because the dual stack is not compatible with prefork. But we do not use prefork, so it is fine to enable the dual ipv4/ipv6 support.