### PR TITLE
Uncomments WORM integration tests

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -447,8 +447,8 @@ func TestGetObjectLegalHold(s *S3Conf) {
 func TestWORMProtection(s *S3Conf) {
 	WORMProtection_bucket_object_lock_configuration_compliance_mode(s)
 	WORMProtection_bucket_object_lock_configuration_governance_mode(s)
-	// WORMProtection_bucket_object_lock_governance_bypass_delete(s)
-	// WORMProtection_bucket_object_lock_governance_bypass_delete_multiple
+	WORMProtection_bucket_object_lock_governance_bypass_delete(s)
+	WORMProtection_bucket_object_lock_governance_bypass_delete_multiple(s)
 	WORMProtection_object_lock_retention_compliance_locked(s)
 	WORMProtection_object_lock_retention_governance_locked(s)
 	WORMProtection_object_lock_retention_governance_bypass_overwrite(s)


### PR DESCRIPTION
Uncommentes two WORM protection integration tests that were accidentally commented out.

1. WORMProtection_bucket_object_lock_governance_bypass_delete.
2. WORMProtection_bucket_object_lock_governance_bypass_delete_multiple.