### PR TITLE
ListObjects(V2) common prefixes pagination

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -192,9 +192,16 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 		// Common prefixes are a set, so should not have duplicates.
 		// These are abstractly a "directory", so need to include the
 		// delimiter at the end.
-		cpmap[prefix+before+delimiter] = struct{}{}
+		cpref := prefix + before + delimiter
+		if cpref == marker {
+			pastMarker = true
+			return nil
+		}
+		cpmap[cpref] = struct{}{}
 		if (len(objects) + len(cpmap)) == int(max) {
-			pastMax = true
+			newMarker = cpref
+			truncated = true
+			return fs.SkipAll
 		}
 
 		return nil

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -184,6 +184,7 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_start_after_empty_result(s)
 	ListObjectsV2_both_delimiter_and_prefix(s)
 	ListObjectsV2_single_dir_object_with_delim_and_prefix(s)
+	ListObjectsV2_truncated_common_prefixes(s)
 }
 
 func TestDeleteObject(s *S3Conf) {
@@ -620,6 +621,7 @@ func GetIntTests() IntTests {
 		"ListObjectsV2_start_after_empty_result":                              ListObjectsV2_start_after_empty_result,
 		"ListObjectsV2_both_delimiter_and_prefix":                             ListObjectsV2_both_delimiter_and_prefix,
 		"ListObjectsV2_single_dir_object_with_delim_and_prefix":               ListObjectsV2_single_dir_object_with_delim_and_prefix,
+		"ListObjectsV2_truncated_common_prefixes":                             ListObjectsV2_truncated_common_prefixes,
 		"DeleteObject_non_existing_object":                                    DeleteObject_non_existing_object,
 		"DeleteObject_name_too_long":                                          DeleteObject_name_too_long,
 		"DeleteObject_non_existing_dir_object":                                DeleteObject_non_existing_dir_object,


### PR DESCRIPTION
Fixes #763 

When calling the ListObjects(V2) actions with delimiter the results are grouped in common prefixes. 
Fixed the pagination for common prefixes: e.g.

Bucket: my-bucket
Objects: d1/f1, d2/f2, d3/f3, d4/f4
Request syntax: GET /?list-type=2&max-keys=3&delimiter=/

Result:
Common Prefixes: d1/, d2/, d3/
NextContinuationToken: d3/