### PR TITLE
Directory objects listing with delimiter

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2130,12 +2130,13 @@ func (p *Posix) fileToObj(bucket string) backend.GetObjFunc {
 				return types.Object{}, fmt.Errorf("get fileinfo: %w", err)
 			}
 
-			key := path + "/"
+			size := int64(0)
 
 			return types.Object{
 				ETag:         &etag,
-				Key:          &key,
+				Key:          &path,
 				LastModified: backend.GetTimePtr(fi.ModTime()),
+				Size:         &size,
 			}, nil
 		}
 

--- a/backend/walk.go
+++ b/backend/walk.go
@@ -95,7 +95,10 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 			if err != nil {
 				return fmt.Errorf("readdir %q: %w", path, err)
 			}
-			if len(ents) == 0 {
+
+			path += string(os.PathSeparator)
+
+			if len(ents) == 0 && delimiter == "" {
 				dirobj, err := getObj(path, d)
 				if err == ErrSkipObj {
 					return nil
@@ -104,9 +107,13 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 					return fmt.Errorf("directory to object %q: %w", path, err)
 				}
 				objects = append(objects, dirobj)
+
+				return nil
 			}
 
-			return nil
+			if len(ents) != 0 {
+				return nil
+			}
 		}
 
 		if !pastMarker {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -180,6 +180,8 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_both_start_after_and_continuation_token(s)
 	ListObjectsV2_start_after_not_in_list(s)
 	ListObjectsV2_start_after_empty_result(s)
+	ListObjectsV2_both_delimiter_and_prefix(s)
+	ListObjectsV2_single_dir_object_with_delim_and_prefix(s)
 }
 
 func TestDeleteObject(s *S3Conf) {
@@ -611,6 +613,8 @@ func GetIntTests() IntTests {
 		"ListObjectsV2_both_start_after_and_continuation_token":               ListObjectsV2_both_start_after_and_continuation_token,
 		"ListObjectsV2_start_after_not_in_list":                               ListObjectsV2_start_after_not_in_list,
 		"ListObjectsV2_start_after_empty_result":                              ListObjectsV2_start_after_empty_result,
+		"ListObjectsV2_both_delimiter_and_prefix":                             ListObjectsV2_both_delimiter_and_prefix,
+		"ListObjectsV2_single_dir_object_with_delim_and_prefix":               ListObjectsV2_single_dir_object_with_delim_and_prefix,
 		"DeleteObject_non_existing_object":                                    DeleteObject_non_existing_object,
 		"DeleteObject_non_existing_dir_object":                                DeleteObject_non_existing_dir_object,
 		"DeleteObject_success":                                                DeleteObject_success,


### PR DESCRIPTION
Fixes #740 

Changed the directory objects listing implementation to include them in common prefixes when the object name includes the specified delimiter.