### PR TITLE
fix: Changes GetObjectAttributes action xml encoding root element to …

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -512,20 +512,22 @@ func (az *Azure) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3
 	return result, nil
 }
 
-func (az *Azure) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error) {
+func (az *Azure) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
 	data, err := az.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: input.Bucket,
 		Key:    input.Key,
 	})
 	if err != nil {
-		return s3response.GetObjectAttributesResult{}, err
+		return s3response.GetObjectAttributesResponse{}, err
 	}
 
-	return s3response.GetObjectAttributesResult{
+	return s3response.GetObjectAttributesResponse{
 		ETag:         data.ETag,
-		LastModified: data.LastModified,
 		ObjectSize:   data.ContentLength,
 		StorageClass: data.StorageClass,
+		LastModified: data.LastModified,
+		VersionId:    data.VersionId,
+		DeleteMarker: data.DeleteMarker,
 	}, nil
 }
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -61,7 +61,7 @@ type Backend interface {
 	HeadObject(context.Context, *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	GetObject(context.Context, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	GetObjectAcl(context.Context, *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error)
-	GetObjectAttributes(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error)
+	GetObjectAttributes(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error)
 	CopyObject(context.Context, *s3.CopyObjectInput) (*s3.CopyObjectOutput, error)
 	ListObjects(context.Context, *s3.ListObjectsInput) (s3response.ListObjectsResult, error)
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input) (s3response.ListObjectsV2Result, error)
@@ -185,8 +185,8 @@ func (BackendUnsupported) GetObject(context.Context, *s3.GetObjectInput) (*s3.Ge
 func (BackendUnsupported) GetObjectAcl(context.Context, *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error) {
 	return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
-func (BackendUnsupported) GetObjectAttributes(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error) {
-	return s3response.GetObjectAttributesResult{}, s3err.GetAPIError(s3err.ErrNotImplemented)
+func (BackendUnsupported) GetObjectAttributes(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
+	return s3response.GetObjectAttributesResponse{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 func (BackendUnsupported) CopyObject(context.Context, *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	return nil, s3err.GetAPIError(s3err.ErrNotImplemented)

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -392,7 +392,7 @@ func (s *S3Proxy) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.
 	return output, nil
 }
 
-func (s *S3Proxy) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error) {
+func (s *S3Proxy) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
 	out, err := s.client.GetObjectAttributes(ctx, input)
 
 	parts := s3response.ObjectParts{}
@@ -419,12 +419,11 @@ func (s *S3Proxy) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAt
 		}
 	}
 
-	return s3response.GetObjectAttributesResult{
+	return s3response.GetObjectAttributesResponse{
 		ETag:         out.ETag,
 		LastModified: out.LastModified,
 		ObjectSize:   out.ObjectSize,
 		StorageClass: out.StorageClass,
-		VersionId:    out.VersionId,
 		ObjectParts:  &parts,
 	}, handleError(err)
 }

--- a/s3api/controllers/backend_moq_test.go
+++ b/s3api/controllers/backend_moq_test.go
@@ -83,7 +83,7 @@ var _ backend.Backend = &BackendMock{}
 //			GetObjectAclFunc: func(contextMoqParam context.Context, getObjectAclInput *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error) {
 //				panic("mock out the GetObjectAcl method")
 //			},
-//			GetObjectAttributesFunc: func(contextMoqParam context.Context, getObjectAttributesInput *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error) {
+//			GetObjectAttributesFunc: func(contextMoqParam context.Context, getObjectAttributesInput *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
 //				panic("mock out the GetObjectAttributes method")
 //			},
 //			GetObjectLegalHoldFunc: func(contextMoqParam context.Context, bucket string, object string, versionId string) (*bool, error) {
@@ -244,7 +244,7 @@ type BackendMock struct {
 	GetObjectAclFunc func(contextMoqParam context.Context, getObjectAclInput *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error)
 
 	// GetObjectAttributesFunc mocks the GetObjectAttributes method.
-	GetObjectAttributesFunc func(contextMoqParam context.Context, getObjectAttributesInput *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error)
+	GetObjectAttributesFunc func(contextMoqParam context.Context, getObjectAttributesInput *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error)
 
 	// GetObjectLegalHoldFunc mocks the GetObjectLegalHold method.
 	GetObjectLegalHoldFunc func(contextMoqParam context.Context, bucket string, object string, versionId string) (*bool, error)
@@ -1518,7 +1518,7 @@ func (mock *BackendMock) GetObjectAclCalls() []struct {
 }
 
 // GetObjectAttributes calls GetObjectAttributesFunc.
-func (mock *BackendMock) GetObjectAttributes(contextMoqParam context.Context, getObjectAttributesInput *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error) {
+func (mock *BackendMock) GetObjectAttributes(contextMoqParam context.Context, getObjectAttributesInput *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
 	if mock.GetObjectAttributesFunc == nil {
 		panic("BackendMock.GetObjectAttributesFunc: method is nil but Backend.GetObjectAttributes was just called")
 	}

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -187,8 +187,8 @@ func TestS3ApiController_GetActions(t *testing.T) {
 			GetObjectAclFunc: func(context.Context, *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error) {
 				return &s3.GetObjectAclOutput{}, nil
 			},
-			GetObjectAttributesFunc: func(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResult, error) {
-				return s3response.GetObjectAttributesResult{}, nil
+			GetObjectAttributesFunc: func(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
+				return s3response.GetObjectAttributesResponse{}, nil
 			},
 			GetObjectFunc: func(context.Context, *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
 				return &s3.GetObjectOutput{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -70,6 +70,7 @@ const (
 	ErrInvalidMaxUploads
 	ErrInvalidMaxParts
 	ErrInvalidPartNumberMarker
+	ErrInvalidObjectAttributes
 	ErrInvalidPart
 	ErrInvalidPartNumber
 	ErrInternalError
@@ -217,6 +218,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidPartNumberMarker: {
 		Code:           "InvalidArgument",
 		Description:    "Argument partNumberMarker must be an integer.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidObjectAttributes: {
+		Code:           "InvalidArgument",
+		Description:    "Invalid attribute name specified.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrNoSuchBucket: {

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -78,30 +78,34 @@ type ListPartsResult struct {
 	Parts []Part `xml:"Part"`
 }
 
-type GetObjectAttributesResult struct {
-	ETag         *string
-	LastModified *time.Time
-	ObjectSize   *int64
-	StorageClass types.StorageClass
-	VersionId    *string
-	ObjectParts  *ObjectParts
+type ObjectAttributes string
+
+const (
+	ObjectAttributesEtag         ObjectAttributes = "ETag"
+	ObjectAttributesChecksum     ObjectAttributes = "Checksum"
+	ObjectAttributesObjectParts  ObjectAttributes = "ObjectParts"
+	ObjectAttributesStorageClass ObjectAttributes = "StorageClass"
+	ObjectAttributesObjectSize   ObjectAttributes = "ObjectSize"
+)
+
+func (o ObjectAttributes) IsValid() bool {
+	return o == ObjectAttributesChecksum ||
+		o == ObjectAttributesEtag ||
+		o == ObjectAttributesObjectParts ||
+		o == ObjectAttributesObjectSize ||
+		o == ObjectAttributesStorageClass
 }
 
-func (r GetObjectAttributesResult) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	type Alias GetObjectAttributesResult
-	aux := &struct {
-		LastModified *string `xml:"LastModified"`
-		*Alias
-	}{
-		Alias: (*Alias)(&r),
-	}
+type GetObjectAttributesResponse struct {
+	ETag         *string
+	ObjectSize   *int64
+	StorageClass types.StorageClass `xml:",omitempty"`
+	ObjectParts  *ObjectParts
 
-	if r.LastModified != nil {
-		formattedTime := r.LastModified.UTC().Format(iso8601TimeFormat)
-		aux.LastModified = &formattedTime
-	}
-
-	return e.EncodeElement(aux, start)
+	// Not included in the response body
+	VersionId    *string
+	LastModified *time.Time
+	DeleteMarker *bool
 }
 
 type ObjectParts struct {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -157,6 +157,7 @@ func TestHeadObject(s *S3Conf) {
 func TestGetObjectAttributes(s *S3Conf) {
 	GetObjectAttributes_non_existing_bucket(s)
 	GetObjectAttributes_non_existing_object(s)
+	GetObjectAttributes_invalid_attrs(s)
 	GetObjectAttributes_existing_object(s)
 }
 
@@ -565,6 +566,7 @@ func TestVersioning(s *S3Conf) {
 	// HeadObject action
 	Versioning_HeadObject_invalid_versionId(s)
 	Versioning_HeadObject_success(s)
+	Versioning_HeadObject_without_versionId(s)
 	Versioning_HeadObject_delete_marker(s)
 	// GetObject action
 	Versioning_GetObject_invalid_versionId(s)
@@ -572,6 +574,9 @@ func TestVersioning(s *S3Conf) {
 	Versioning_GetObject_delete_marker_without_versionId(s)
 	Versioning_GetObject_delete_marker(s)
 	Versioning_GetObject_null_versionId_obj(s)
+	// GetObjectAttributes action
+	Versioning_GetObjectAttributes_object_version(s)
+	Versioning_GetObjectAttributes_delete_marker(s)
 	// DeleteObject(s) actions
 	Versioning_DeleteObject_delete_object_version(s)
 	Versioning_DeleteObject_non_existing_object(s)
@@ -720,6 +725,7 @@ func GetIntTests() IntTests {
 		"HeadObject_success":                                                  HeadObject_success,
 		"GetObjectAttributes_non_existing_bucket":                             GetObjectAttributes_non_existing_bucket,
 		"GetObjectAttributes_non_existing_object":                             GetObjectAttributes_non_existing_object,
+		"GetObjectAttributes_invalid_attrs":                                   GetObjectAttributes_invalid_attrs,
 		"GetObjectAttributes_existing_object":                                 GetObjectAttributes_existing_object,
 		"GetObject_non_existing_key":                                          GetObject_non_existing_key,
 		"GetObject_directory_object_noslash":                                  GetObject_directory_object_noslash,
@@ -960,12 +966,15 @@ func GetIntTests() IntTests {
 		"Versioning_CopyObject_special_chars":                                 Versioning_CopyObject_special_chars,
 		"Versioning_HeadObject_invalid_versionId":                             Versioning_HeadObject_invalid_versionId,
 		"Versioning_HeadObject_success":                                       Versioning_HeadObject_success,
+		"Versioning_HeadObject_without_versionId":                             Versioning_HeadObject_without_versionId,
 		"Versioning_HeadObject_delete_marker":                                 Versioning_HeadObject_delete_marker,
 		"Versioning_GetObject_invalid_versionId":                              Versioning_GetObject_invalid_versionId,
 		"Versioning_GetObject_success":                                        Versioning_GetObject_success,
 		"Versioning_GetObject_delete_marker_without_versionId":                Versioning_GetObject_delete_marker_without_versionId,
 		"Versioning_GetObject_delete_marker":                                  Versioning_GetObject_delete_marker,
 		"Versioning_GetObject_null_versionId_obj":                             Versioning_GetObject_null_versionId_obj,
+		"Versioning_GetObjectAttributes_object_version":                       Versioning_GetObjectAttributes_object_version,
+		"Versioning_GetObjectAttributes_delete_marker":                        Versioning_GetObjectAttributes_delete_marker,
 		"Versioning_DeleteObject_delete_object_version":                       Versioning_DeleteObject_delete_object_version,
 		"Versioning_DeleteObject_non_existing_object":                         Versioning_DeleteObject_non_existing_object,
 		"Versioning_DeleteObject_delete_a_delete_marker":                      Versioning_DeleteObject_delete_a_delete_marker,


### PR DESCRIPTION
Fixes #916
Fixes #917
Fixes #931

Updates the GetObjectAttributes action to use GetObjectAttributesResponse as the root element in XML encoding.
Adds input validation for the x-amz-object-attributes header, and included x-amz-delete-marker and x-amz-version-id headers in the response.
Adds VersionId to the HeadObject response if it wasn't specified in the request.