### PR TITLE
fix: Fixes object version creatiion racing in posix

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -616,7 +616,7 @@ func TestVersioning(s *S3Conf) {
 	Versioning_WORM_obj_version_locked_with_governance_retention(s)
 	Versioning_WORM_obj_version_locked_with_compliance_retention(s)
 	// Concurrent requests
-	//Versioninig_concurrent_upload_object(s)
+	Versioning_concurrent_upload_object(s)
 }
 
 func TestVersioningDisabled(s *S3Conf) {


### PR DESCRIPTION
Fixes #841 

The implementation uses sync.Map combined with reference-counted mutexes to manage concurrent object version creation. Each time a new object version creation is triggered within the PutObject action, the mutex locks to ensure all object versions are created correctly.