### PR TITLE
fix: Fixes the double entry issue for single null versionId object ve…

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -952,6 +952,11 @@ func (p *Posix) fileToObjVersions(bucket string) backend.GetVersionsFunc {
 					Truncated:           true,
 					NextVersionIdMarker: nullVersionId,
 				}, nil
+			} else {
+				return &backend.ObjVersionFuncResult{
+					ObjectVersions: objects,
+					DelMarkers:     delMarkers,
+				}, nil
 			}
 		}
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -578,6 +578,7 @@ func TestVersioning(s *S3Conf) {
 	ListObjectVersions_multiple_object_versions_truncated(s)
 	ListObjectVersions_with_delete_markers(s)
 	ListObjectVersions_containing_null_versionId_obj(s)
+	ListObjectVersions_single_null_versionId_object(s)
 	// Multipart upload
 	Versioning_Multipart_Upload_success(s)
 	Versioning_Multipart_Upload_overwrite_an_object(s)
@@ -961,6 +962,7 @@ func GetIntTests() IntTests {
 		"ListObjectVersions_multiple_object_versions_truncated":               ListObjectVersions_multiple_object_versions_truncated,
 		"ListObjectVersions_with_delete_markers":                              ListObjectVersions_with_delete_markers,
 		"ListObjectVersions_containing_null_versionId_obj":                    ListObjectVersions_containing_null_versionId_obj,
+		"ListObjectVersions_single_null_versionId_object":                     ListObjectVersions_single_null_versionId_object,
 		"Versioning_Multipart_Upload_success":                                 Versioning_Multipart_Upload_success,
 		"Versioning_Multipart_Upload_overwrite_an_object":                     Versioning_Multipart_Upload_overwrite_an_object,
 		"Versioning_UploadPartCopy_non_existing_versionId":                    Versioning_UploadPartCopy_non_existing_versionId,


### PR DESCRIPTION
Fixes #893 

When there is a single null versionId object in the versioning directory, `ListObjectVersions` returns double object version entries. 

Fixes the double entry issue in `ListObjectVersions`.