### PR TITLE
fix: Modified DeleteObject error handling to return a successful resp…

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -537,6 +537,7 @@ func TestVersioning(s *S3Conf) {
 	Versioning_GetObject_delete_marker(s)
 	// DeleteObject(s) actions
 	Versioning_DeleteObject_delete_object_version(s)
+	Versioning_DeleteObject_non_existing_object(s)
 	Versioning_DeleteObject_delete_a_delete_marker(s)
 	Versioning_DeleteObjects_success(s)
 	Versioning_DeleteObjects_delete_deleteMarkers(s)
@@ -884,6 +885,7 @@ func GetIntTests() IntTests {
 		"Versioning_GetObject_success":                                        Versioning_GetObject_success,
 		"Versioning_GetObject_delete_marker":                                  Versioning_GetObject_delete_marker,
 		"Versioning_DeleteObject_delete_object_version":                       Versioning_DeleteObject_delete_object_version,
+		"Versioning_DeleteObject_non_existing_object":                         Versioning_DeleteObject_non_existing_object,
 		"Versioning_DeleteObject_delete_a_delete_marker":                      Versioning_DeleteObject_delete_a_delete_marker,
 		"Versioning_DeleteObjects_success":                                    Versioning_DeleteObjects_success,
 		"Versioning_DeleteObjects_delete_deleteMarkers":                       Versioning_DeleteObjects_delete_deleteMarkers,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -10927,6 +10927,36 @@ func Versioning_DeleteObject_delete_object_version(s *S3Conf) error {
 	}, withVersioning())
 }
 
+func Versioning_DeleteObject_non_existing_object(s *S3Conf) error {
+	testName := "Versioning_DeleteObject_non_existing_object"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		obj := "my-obj"
+
+		ctx, canel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: &bucket,
+			Key:    &obj,
+		})
+		canel()
+		if err != nil {
+			return err
+		}
+
+		ctx, canel = context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket:    &bucket,
+			Key:       &obj,
+			VersionId: getPtr("non_existing_version_id"),
+		})
+		canel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidVersionId)); err != nil {
+			return err
+		}
+
+		return nil
+	}, withVersioning())
+}
+
 func Versioning_DeleteObject_delete_a_delete_marker(s *S3Conf) error {
 	testName := "Versioning_DeleteObject_delete_a_delete_marker"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
Fixes #834
Fixes #842

Consider the versioning is enabled in the bucket:
When attempting to delete a non-existing object without specifying versionId, DeleteObject should return successful response.
If versionId is specified and the object version doesn't exist, it should return `InvalidVersionId` error.