### PR TITLE
fix: Fixed object versions listing with ListObjectVersions when versi…

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -614,9 +614,6 @@ func (p *Posix) createObjVersion(bucket, key string, size int64, acc auth.Accoun
 }
 
 func (p *Posix) ListObjectVersions(ctx context.Context, input *s3.ListObjectVersionsInput) (s3response.ListVersionsResult, error) {
-	if !p.versioningEnabled() {
-		return s3response.ListVersionsResult{}, nil
-	}
 	bucket := *input.Bucket
 	var prefix, delim, keyMarker, versionIdMarker string
 	var max int
@@ -734,6 +731,7 @@ func (p *Posix) fileToObjVersions(bucket string) backend.GetVersionsFunc {
 				IsLatest:     getBoolPtr(true),
 				Size:         &size,
 				VersionId:    &versionId,
+				StorageClass: types.ObjectVersionStorageClassStandard,
 			})
 
 			return &backend.ObjVersionFuncResult{
@@ -795,6 +793,7 @@ func (p *Posix) fileToObjVersions(bucket string) backend.GetVersionsFunc {
 					Size:         &size,
 					VersionId:    &versionId,
 					IsLatest:     getBoolPtr(true),
+					StorageClass: types.ObjectVersionStorageClassStandard,
 				})
 			}
 
@@ -888,6 +887,7 @@ func (p *Posix) fileToObjVersions(bucket string) backend.GetVersionsFunc {
 					Size:         &size,
 					VersionId:    &versionId,
 					IsLatest:     getBoolPtr(false),
+					StorageClass: types.ObjectVersionStorageClassStandard,
 				})
 			}
 

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -385,7 +385,6 @@ type ListVersionsResult struct {
 	NextKeyMarker       *string
 	NextVersionIdMarker *string
 	Prefix              *string
-	RequestCharged      types.RequestCharged
 	VersionIdMarker     *string
 	Versions            []types.ObjectVersion `xml:"Version"`
 }

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -191,6 +191,11 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_list_all_objs(s)
 }
 
+// VD stands for Versioning Disabled
+func TestListObjectVersions_VD(s *S3Conf) {
+	ListObjectVersions_VD_success(s)
+}
+
 func TestDeleteObject(s *S3Conf) {
 	DeleteObject_non_existing_object(s)
 	DeleteObject_directory_object_noslash(s)
@@ -449,6 +454,9 @@ func TestFullFlow(s *S3Conf) {
 	TestGetObject(s)
 	TestListObjects(s)
 	TestListObjectsV2(s)
+	if !s.versioningEnabled && !s.azureTests {
+		TestListObjectVersions_VD(s)
+	}
 	TestDeleteObject(s)
 	TestDeleteObjects(s)
 	TestCopyObject(s)
@@ -708,6 +716,7 @@ func GetIntTests() IntTests {
 		"ListObjectsV2_truncated_common_prefixes":                             ListObjectsV2_truncated_common_prefixes,
 		"ListObjectsV2_all_objs_max_keys":                                     ListObjectsV2_all_objs_max_keys,
 		"ListObjectsV2_list_all_objs":                                         ListObjectsV2_list_all_objs,
+		"ListObjectVersions_VD_success":                                       ListObjectVersions_VD_success,
 		"DeleteObject_non_existing_object":                                    DeleteObject_non_existing_object,
 		"DeleteObject_directory_object_noslash":                               DeleteObject_directory_object_noslash,
 		"DeleteObject_name_too_long":                                          DeleteObject_name_too_long,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -976,11 +976,12 @@ func createObjVersions(client *s3.Client, bucket, object string, count int) ([]t
 		isLatest := i == count-1
 
 		versions = append(versions, types.ObjectVersion{
-			ETag:      r.res.ETag,
-			IsLatest:  &isLatest,
-			Key:       &object,
-			Size:      &dataLength,
-			VersionId: r.res.VersionId,
+			ETag:         r.res.ETag,
+			IsLatest:     &isLatest,
+			Key:          &object,
+			Size:         &dataLength,
+			VersionId:    r.res.VersionId,
+			StorageClass: types.ObjectVersionStorageClassStandard,
 		})
 	}
 
@@ -1035,6 +1036,10 @@ func compareVersions(v1, v2 []types.ObjectVersion) bool {
 			return false
 		}
 		if *version.ETag != *v2[i].ETag {
+			return false
+		}
+
+		if version.StorageClass != v2[i].StorageClass {
 			return false
 		}
 	}


### PR DESCRIPTION
Fixes #862 

Removes object versioning check in `ListObjectVersions` to list objects, even when versioning is not configured for the gateway. 
Hardcodes `STANDART` storage class for object versions in `ListObjectVersions.