### PR TITLE
fix: Implemented the AmzDate type to handle iso8601 date parsing and …

### DIFF
--- a/auth/object_lock.go
+++ b/auth/object_lock.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/versity/versitygw/backend"
 	"github.com/versity/versitygw/s3err"
+	"github.com/versity/versitygw/s3response"
 )
 
 type BucketLockConfig struct {
@@ -92,12 +93,12 @@ func ParseBucketLockConfigurationOutput(input []byte) (*types.ObjectLockConfigur
 }
 
 func ParseObjectLockRetentionInput(input []byte) ([]byte, error) {
-	var retention types.ObjectLockRetention
+	var retention s3response.PutObjectRetentionInput
 	if err := xml.Unmarshal(input, &retention); err != nil {
 		return nil, s3err.GetAPIError(s3err.ErrInvalidRequest)
 	}
 
-	if retention.RetainUntilDate == nil || retention.RetainUntilDate.Before(time.Now()) {
+	if retention.RetainUntilDate.Before(time.Now()) {
 		return nil, s3err.GetAPIError(s3err.ErrPastObjectLockRetainDate)
 	}
 	switch retention.Mode {


### PR DESCRIPTION
Fixes #855 

Implemented the `AmzDate` type to parse/validate iso8601 xml date strings. The type is used in `PutObjectRetentionInput` to parse the `RetainUntilDate` prop, which could be an any structure of iso8601 date string.

The type parses iso8601 date strings with the following layouts. 
```go
	iso8601TimeFormat         = "2006-01-02T15:04:05.000Z"
	iso8601TimeFormatExtended = "2006-01-02T15:04:05.000000Z"
	iso8601TimeFormatWithTZ   = "2006-01-02T15:04:05-0700"
```

This implementation can't be tested with integration tests(with Go sdk), as Go sdk uses the following formatting before sending the request.
```go
// FormatDateTime formats value as a date-time, (RFC3339 section 5.6)
//
// Example: 1985-04-12T23:20:50.52Z
func FormatDateTime(value time.Time) string {
	return value.UTC().Format(dateTimeFormatOutput)
}
```