### PR TITLE
fix: Fixes multiple null versionId delete markers creation with Delet…

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -572,6 +572,7 @@ func TestVersioning(s *S3Conf) {
 	Versioning_DeleteObject_non_existing_object(s)
 	Versioning_DeleteObject_delete_a_delete_marker(s)
 	Versioning_Delete_null_versionId_object(s)
+	Versioning_DeleteObject_suspended(s)
 	Versioning_DeleteObjects_success(s)
 	Versioning_DeleteObjects_delete_deleteMarkers(s)
 	// ListObjectVersions
@@ -959,6 +960,7 @@ func GetIntTests() IntTests {
 		"Versioning_DeleteObject_non_existing_object":                         Versioning_DeleteObject_non_existing_object,
 		"Versioning_DeleteObject_delete_a_delete_marker":                      Versioning_DeleteObject_delete_a_delete_marker,
 		"Versioning_Delete_null_versionId_object":                             Versioning_Delete_null_versionId_object,
+		"Versioning_DeleteObject_suspended":                                   Versioning_DeleteObject_suspended,
 		"Versioning_DeleteObjects_success":                                    Versioning_DeleteObjects_success,
 		"Versioning_DeleteObjects_delete_deleteMarkers":                       Versioning_DeleteObjects_delete_deleteMarkers,
 		"ListObjectVersions_non_existing_bucket":                              ListObjectVersions_non_existing_bucket,


### PR DESCRIPTION
Fixes #902

If the bucket versioning is suspended, newly created delete markers should have null versionId.
Removes the versionId generation for null versionId delete markers.