### PR TITLE
fix: Resolves the null object version get issue from posix directory

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2717,8 +2717,7 @@ func (p *Posix) GetObject(_ context.Context, input *s3.GetObjectInput) (*s3.GetO
 			return nil, fmt.Errorf("get obj versionId: %w", err)
 		}
 		if errors.Is(err, meta.ErrNoSuchKey) {
-			bucket = filepath.Join(p.versioningDir, bucket)
-			object = filepath.Join(genObjVersionKey(object), versionId)
+			vId = []byte(nullVersionId)
 		}
 
 		if string(vId) != versionId {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -564,6 +564,7 @@ func TestVersioning(s *S3Conf) {
 	Versioning_GetObject_success(s)
 	Versioning_GetObject_delete_marker_without_versionId(s)
 	Versioning_GetObject_delete_marker(s)
+	Versioning_GetObject_null_versionId_obj(s)
 	// DeleteObject(s) actions
 	Versioning_DeleteObject_delete_object_version(s)
 	Versioning_DeleteObject_non_existing_object(s)
@@ -949,6 +950,7 @@ func GetIntTests() IntTests {
 		"Versioning_GetObject_success":                                        Versioning_GetObject_success,
 		"Versioning_GetObject_delete_marker_without_versionId":                Versioning_GetObject_delete_marker_without_versionId,
 		"Versioning_GetObject_delete_marker":                                  Versioning_GetObject_delete_marker,
+		"Versioning_GetObject_null_versionId_obj":                             Versioning_GetObject_null_versionId_obj,
 		"Versioning_DeleteObject_delete_object_version":                       Versioning_DeleteObject_delete_object_version,
 		"Versioning_DeleteObject_non_existing_object":                         Versioning_DeleteObject_non_existing_object,
 		"Versioning_DeleteObject_delete_a_delete_marker":                      Versioning_DeleteObject_delete_a_delete_marker,


### PR DESCRIPTION
If bucket versioning is enabled and the null versionId object is stored in posix directory, `GetObject` with versionId set to `null` returns `InvalidArgument`.

Resolves the issue of retrieving the null versionId object from posix directory by specifying versionId as `null`.

Fixes #894 