### PR TITLE
chore: update example service config for directory perms option

### DIFF
--- a/extra/example.conf
+++ b/extra/example.conf
@@ -311,6 +311,12 @@ ROOT_SECRET_ACCESS_KEY=
 # to directories at the top level gateway directory as buckets.
 #VGW_BUCKET_LINKS=false
 
+# The default permissions mode when creating new directories is 0755. Use
+# VGW_DIR_PERMS option to set a different mode for any new directory that the
+# gateway creates. This applies to buckets created through the gateway as well
+# as any parent directories automatically created with object uploads.
+#VGW_DIR_PERMS=0755
+
 ###########
 # scoutfs #
 ###########
@@ -345,6 +351,12 @@ ROOT_SECRET_ACCESS_KEY=
 # The VGW_BUCKET_LINKS option will enable the gateway to treat symbolic links
 # to directories at the top level gateway directory as buckets.
 #VGW_BUCKET_LINKS=false
+
+# The default permissions mode when creating new directories is 0755. Use
+# VGW_DIR_PERMS option to set a different mode for any new directory that the
+# gateway creates. This applies to buckets created through the gateway as well
+# as any parent directories automatically created with object uploads.
+#VGW_DIR_PERMS=0755
 
 ######
 # s3 #


### PR DESCRIPTION
This was missed when we added an option for setting directory permissions different than the default 0755. This adds the VGW_DIR_PERMS option and description to the example.conf file.