### PR TITLE
elide some syscalls in posix backend

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -3472,15 +3472,10 @@ func (p *Posix) GetBucketAcl(_ context.Context, input *s3.GetBucketAclInput) ([]
 	if input.Bucket == nil {
 		return nil, s3err.GetAPIError(s3err.ErrInvalidBucketName)
 	}
-	_, err := os.Stat(*input.Bucket)
+	b, err := p.meta.RetrieveAttribute(nil, *input.Bucket, "", aclkey)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, s3err.GetAPIError(s3err.ErrNoSuchBucket)
 	}
-	if err != nil {
-		return nil, fmt.Errorf("stat bucket: %w", err)
-	}
-
-	b, err := p.meta.RetrieveAttribute(nil, *input.Bucket, "", aclkey)
 	if errors.Is(err, meta.ErrNoSuchKey) {
 		return []byte{}, nil
 	}


### PR DESCRIPTION
Part of #920

posix GetObject before:
```python
newfstatat(dfd: CWD, filename: 0x4692d8, statbuf: 0xc0001c6fa8)       = 0
getxattr(pathname: 0x469300, name: 0x469302, value: 0xc000214c00, size: 1024) = -1 ENODATA
newfstatat(dfd: CWD, filename: 0x469310, statbuf: 0xc0001c7078)       = 0
newfstatat(dfd: CWD, filename: 0x469320, statbuf: 0xc0001c7148)       = 0
listxattr(pathname: 0x469338, list: 0x2036c60)                        = 0
getxattr(pathname: 0x469348, name: 0x469360, value: 0xc000215000, size: 1024) = -1 ENODATA
getxattr(pathname: 0x469378, name: 0x47eab0, value: 0xc000215400, size: 1024) = -1 ENODATA
openat(dfd: CWD, filename: 0x469380, flags: RDONLY|CLOEXEC)           = 8
```
  
posix GetObject after:
```python
getxattr(pathname: 0x472378, name: 0x472380, value: 0xc000540000, size: 1024) = -1 ENODATA
newfstatat(dfd: CWD, filename: 0x472398, statbuf: 0xc0001ce9f8)       = 0
listxattr(pathname: 0x4723b0, list: 0x2036c60)                        = 0
openat(dfd: CWD, filename: 0x4723b7, flags: RDONLY|CLOEXEC)           = 8
```