### PR TITLE
fix: v4auth uri escape paths in canonical request

### DIFF
--- a/s3api/utils/auth-reader.go
+++ b/s3api/utils/auth-reader.go
@@ -133,7 +133,6 @@ func CheckValidSignature(ctx *fiber.Ctx, auth AuthData, secret, checksum string,
 		},
 		req, checksum, service, auth.Region, tdate, signedHdrs,
 		func(options *v4.SignerOptions) {
-			options.DisableURIPathEscaping = true
 			if debug {
 				options.LogSigning = true
 				options.Logger = logging.NewStandardLogger(os.Stderr)


### PR DESCRIPTION
According to the docs:
https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html The Canonical URIL and Canonical Query String need to be passed through UriEncode() when generating the string to sign.

Its likely that the signer we are using is expecting this to already be escaped under normal use. But for our purposes we still need this to be escaped before generating the signature to compare.

Fixes #781