### PR TITLE
fix: copy object missing prefix on metadata delete

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2038,8 +2038,9 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 			return &s3.CopyObjectOutput{}, s3err.GetAPIError(s3err.ErrInvalidCopyDest)
 		}
 
-		for key := range mdmap {
-			err := p.meta.DeleteAttribute(dstBucket, dstObject, key)
+		for k := range mdmap {
+			err := p.meta.DeleteAttribute(dstBucket, dstObject,
+				fmt.Sprintf("%v.%v", metaHdr, k))
 			if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 				return nil, fmt.Errorf("delete user metadata: %w", err)
 			}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -428,12 +428,15 @@ func getPtr(str string) *string {
 	return &str
 }
 
+// mp1 needs to be the response from the server
+// mp2 needs to be the expected values
+// The keys from the server are always converted to lowercase
 func areMapsSame(mp1, mp2 map[string]string) bool {
 	if len(mp1) != len(mp2) {
 		return false
 	}
-	for key, val := range mp1 {
-		if mp2[key] != val {
+	for key, val := range mp2 {
+		if mp1[strings.ToLower(key)] != val {
 			return false
 		}
 	}


### PR DESCRIPTION
When using the REPLACE directive, we were incorrectly removing the old metadata on the object due to missing the metadata prefix on the key.  Fix this to remove the correct metadata before setting new metadata.

Fixes #787