### PR TITLE
fix: Fixed the error case, to return ObjectParentIsFile error when ov…

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2008,6 +2008,9 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (s3respons
 	if errors.Is(err, syscall.ENAMETOOLONG) {
 		return s3response.PutObjectOutput{}, s3err.GetAPIError(s3err.ErrKeyTooLong)
 	}
+	if errors.Is(err, syscall.ENOTDIR) {
+		return s3response.PutObjectOutput{}, s3err.GetAPIError(s3err.ErrObjectParentIsFile)
+	}
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		return s3response.PutObjectOutput{}, fmt.Errorf("stat object: %w", err)
 	}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -477,6 +477,7 @@ func TestFullFlow(s *S3Conf) {
 func TestPosix(s *S3Conf) {
 	PutObject_overwrite_dir_obj(s)
 	PutObject_overwrite_file_obj(s)
+	PutObject_overwrite_file_obj_with_nested_obj(s)
 	PutObject_dir_obj_with_data(s)
 	CreateMultipartUpload_dir_obj(s)
 	PutObject_name_too_long(s)
@@ -836,6 +837,7 @@ func GetIntTests() IntTests {
 		"WORMProtection_root_bypass_governance_retention_delete_object":       WORMProtection_root_bypass_governance_retention_delete_object,
 		"PutObject_overwrite_dir_obj":                                         PutObject_overwrite_dir_obj,
 		"PutObject_overwrite_file_obj":                                        PutObject_overwrite_file_obj,
+		"PutObject_overwrite_file_obj_with_nested_obj":                        PutObject_overwrite_file_obj_with_nested_obj,
 		"PutObject_dir_obj_with_data":                                         PutObject_dir_obj_with_data,
 		"CreateMultipartUpload_dir_obj":                                       CreateMultipartUpload_dir_obj,
 		"IAM_user_access_denied":                                              IAM_user_access_denied,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -10113,6 +10113,17 @@ func PutObject_overwrite_file_obj(s *S3Conf) error {
 	})
 }
 
+func PutObject_overwrite_file_obj_with_nested_obj(s *S3Conf) error {
+	testName := "PutObject_overwrite_file_obj_with_nested_obj"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		_, err := putObjects(s3client, []string{"foo", "foo/bar"}, bucket)
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectParentIsFile)); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
 func PutObject_dir_obj_with_data(s *S3Conf) error {
 	testName := "PutObject_dir_obj_with_data"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
Fixes #814
os.Stat returns `syscall.ENOTDIR` , if trying to stat a nested file/directory in an existing file.
e.g.
Existing file: foo
Try to stat: foo/bar
The implementation converts `syscall.ENOTDIR`  os error to s3err.ErrObjectParentIsFile  in `PutObject` in posix.