### PR TITLE
Object lock for bucket versioning

### DIFF
--- a/backend/scoutfs/scoutfs.go
+++ b/backend/scoutfs/scoutfs.go
@@ -554,7 +554,7 @@ func (s *ScoutFS) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s
 	contentLength := fi.Size()
 
 	var objectLockLegalHoldStatus types.ObjectLockLegalHoldStatus
-	status, err := s.Posix.GetObjectLegalHold(ctx, bucket, object, "")
+	status, err := s.Posix.GetObjectLegalHold(ctx, bucket, object, *input.VersionId)
 	if err == nil {
 		if *status {
 			objectLockLegalHoldStatus = types.ObjectLockLegalHoldStatusOn
@@ -565,7 +565,7 @@ func (s *ScoutFS) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s
 
 	var objectLockMode types.ObjectLockMode
 	var objectLockRetainUntilDate *time.Time
-	retention, err := s.Posix.GetObjectRetention(ctx, bucket, object, "")
+	retention, err := s.Posix.GetObjectRetention(ctx, bucket, object, *input.VersionId)
 	if err == nil {
 		var config types.ObjectLockRetention
 		if err := json.Unmarshal(retention, &config); err == nil {

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -2243,7 +2243,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			})
 	}
 
-	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, []string{keyStart}, true, c.be)
+	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, []types.ObjectIdentifier{{Key: &keyStart}}, true, c.be)
 	if err != nil {
 		return SendResponse(ctx, err,
 			&MetaOpts{
@@ -2527,7 +2527,7 @@ func (c S3ApiController) DeleteObjects(ctx *fiber.Ctx) error {
 	// The AWS CLI sends 'True', while Go SDK sends 'true'
 	bypass := strings.EqualFold(bypassHdr, "true")
 
-	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, utils.ParseDeleteObjects(dObj.Objects), bypass, c.be)
+	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, dObj.Objects, bypass, c.be)
 	if err != nil {
 		return SendResponse(ctx, err,
 			&MetaOpts{
@@ -2680,7 +2680,7 @@ func (c S3ApiController) DeleteActions(ctx *fiber.Ctx) error {
 	// The AWS CLI sends 'True', while Go SDK sends 'true'
 	bypass := strings.EqualFold(bypassHdr, "true")
 
-	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, []string{key}, bypass, c.be)
+	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, []types.ObjectIdentifier{{Key: &key, VersionId: &versionId}}, bypass, c.be)
 	if err != nil {
 		return SendResponse(ctx, err,
 			&MetaOpts{

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -553,6 +553,18 @@ func TestVersioning(s *S3Conf) {
 	Versioning_Multipart_Upload_overwrite_an_object(s)
 	Versioning_UploadPartCopy_non_existing_versionId(s)
 	Versioning_UploadPartCopy_from_an_object_version(s)
+	// Object-Lock Retention
+	Versionsin_PutObjectRetention_invalid_versionId(s)
+	Versioning_GetObjectRetention_invalid_versionId(s)
+	Versioning_Put_GetObjectRetention_success(s)
+	// Object-Lock Legal hold
+	Versionsin_PutObjectLegalHold_invalid_versionId(s)
+	Versioning_GetObjectLegalHold_invalid_versionId(s)
+	Versioning_Put_GetObjectLegalHold_success(s)
+	// WORM protection
+	Versioning_WORM_obj_version_locked_with_legal_hold(s)
+	Versioning_WORM_obj_version_locked_with_governance_retention(s)
+	Versioning_WORM_obj_version_locked_with_compliance_retention(s)
 }
 
 type IntTests map[string]func(s *S3Conf) error
@@ -900,5 +912,14 @@ func GetIntTests() IntTests {
 		"Versioning_Multipart_Upload_overwrite_an_object":                     Versioning_Multipart_Upload_overwrite_an_object,
 		"Versioning_UploadPartCopy_non_existing_versionId":                    Versioning_UploadPartCopy_non_existing_versionId,
 		"Versioning_UploadPartCopy_from_an_object_version":                    Versioning_UploadPartCopy_from_an_object_version,
+		"Versionsin_PutObjectRetention_invalid_versionId":                     Versionsin_PutObjectRetention_invalid_versionId,
+		"Versioning_GetObjectRetention_invalid_versionId":                     Versioning_GetObjectRetention_invalid_versionId,
+		"Versioning_Put_GetObjectRetention_success":                           Versioning_Put_GetObjectRetention_success,
+		"Versionsin_PutObjectLegalHold_invalid_versionId":                     Versionsin_PutObjectLegalHold_invalid_versionId,
+		"Versioning_GetObjectLegalHold_invalid_versionId":                     Versioning_GetObjectLegalHold_invalid_versionId,
+		"Versioning_Put_GetObjectLegalHold_success":                           Versioning_Put_GetObjectLegalHold_success,
+		"Versioning_WORM_obj_version_locked_with_legal_hold":                  Versioning_WORM_obj_version_locked_with_legal_hold,
+		"Versioning_WORM_obj_version_locked_with_governance_retention":        Versioning_WORM_obj_version_locked_with_governance_retention,
+		"Versioning_WORM_obj_version_locked_with_compliance_retention":        Versioning_WORM_obj_version_locked_with_compliance_retention,
 	}
 }


### PR DESCRIPTION
Object lock functionality for bucket versioning had been reverted and removed from versioning PR.

Reverted back the functionality from local copy, fixed merge conflicts with the recent changes and adjusted to the integration tests.