### PR TITLE
fix: DeleteObject not working as expected when using `--bucketlinks` (#784)

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1571,7 +1571,7 @@ func (p *Posix) removeParents(bucket, object string) error {
 	for {
 		parent := filepath.Dir(objPath)
 
-		if parent == string(filepath.Separator) {
+		if parent == "." {
 			// stop removing parents if we hit the bucket directory.
 			break
 		}


### PR DESCRIPTION
This fixes #784.

`removeParents()` gets called when `posix.DeleteObject()` is called. It will iterate through each parent directory of an object path that is being deleted, and it'll also delete that parent unless:
1. The parent is the bucket
2. The parent has a valid etag
3. The parent is not empty (or if `os.Remove()` fails for another reason)

I believe the logic used to check if the parent is the bucket is off.

Currently this is the condition:

```go
parent := filepath.Dir(objPath)

if parent == string(filepath.Separator) {
	// stop removing parents if we hit the bucket directory.
	break
}
```

Because `objPath` doesn't start with a `/` (relative style), it is impossible for `parent` to ever equal `/`. Instead I think we should test for `.`

Referenced: https://pkg.go.dev/path/filepath#example-Dir