### PR TITLE
fix: Return XAdminMethodNotSupported error for single IAM methods.

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -262,8 +262,8 @@ func CheckIfAccountsExist(accs []string, iam IAMService) ([]string, error) {
 				result = append(result, acc)
 				continue
 			}
-			if err == ErrNotSupported {
-				return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
+			if errors.Is(err, s3err.GetAPIError(s3err.ErrAdminMethodNotSupported)) {
+				return nil, err
 			}
 			return nil, fmt.Errorf("check user account: %w", err)
 		}

--- a/auth/iam_single.go
+++ b/auth/iam_single.go
@@ -15,7 +15,7 @@
 package auth
 
 import (
-	"errors"
+	"github.com/versity/versitygw/s3err"
 )
 
 // IAMServiceSingle manages the single tenant (root-only) IAM service
@@ -23,31 +23,29 @@ type IAMServiceSingle struct{}
 
 var _ IAMService = &IAMServiceSingle{}
 
-var ErrNotSupported = errors.New("method is not supported")
-
 // CreateAccount not valid in single tenant mode
 func (IAMServiceSingle) CreateAccount(account Account) error {
-	return ErrNotSupported
+	return s3err.GetAPIError(s3err.ErrAdminMethodNotSupported)
 }
 
 // GetUserAccount no accounts in single tenant mode
 func (IAMServiceSingle) GetUserAccount(access string) (Account, error) {
-	return Account{}, ErrNoSuchUser
+	return Account{}, s3err.GetAPIError(s3err.ErrAdminMethodNotSupported)
 }
 
 // UpdateUserAccount no accounts in single tenant mode
 func (IAMServiceSingle) UpdateUserAccount(access string, props MutableProps) error {
-	return ErrNotSupported
+	return s3err.GetAPIError(s3err.ErrAdminMethodNotSupported)
 }
 
 // DeleteUserAccount no accounts in single tenant mode
 func (IAMServiceSingle) DeleteUserAccount(access string) error {
-	return ErrNotSupported
+	return s3err.GetAPIError(s3err.ErrAdminMethodNotSupported)
 }
 
 // ListUserAccounts no accounts in single tenant mode
 func (IAMServiceSingle) ListUserAccounts() ([]Account, error) {
-	return []Account{}, nil
+	return []Account{}, s3err.GetAPIError(s3err.ErrAdminMethodNotSupported)
 }
 
 // Shutdown graceful termination of service

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -154,6 +154,7 @@ const (
 	ErrAdminUserExists
 	ErrAdminInvalidUserRole
 	ErrAdminMissingUserAcess
+	ErrAdminMethodNotSupported
 )
 
 var errorCodeResponse = map[ErrorCode]APIError{
@@ -635,6 +636,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "XAdminInvalidArgument",
 		Description:    "User access key ID is missing.",
 		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrAdminMethodNotSupported: {
+		Code:           "XAdminMethodNotSupported",
+		Description:    "The method is not supported in single root user mode.",
+		HTTPStatusCode: http.StatusNotImplemented,
 	},
 }
 


### PR DESCRIPTION
In single `IAM` user mode, all IAM methods return a 'not supported' error. 
This update introduces an admin-specific error for this scenario.