### PR TITLE
fix: Added the implementation to automatically enable bucket versioni…

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -134,6 +134,7 @@ const (
 	ErrKeyTooLong
 	ErrInvalidVersionId
 	ErrNoSuchVersion
+	ErrSuspendedVersioningNotAllowed
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -536,6 +537,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "NoSuchVersion",
 		Description:    "The specified version does not exist.",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrSuspendedVersioningNotAllowed: {
+		Code:           "InvalidBucketState",
+		Description:    "An Object Lock configuration is present on this bucket, so the versioning state cannot be changed.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 
 	// non aws errors

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -553,6 +553,9 @@ func TestVersioning(s *S3Conf) {
 	Versioning_Multipart_Upload_overwrite_an_object(s)
 	Versioning_UploadPartCopy_non_existing_versionId(s)
 	Versioning_UploadPartCopy_from_an_object_version(s)
+	// Object lock configuration
+	Versioning_Enable_object_lock(s)
+	Versioning_status_switch_to_suspended_with_object_lock(s)
 	// Object-Lock Retention
 	Versionsin_PutObjectRetention_invalid_versionId(s)
 	Versioning_GetObjectRetention_invalid_versionId(s)
@@ -912,6 +915,8 @@ func GetIntTests() IntTests {
 		"Versioning_Multipart_Upload_overwrite_an_object":                     Versioning_Multipart_Upload_overwrite_an_object,
 		"Versioning_UploadPartCopy_non_existing_versionId":                    Versioning_UploadPartCopy_non_existing_versionId,
 		"Versioning_UploadPartCopy_from_an_object_version":                    Versioning_UploadPartCopy_from_an_object_version,
+		"Versioning_Enable_object_lock":                                       Versioning_Enable_object_lock,
+		"Versioning_status_switch_to_suspended_with_object_lock":              Versioning_status_switch_to_suspended_with_object_lock,
 		"Versionsin_PutObjectRetention_invalid_versionId":                     Versionsin_PutObjectRetention_invalid_versionId,
 		"Versioning_GetObjectRetention_invalid_versionId":                     Versioning_GetObjectRetention_invalid_versionId,
 		"Versioning_Put_GetObjectRetention_success":                           Versioning_Put_GetObjectRetention_success,


### PR DESCRIPTION
Fixes #837
Fixes #838 

Implemented a feature that automatically enables bucket versioning whenever object lock is activated, ensuring compatibility with object lock requirements.

Added error handling to block any attempt to set bucket versioning status to `Suspended` when object lock is enabled.