### PR TITLE
fix: Removed ObjectLockConfigurationNotFoundError, when attempting to…

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -522,7 +522,8 @@ func TestVersioning(s *S3Conf) {
 	// PutBucketVersioning action
 	PutBucketVersioning_non_existing_bucket(s)
 	PutBucketVersioning_invalid_status(s)
-	PutBucketVersioning_success(s)
+	PutBucketVersioning_success_enabled(s)
+	PutBucketVersioning_success_suspended(s)
 	// GetBucketVersioning action
 	GetBucketVersioning_non_existing_bucket(s)
 	GetBucketVersioning_empty_response(s)
@@ -897,7 +898,8 @@ func GetIntTests() IntTests {
 		"AccessControl_copy_object_with_starting_slash_for_user":              AccessControl_copy_object_with_starting_slash_for_user,
 		"PutBucketVersioning_non_existing_bucket":                             PutBucketVersioning_non_existing_bucket,
 		"PutBucketVersioning_invalid_status":                                  PutBucketVersioning_invalid_status,
-		"PutBucketVersioning_success":                                         PutBucketVersioning_success,
+		"PutBucketVersioning_success_enabled":                                 PutBucketVersioning_success_enabled,
+		"PutBucketVersioning_success_suspended":                               PutBucketVersioning_success_suspended,
 		"GetBucketVersioning_non_existing_bucket":                             GetBucketVersioning_non_existing_bucket,
 		"GetBucketVersioning_empty_response":                                  GetBucketVersioning_empty_response,
 		"GetBucketVersioning_success":                                         GetBucketVersioning_success,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -10412,14 +10412,33 @@ func PutBucketVersioning_invalid_status(s *S3Conf) error {
 	})
 }
 
-func PutBucketVersioning_success(s *S3Conf) error {
-	testName := "PutBucketVersioning_success"
+func PutBucketVersioning_success_enabled(s *S3Conf) error {
+	testName := "PutBucketVersioning_success_enabled"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
 		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 		_, err := s3client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
 			Bucket: &bucket,
 			VersioningConfiguration: &types.VersioningConfiguration{
 				Status: types.BucketVersioningStatusEnabled,
+			},
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func PutBucketVersioning_success_suspended(s *S3Conf) error {
+	testName := "PutBucketVersioning_success_suspended"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+			Bucket: &bucket,
+			VersioningConfiguration: &types.VersioningConfiguration{
+				Status: types.BucketVersioningStatusSuspended,
 			},
 		})
 		cancel()


### PR DESCRIPTION
Fixes #866 

Adds `ErrObjectLockConfigurationNotFound` error check in `PutBucketVersioning`, when attempting to set bucket versioning status to `Suspended`