### PR TITLE
fix: listobjects internal server error for prefix not directory

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -21,6 +21,7 @@ import (
 	"io/fs"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/versity/versitygw/s3response"
@@ -231,7 +232,7 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 	})
 	if err != nil {
 		// suppress file not found caused by user's prefix
-		if errors.Is(err, fs.ErrNotExist) {
+		if errors.Is(err, fs.ErrNotExist) || errors.Is(err, syscall.ENOTDIR) {
 			return WalkResults{}, nil
 		}
 		return WalkResults{}, err

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -201,6 +201,7 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_truncated_common_prefixes(s)
 	ListObjectsV2_all_objs_max_keys(s)
 	ListObjectsV2_list_all_objs(s)
+	ListObjectsV2_invalid_parent_prefix(s)
 }
 
 // VD stands for Versioning Disabled
@@ -768,6 +769,7 @@ func GetIntTests() IntTests {
 		"ListObjectsV2_truncated_common_prefixes":                             ListObjectsV2_truncated_common_prefixes,
 		"ListObjectsV2_all_objs_max_keys":                                     ListObjectsV2_all_objs_max_keys,
 		"ListObjectsV2_list_all_objs":                                         ListObjectsV2_list_all_objs,
+		"ListObjectsV2_invalid_parent_prefix":                                 ListObjectsV2_invalid_parent_prefix,
 		"ListObjectVersions_VD_success":                                       ListObjectVersions_VD_success,
 		"DeleteObject_non_existing_object":                                    DeleteObject_non_existing_object,
 		"DeleteObject_directory_object_noslash":                               DeleteObject_directory_object_noslash,


### PR DESCRIPTION
We need to treat a prefix that has a parent component as a file instead of a directory in the filesystem as a non existing prefix instead of an internal server error. This error was caused because we were not handling ENOTDIR within the fs walk.

Fixes #949