### PR TITLE
fix: unexpected errors during upload races

### DIFF
--- a/auth/object_lock.go
+++ b/auth/object_lock.go
@@ -227,6 +227,9 @@ func CheckObjectAccess(ctx context.Context, bucket, userAccess string, objects [
 
 		status, err := be.GetObjectLegalHold(ctx, bucket, key, versionId)
 		if err != nil {
+			if errors.Is(err, s3err.GetAPIError(s3err.ErrNoSuchKey)) {
+				continue
+			}
 			if errors.Is(err, s3err.GetAPIError(s3err.ErrNoSuchObjectLockConfiguration)) {
 				checkLegalHold = false
 			} else {

--- a/backend/meta/meta.go
+++ b/backend/meta/meta.go
@@ -14,17 +14,19 @@
 
 package meta
 
+import "os"
+
 // MetadataStorer defines the interface for managing metadata.
 // When object == "", the operation is on the bucket.
 type MetadataStorer interface {
 	// RetrieveAttribute retrieves the value of a specific attribute for an object or a bucket.
 	// Returns the value of the attribute, or an error if the attribute does not exist.
-	RetrieveAttribute(bucket, object, attribute string) ([]byte, error)
+	RetrieveAttribute(f *os.File, bucket, object, attribute string) ([]byte, error)
 
 	// StoreAttribute stores the value of a specific attribute for an object or a bucket.
 	// If attribute already exists, new attribute should replace existing.
 	// Returns an error if the operation fails.
-	StoreAttribute(bucket, object, attribute string, value []byte) error
+	StoreAttribute(f *os.File, bucket, object, attribute string, value []byte) error
 
 	// DeleteAttribute removes the value of a specific attribute for an object or a bucket.
 	// Returns an error if the operation fails.

--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -174,6 +174,10 @@ func (tmp *tmpfile) cleanup() {
 	tmp.f.Close()
 }
 
+func (tmp *tmpfile) File() *os.File {
+	return tmp.f
+}
+
 func moveData(from *os.File, to *os.File) error {
 	return scoutfs.MoveData(from, to)
 }

--- a/backend/scoutfs/scoutfs_incompat.go
+++ b/backend/scoutfs/scoutfs_incompat.go
@@ -28,9 +28,7 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 	return nil, fmt.Errorf("scoutfs only available on linux")
 }
 
-type tmpfile struct {
-	f *os.File
-}
+type tmpfile struct{}
 
 var (
 	errNotSupported = errors.New("not supported")
@@ -54,6 +52,10 @@ func (tmp *tmpfile) Write(b []byte) (int, error) {
 }
 
 func (tmp *tmpfile) cleanup() {
+}
+
+func (tmp *tmpfile) File() *os.File {
+	return nil
 }
 
 func moveData(_, _ *os.File) error {

--- a/cmd/versitygw/gateway_test.go
+++ b/cmd/versitygw/gateway_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/versity/versitygw/backend/meta"
 	"github.com/versity/versitygw/backend/posix"
@@ -75,6 +76,9 @@ func initPosix(ctx context.Context) {
 		}
 		wg.Done()
 	}()
+
+	// wait for server to start
+	time.Sleep(1 * time.Second)
 }
 
 func TestIntegration(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/urfave/cli/v2 v2.27.4
 	github.com/valyala/fasthttp v1.56.0
 	github.com/versity/scoutfs-go v0.0.0-20240325223134-38eb2f5f7d44
+	golang.org/x/sync v0.8.0
 	golang.org/x/sys v0.26.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.8.0 h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=
+golang.org/x/sync v0.8.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -134,6 +134,7 @@ func TestPutObject(s *S3Conf) {
 	PutObject_missing_object_lock_retention_config(s)
 	PutObject_with_object_lock(s)
 	PutObject_success(s)
+	PutObject_racey_success(s)
 	PutObject_invalid_credentials(s)
 }
 
@@ -304,6 +305,9 @@ func TestCompleteMultipartUpload(s *S3Conf) {
 	CompleteMultipartUpload_invalid_part_number(s)
 	CompleteMultipartUpload_invalid_ETag(s)
 	CompleteMultipartUpload_success(s)
+	if !s.azureTests {
+		CompleteMultipartUpload_racey_success(s)
+	}
 }
 
 func TestPutBucketAcl(s *S3Conf) {
@@ -571,17 +575,19 @@ func TestVersioning(s *S3Conf) {
 	Versioning_Enable_object_lock(s)
 	Versioning_status_switch_to_suspended_with_object_lock(s)
 	// Object-Lock Retention
-	Versionsin_PutObjectRetention_invalid_versionId(s)
+	Versioning_PutObjectRetention_invalid_versionId(s)
 	Versioning_GetObjectRetention_invalid_versionId(s)
 	Versioning_Put_GetObjectRetention_success(s)
 	// Object-Lock Legal hold
-	Versionsin_PutObjectLegalHold_invalid_versionId(s)
+	Versioning_PutObjectLegalHold_invalid_versionId(s)
 	Versioning_GetObjectLegalHold_invalid_versionId(s)
 	Versioning_Put_GetObjectLegalHold_success(s)
 	// WORM protection
 	Versioning_WORM_obj_version_locked_with_legal_hold(s)
 	Versioning_WORM_obj_version_locked_with_governance_retention(s)
 	Versioning_WORM_obj_version_locked_with_compliance_retention(s)
+	// Concurrent requests
+	//Versioninig_concurrent_upload_object(s)
 }
 
 func TestVersioningDisabled(s *S3Conf) {
@@ -677,6 +683,7 @@ func GetIntTests() IntTests {
 		"PutObject_special_chars":                                             PutObject_special_chars,
 		"PutObject_invalid_long_tags":                                         PutObject_invalid_long_tags,
 		"PutObject_success":                                                   PutObject_success,
+		"PutObject_racey_success":                                             PutObject_racey_success,
 		"HeadObject_non_existing_object":                                      HeadObject_non_existing_object,
 		"HeadObject_invalid_part_number":                                      HeadObject_invalid_part_number,
 		"HeadObject_non_existing_mp":                                          HeadObject_non_existing_mp,
@@ -790,6 +797,7 @@ func GetIntTests() IntTests {
 		"CompleteMultipartUpload_invalid_part_number":                         CompleteMultipartUpload_invalid_part_number,
 		"CompleteMultipartUpload_invalid_ETag":                                CompleteMultipartUpload_invalid_ETag,
 		"CompleteMultipartUpload_success":                                     CompleteMultipartUpload_success,
+		"CompleteMultipartUpload_racey_success":                               CompleteMultipartUpload_racey_success,
 		"PutBucketAcl_non_existing_bucket":                                    PutBucketAcl_non_existing_bucket,
 		"PutBucketAcl_disabled":                                               PutBucketAcl_disabled,
 		"PutBucketAcl_none_of_the_options_specified":                          PutBucketAcl_none_of_the_options_specified,
@@ -939,14 +947,15 @@ func GetIntTests() IntTests {
 		"Versioning_UploadPartCopy_from_an_object_version":                    Versioning_UploadPartCopy_from_an_object_version,
 		"Versioning_Enable_object_lock":                                       Versioning_Enable_object_lock,
 		"Versioning_status_switch_to_suspended_with_object_lock":              Versioning_status_switch_to_suspended_with_object_lock,
-		"Versionsin_PutObjectRetention_invalid_versionId":                     Versionsin_PutObjectRetention_invalid_versionId,
+		"Versioning_PutObjectRetention_invalid_versionId":                     Versioning_PutObjectRetention_invalid_versionId,
 		"Versioning_GetObjectRetention_invalid_versionId":                     Versioning_GetObjectRetention_invalid_versionId,
 		"Versioning_Put_GetObjectRetention_success":                           Versioning_Put_GetObjectRetention_success,
-		"Versionsin_PutObjectLegalHold_invalid_versionId":                     Versionsin_PutObjectLegalHold_invalid_versionId,
+		"Versioning_PutObjectLegalHold_invalid_versionId":                     Versioning_PutObjectLegalHold_invalid_versionId,
 		"Versioning_GetObjectLegalHold_invalid_versionId":                     Versioning_GetObjectLegalHold_invalid_versionId,
 		"Versioning_Put_GetObjectLegalHold_success":                           Versioning_Put_GetObjectLegalHold_success,
 		"Versioning_WORM_obj_version_locked_with_legal_hold":                  Versioning_WORM_obj_version_locked_with_legal_hold,
 		"Versioning_WORM_obj_version_locked_with_governance_retention":        Versioning_WORM_obj_version_locked_with_governance_retention,
 		"Versioning_WORM_obj_version_locked_with_compliance_retention":        Versioning_WORM_obj_version_locked_with_compliance_retention,
+		"Versioning_concurrent_upload_object":                                 Versioning_concurrent_upload_object,
 	}
 }

--- a/tests/integration/s3conf.go
+++ b/tests/integration/s3conf.go
@@ -115,6 +115,7 @@ func (c *S3Conf) Config() aws.Config {
 		config.WithRegion(c.awsRegion),
 		config.WithCredentialsProvider(creds),
 		config.WithHTTPClient(client),
+		config.WithRetryMaxAttempts(1),
 	}
 
 	if c.checksumDisable {


### PR DESCRIPTION
This fixes the cases for racing uploads with the same object names. Before we were making some bad assumptions about what would cause an error when trying to link/rename the final object name into the namespace, but missed the case that another upload for the same name could be racing with this upload and causing an incorrect error.

This also changes the order of setting metadata to prevent accidental setting of metadata for the current upload to another racing upload.

Fixes #854