### PR TITLE
fix: Fixes max-parts, max-keys, max-uploads validation defaulting to …

### DIFF
--- a/s3api/utils/utils.go
+++ b/s3api/utils/utils.go
@@ -180,7 +180,7 @@ func ParseUint(str string) (int32, error) {
 	}
 	num, err := strconv.ParseUint(str, 10, 16)
 	if err != nil {
-		return 1000, s3err.GetAPIError(s3err.ErrInvalidMaxKeys)
+		return 1000, fmt.Errorf("invalid uint: %w", err)
 	}
 	return int32(num), nil
 }

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -280,6 +280,8 @@ func TestUploadPartCopy(s *S3Conf) {
 func TestListParts(s *S3Conf) {
 	ListParts_incorrect_uploadId(s)
 	ListParts_incorrect_object_key(s)
+	ListParts_invalid_max_parts(s)
+	ListParts_default_max_parts(s)
 	ListParts_truncated(s)
 	ListParts_success(s)
 }
@@ -796,6 +798,8 @@ func GetIntTests() IntTests {
 		"UploadPartCopy_by_range_success":                                     UploadPartCopy_by_range_success,
 		"ListParts_incorrect_uploadId":                                        ListParts_incorrect_uploadId,
 		"ListParts_incorrect_object_key":                                      ListParts_incorrect_object_key,
+		"ListParts_invalid_max_parts":                                         ListParts_invalid_max_parts,
+		"ListParts_default_max_parts":                                         ListParts_default_max_parts,
 		"ListParts_truncated":                                                 ListParts_truncated,
 		"ListParts_success":                                                   ListParts_success,
 		"ListMultipartUploads_non_existing_bucket":                            ListMultipartUploads_non_existing_bucket,


### PR DESCRIPTION
Fixes #905
Refactors validation of the `max-keys` (ListObjects, ListObjectsV2), `max-parts` (ListParts), and `max-uploads` (ListMultipartUploads) query parameters by defaulting them to 1000.