### PR TITLE
fix: get object range min=max return single byte min

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -95,7 +95,7 @@ func ParseRange(size int64, acceptRange string) (int64, int64, error) {
 		return 0, 0, errInvalidRange
 	}
 
-	if endOffset <= startOffset {
+	if endOffset < startOffset {
 		return 0, 0, errInvalidRange
 	}
 

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -3265,17 +3265,6 @@ func GetObject_invalid_ranges(s *S3Conf) error {
 		}
 
 		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
-		_, err = s3client.GetObject(ctx, &s3.GetObjectInput{
-			Bucket: &bucket,
-			Key:    &obj,
-			Range:  getPtr("bytes=0-0"),
-		})
-		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidRange)); err != nil {
-			return err
-		}
-
-		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
 		resp, err := s3client.GetObject(ctx, &s3.GetObjectInput{
 			Bucket: &bucket,
 			Key:    &obj,

--- a/tests/test_aws_root_inner.sh
+++ b/tests/test_aws_root_inner.sh
@@ -190,7 +190,7 @@ test_get_object_invalid_range_aws_root() {
   assert_success
 
   run get_object_with_range "$BUCKET_ONE_NAME" "$bucket_file" "bytes=0-0" "$TEST_FILE_FOLDER/$bucket_file-range"
-  assert_failure
+  assert_success
 }
 
 test_put_object_aws_root() {


### PR DESCRIPTION
The range min-max where min=max was incorrectly returning invalid object range.  On AWS, this returns the byte at offset min.

Fixes #810