### PR TITLE
ListObjects: don't recurse beyond prefix

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"sort"
 	"strings"
 
@@ -85,8 +84,16 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 			// building to match. So only skip if path isn't a prefix of prefix
 			// and prefix isn't a prefix of path.
 			if prefix != "" &&
-				!strings.HasPrefix(path+string(os.PathSeparator), prefix) &&
-				!strings.HasPrefix(prefix, path+string(os.PathSeparator)) {
+				!strings.HasPrefix(path+"/", prefix) &&
+				!strings.HasPrefix(prefix, path+"/") {
+				return fs.SkipDir
+			}
+
+			// Don't recurse into subdirectories when listing with delimiter.
+			if delimiter == "/" &&
+				prefix != path+"/" &&
+				strings.HasPrefix(path+"/", prefix) {
+				cpmap[path+"/"] = struct{}{}
 				return fs.SkipDir
 			}
 
@@ -97,7 +104,7 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 				return fmt.Errorf("readdir %q: %w", path, err)
 			}
 
-			path += string(os.PathSeparator)
+			path += "/"
 
 			if len(ents) == 0 && delimiter == "" {
 				dirobj, err := getObj(path, d)
@@ -315,8 +322,16 @@ func WalkVersions(ctx context.Context, fileSystem fs.FS, prefix, delimiter, keyM
 			// building to match. So only skip if path isn't a prefix of prefix
 			// and prefix isn't a prefix of path.
 			if prefix != "" &&
-				!strings.HasPrefix(path+string(os.PathSeparator), prefix) &&
-				!strings.HasPrefix(prefix, path+string(os.PathSeparator)) {
+				!strings.HasPrefix(path+"/", prefix) &&
+				!strings.HasPrefix(prefix, path+"/") {
+				return fs.SkipDir
+			}
+
+			// Don't recurse into subdirectories when listing with delimiter.
+			if delimiter == "/" &&
+				prefix != path+"/" &&
+				strings.HasPrefix(path+"/", prefix) {
+				cpmap[path+"/"] = struct{}{}
 				return fs.SkipDir
 			}
 


### PR DESCRIPTION
This fixes the biggest performance issue with ListObjects for me - it would recurse into all subdirectories, even when using a delimiter.

There are still a few issues:
- Large directories take forever to list.
- Parent directories are still walked for no reason - perhaps the posix backend should scope the os.DirFS() to the last directory in the prefix rather than starting at the root, and stitch the paths back together in `p.fileToObj`. I looked at doing that but wasn't sure if I'd hit a `prefix = ""` edge case.

Also fixes #903