### PR TITLE
fix: Fixed CopyObject copy-source parsing to handle object names with…

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -116,15 +116,13 @@ func ParseCopySource(copySourceHeader string) (string, string, string, error) {
 		copySourceHeader = copySourceHeader[1:]
 	}
 
-	cSplitted := strings.Split(copySourceHeader, "?")
-	copySource := cSplitted[0]
-	var versionId string
-	if len(cSplitted) > 1 {
-		versionIdParts := strings.Split(cSplitted[1], "=")
-		if len(versionIdParts) != 2 || versionIdParts[0] != "versionId" {
-			return "", "", "", s3err.GetAPIError(s3err.ErrInvalidRequest)
-		}
-		versionId = versionIdParts[1]
+	var copySource, versionId string
+	i := strings.LastIndex(copySourceHeader, "?versionId=")
+	if i == -1 {
+		copySource = copySourceHeader
+	} else {
+		copySource = copySourceHeader[:i]
+		versionId = copySourceHeader[i+11:]
 	}
 
 	srcBucket, srcObject, ok := strings.Cut(copySource, "/")

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -356,7 +356,7 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	},
 	ErrInvalidAccessKeyID: {
 		Code:           "InvalidAccessKeyId",
-		Description:    "The access key ID you provided does not exist in our records.",
+		Description:    "The AWS Access Key Id you provided does not exist in our records.",
 		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrRequestNotReadyYet: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -528,6 +528,7 @@ func TestVersioning(s *S3Conf) {
 	Versioning_CopyObject_success(s)
 	Versioning_CopyObject_non_existing_version_id(s)
 	Versioning_CopyObject_from_an_object_version(s)
+	Versioning_CopyObject_special_chars(s)
 	// HeadObject action
 	Versioning_HeadObject_invalid_versionId(s)
 	Versioning_HeadObject_success(s)
@@ -895,6 +896,7 @@ func GetIntTests() IntTests {
 		"Versioning_CopyObject_success":                                       Versioning_CopyObject_success,
 		"Versioning_CopyObject_non_existing_version_id":                       Versioning_CopyObject_non_existing_version_id,
 		"Versioning_CopyObject_from_an_object_version":                        Versioning_CopyObject_from_an_object_version,
+		"Versioning_CopyObject_special_chars":                                 Versioning_CopyObject_special_chars,
 		"Versioning_HeadObject_invalid_versionId":                             Versioning_HeadObject_invalid_versionId,
 		"Versioning_HeadObject_success":                                       Versioning_HeadObject_success,
 		"Versioning_HeadObject_delete_marker":                                 Versioning_HeadObject_delete_marker,


### PR DESCRIPTION
Fixes #835 

Fixed CopyObject copy-source parsing to handle object names with special characters.

e.g
foo?bar
bar&baz/foo
...