### PR TITLE
fix: return better error when trying to delete non empty directory ob…

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2646,6 +2646,9 @@ func (p *Posix) DeleteObject(ctx context.Context, input *s3.DeleteObjectInput) (
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil, s3err.GetAPIError(s3err.ErrNoSuchKey)
 	}
+	if errors.Is(err, syscall.ENOTEMPTY) {
+		return nil, s3err.GetAPIError(s3err.ErrDirectoryNotEmpty)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("delete object: %w", err)
 	}

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -144,6 +144,7 @@ const (
 	ErrExistingObjectIsDirectory
 	ErrObjectParentIsFile
 	ErrDirectoryObjectContainsData
+	ErrDirectoryNotEmpty
 	ErrQuotaExceeded
 	ErrVersioningNotConfigured
 
@@ -591,6 +592,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrDirectoryObjectContainsData: {
 		Code:           "DirectoryObjectContainsData",
 		Description:    "Directory object contains data payload.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrDirectoryNotEmpty: {
+		Code:           "ErrDirectoryNotEmpty",
+		Description:    "Directory object not empty.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrQuotaExceeded: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -519,6 +519,7 @@ func TestPosix(s *S3Conf) {
 	PutObject_name_too_long(s)
 	HeadObject_name_too_long(s)
 	DeleteObject_name_too_long(s)
+	DeleteObject_directory_not_empty(s)
 	// posix specific versioning tests
 	if !s.versioningEnabled {
 		TestVersioningDisabled(s)
@@ -770,6 +771,7 @@ func GetIntTests() IntTests {
 		"ListObjectVersions_VD_success":                                       ListObjectVersions_VD_success,
 		"DeleteObject_non_existing_object":                                    DeleteObject_non_existing_object,
 		"DeleteObject_directory_object_noslash":                               DeleteObject_directory_object_noslash,
+		"DeleteObject_directory_not_empty":                                    DeleteObject_directory_not_empty,
 		"DeleteObject_name_too_long":                                          DeleteObject_name_too_long,
 		"DeleteObject_non_existing_dir_object":                                DeleteObject_non_existing_dir_object,
 		"DeleteObject_success":                                                DeleteObject_success,


### PR DESCRIPTION
…ject

The posix backend will return ENOTEMPTY when trying to delete a directory that is not empty. This normally would run successfully on object systems. So we need to create another non-standard error for this case. We mainly just don't want to return InternalError for this case.

Fixes #946