### PR TITLE
fix: Adds bucket object lock status check in GetObjectLegalHold and G…

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -437,12 +437,12 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	},
 	ErrNoSuchObjectLockConfiguration: {
 		Code:           "NoSuchObjectLockConfiguration",
-		Description:    "The specified object does not have an ObjectLock configuration.",
+		Description:    "The specified object does not have a ObjectLock configuration.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidBucketObjectLockConfiguration: {
 		Code:           "InvalidRequest",
-		Description:    "Bucket is missing ObjectLockConfiguration.",
+		Description:    "Bucket is missing Object Lock Configuration.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrObjectLockConfigurationNotAllowed: {
@@ -521,8 +521,9 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrInvalidMetadataDirective: {
-		Code:        "InvalidArgument",
-		Description: "Unknown metadata directive.",
+		Code:           "InvalidArgument",
+		Description:    "Unknown metadata directive.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidVersionId: {
 		Code:           "InvalidArgument",

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -407,6 +407,7 @@ func TestPutObjectRetention(s *S3Conf) {
 func TestGetObjectRetention(s *S3Conf) {
 	GetObjectRetention_non_existing_bucket(s)
 	GetObjectRetention_non_existing_object(s)
+	GetObjectRetention_disabled_lock(s)
 	GetObjectRetention_unset_config(s)
 	GetObjectRetention_success(s)
 }
@@ -424,6 +425,7 @@ func TestPutObjectLegalHold(s *S3Conf) {
 func TestGetObjectLegalHold(s *S3Conf) {
 	GetObjectLegalHold_non_existing_bucket(s)
 	GetObjectLegalHold_non_existing_object(s)
+	GetObjectLegalHold_disabled_lock(s)
 	GetObjectLegalHold_unset_config(s)
 	GetObjectLegalHold_success(s)
 }
@@ -877,6 +879,7 @@ func GetIntTests() IntTests {
 		"PutObjectRetention_success":                                          PutObjectRetention_success,
 		"GetObjectRetention_non_existing_bucket":                              GetObjectRetention_non_existing_bucket,
 		"GetObjectRetention_non_existing_object":                              GetObjectRetention_non_existing_object,
+		"GetObjectRetention_disabled_lock":                                    GetObjectRetention_disabled_lock,
 		"GetObjectRetention_unset_config":                                     GetObjectRetention_unset_config,
 		"GetObjectRetention_success":                                          GetObjectRetention_success,
 		"PutObjectLegalHold_non_existing_bucket":                              PutObjectLegalHold_non_existing_bucket,
@@ -888,6 +891,7 @@ func GetIntTests() IntTests {
 		"PutObjectLegalHold_success":                                          PutObjectLegalHold_success,
 		"GetObjectLegalHold_non_existing_bucket":                              GetObjectLegalHold_non_existing_bucket,
 		"GetObjectLegalHold_non_existing_object":                              GetObjectLegalHold_non_existing_object,
+		"GetObjectLegalHold_disabled_lock":                                    GetObjectLegalHold_disabled_lock,
 		"GetObjectLegalHold_unset_config":                                     GetObjectLegalHold_unset_config,
 		"GetObjectLegalHold_success":                                          GetObjectLegalHold_success,
 		"WORMProtection_bucket_object_lock_configuration_compliance_mode":     WORMProtection_bucket_object_lock_configuration_compliance_mode,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -8930,6 +8930,29 @@ func GetObjectRetention_non_existing_object(s *S3Conf) error {
 	})
 }
 
+func GetObjectRetention_disabled_lock(s *S3Conf) error {
+	testName := "GetObjectRetention_disabled_lock"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		key := "my-obj"
+		_, err := putObjects(s3client, []string{key}, bucket)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.GetObjectRetention(ctx, &s3.GetObjectRetentionInput{
+			Bucket: &bucket,
+			Key:    &key,
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidBucketObjectLockConfiguration)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func GetObjectRetention_unset_config(s *S3Conf) error {
 	testName := "GetObjectRetention_unset_config"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
@@ -8950,7 +8973,7 @@ func GetObjectRetention_unset_config(s *S3Conf) error {
 		}
 
 		return nil
-	})
+	}, withLock())
 }
 
 func GetObjectRetention_success(s *S3Conf) error {
@@ -9225,6 +9248,29 @@ func GetObjectLegalHold_non_existing_object(s *S3Conf) error {
 	})
 }
 
+func GetObjectLegalHold_disabled_lock(s *S3Conf) error {
+	testName := "GetObjectLegalHold_disabled_lock"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		key := "my-obj"
+		_, err := putObjects(s3client, []string{key}, bucket)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.GetObjectLegalHold(ctx, &s3.GetObjectLegalHoldInput{
+			Bucket: &bucket,
+			Key:    &key,
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidBucketObjectLockConfiguration)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func GetObjectLegalHold_unset_config(s *S3Conf) error {
 	testName := "GetObjectLegalHold_unset_config"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
@@ -9245,7 +9291,7 @@ func GetObjectLegalHold_unset_config(s *S3Conf) error {
 		}
 
 		return nil
-	})
+	}, withLock())
 }
 
 func GetObjectLegalHold_success(s *S3Conf) error {


### PR DESCRIPTION
Fixes #883 

Adds bucket object lock status check in GetObjectLegalHold and GetObjectRetention actions. It returns `ErrInvalidBucketObjectLockConfiguration`, if attempting to get object legal hold/retention when object lock isn't enabled for the bucket.