### PR TITLE
fix: Added VersioningNotConfigured error in Put/GetBucketVersioning a…

### DIFF
--- a/cmd/versitygw/test.go
+++ b/cmd/versitygw/test.go
@@ -108,6 +108,14 @@ func initTestCommands() []*cli.Command {
 			Name:   "posix",
 			Usage:  "Tests posix specific features",
 			Action: getAction(integration.TestPosix),
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:        "versioning-enabled",
+					Usage:       "Test posix when versioning is enabled",
+					Destination: &versioningEnabled,
+					Aliases:     []string{"vs"},
+				},
+			},
 		},
 		{
 			Name:   "iam",

--- a/runtests.sh
+++ b/runtests.sh
@@ -5,17 +5,19 @@ rm -rf /tmp/gw
 mkdir /tmp/gw
 rm -rf /tmp/covdata
 mkdir /tmp/covdata
+rm -rf /tmp/versioing.covdata
+mkdir /tmp/versioning.covdata
 rm -rf /tmp/versioningdir
 mkdir /tmp/versioningdir
 
-# run server in background
-GOCOVERDIR=/tmp/covdata ./versitygw -a user -s pass --iam-dir /tmp/gw posix --versioning-dir /tmp/versioningdir /tmp/gw &
+# run server in background not versioning-enabled
+# port: 7070(default)
+GOCOVERDIR=/tmp/covdata ./versitygw -a user -s pass --iam-dir /tmp/gw posix /tmp/gw &
 GW_PID=$!
 
-# wait a second for server to start up
 sleep 1
 
-# check if server is still running
+# check if versioning-enabled gateway process is still running
 if ! kill -0 $GW_PID; then
 	echo "server no longer running"
 	exit 1
@@ -23,7 +25,7 @@ fi
 
 # run tests
 # full flow tests
-if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7070 full-flow -vs; then
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7070 full-flow; then
 	echo "full flow tests failed"
 	kill $GW_PID
 	exit 1
@@ -41,8 +43,39 @@ if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7070 iam; then
 	exit 1
 fi
 
-# kill off server
 kill $GW_PID
+
+# run server in background versioning-enabled
+# port: 7071
+GOCOVERDIR=/tmp/versioning.covdata ./versitygw -p :7071 -a user -s pass --iam-dir /tmp/gw posix --versioning-dir /tmp/versioningdir /tmp/gw &
+GW_VS_PID=$!
+
+# wait a second for server to start up
+sleep 1
+
+# check if versioning-enabled gateway process is still running
+if ! kill -0 $GW_VS_PID; then
+	echo "versioning-enabled server no longer running"
+	exit 1
+fi
+
+# run tests
+# full flow tests
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7071 full-flow -vs; then
+	echo "versioning-enabled full-flow tests failed"
+	kill $GW_VS_PID
+	exit 1
+fi
+# posix tests
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7071 posix -vs; then
+	echo "versiongin-enabled posix tests failed"
+	kill $GW_VS_PID
+	exit 1
+fi
+
+# kill off server
+kill $GW_VS_PID
+
 exit 0
 
 # if the above binary was built with -cover enabled (make testbin),

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -141,6 +141,7 @@ const (
 	ErrObjectParentIsFile
 	ErrDirectoryObjectContainsData
 	ErrQuotaExceeded
+	ErrVersioningNotConfigured
 )
 
 var errorCodeResponse = map[ErrorCode]APIError{
@@ -564,6 +565,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "QuotaExceeded",
 		Description:    "Your request was denied due to quota exceeded.",
 		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrVersioningNotConfigured: {
+		Code:           "VersioningNotConfigured",
+		Description:    "Versioning has not been configured for the gateway.",
+		HTTPStatusCode: http.StatusNotImplemented,
 	},
 }
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -490,6 +490,10 @@ func TestPosix(s *S3Conf) {
 	PutObject_name_too_long(s)
 	HeadObject_name_too_long(s)
 	DeleteObject_name_too_long(s)
+	// posix specific versioning tests
+	if !s.versioningEnabled {
+		TestVersioningDisabled(s)
+	}
 }
 
 func TestIAM(s *S3Conf) {
@@ -569,6 +573,11 @@ func TestVersioning(s *S3Conf) {
 	Versioning_WORM_obj_version_locked_with_legal_hold(s)
 	Versioning_WORM_obj_version_locked_with_governance_retention(s)
 	Versioning_WORM_obj_version_locked_with_compliance_retention(s)
+}
+
+func TestVersioningDisabled(s *S3Conf) {
+	VersioningDisabled_GetBucketVersioning_not_configured(s)
+	VersioningDisabled_PutBucketVersioning_not_configured(s)
 }
 
 type IntTests map[string]func(s *S3Conf) error

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -12170,3 +12170,37 @@ func Versioning_WORM_obj_version_locked_with_compliance_retention(s *S3Conf) err
 		return nil
 	}, withLock(), withVersioning())
 }
+
+func VersioningDisabled_GetBucketVersioning_not_configured(s *S3Conf) error {
+	testName := "VersioningDisabled_GetBucketVersioning_not_configured"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+			Bucket: &bucket,
+			VersioningConfiguration: &types.VersioningConfiguration{
+				Status: types.BucketVersioningStatusEnabled,
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrVersioningNotConfigured)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+func VersioningDisabled_PutBucketVersioning_not_configured(s *S3Conf) error {
+	testName := "VersioningDisabled_PutBucketVersioning_not_configured"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{
+			Bucket: &bucket,
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrVersioningNotConfigured)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}


### PR DESCRIPTION
Fixes #860 

Returns `VersioningNotConfigured` when attempting to get or set bucket versioning, and versioning is not configured for the gateway.

Adds gateway testing in non-versioning-enabled mode with full-flow and posix tests in the pipeline.