### PR TITLE
fix: azure list multipart uploads test failures

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1036,7 +1036,8 @@ func (az *Azure) ListMultipartUploads(ctx context.Context, input *s3.ListMultipa
 	prefix := string(metaTmpMultipartPrefix)
 
 	pager := client.NewListBlobsFlatPager(&container.ListBlobsFlatOptions{
-		Prefix: &prefix,
+		Include: container.ListBlobsInclude{Metadata: true},
+		Prefix:  &prefix,
 	})
 
 	for pager.More() {


### PR DESCRIPTION
The latest azurite made a change where the blob metadata must be explicitly requested when calling NewListBlobsFlatPager(). We were taking action on metadata iteams, and the tests were failing due to these always missing without requesting metadata to be included in the response.

Fix is to enable metadata for the response.