### PR TITLE
fix: Adds a check to ensure that the CompleteMultipartUpload parts ar…

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -3189,6 +3189,20 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 				})
 		}
 
+		if len(data.Parts) == 0 {
+			if c.debug {
+				log.Println("empty parts provided for complete multipart upload")
+			}
+			return SendXMLResponse(ctx, nil,
+				s3err.GetAPIError(s3err.ErrEmptyParts),
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionCompleteMultipartUpload,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
 		err = auth.VerifyAccess(ctx.Context(), c.be,
 			auth.AccessOptions{
 				Readonly:      c.readonly,

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -1713,6 +1713,19 @@ func TestS3ApiController_CreateActions(t *testing.T) {
 		</SelectObjectContentRequest>
 	`
 
+	completMpBody := `
+		<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+			<Part>
+				<ETag>etag</ETag>
+				<PartNumber>1</PartNumber>
+			</Part>
+		</CompleteMultipartUpload>
+	`
+
+	completMpEmptyBody := `
+		<CompleteMultipartUpload xmlns="http://s3.amazonaws.com/doc/2006-03-01/"></CompleteMultipartUpload>
+	`
+
 	app.Use(func(ctx *fiber.Ctx) error {
 		ctx.Locals("account", auth.Account{Access: "valid access"})
 		ctx.Locals("isRoot", true)
@@ -1766,10 +1779,19 @@ func TestS3ApiController_CreateActions(t *testing.T) {
 			statusCode: 400,
 		},
 		{
+			name: "Complete-multipart-upload-empty-parts",
+			app:  app,
+			args: args{
+				req: httptest.NewRequest(http.MethodPost, "/my-bucket/my-key?uploadId=23423", strings.NewReader(completMpEmptyBody)),
+			},
+			wantErr:    false,
+			statusCode: 400,
+		},
+		{
 			name: "Complete-multipart-upload-success",
 			app:  app,
 			args: args{
-				req: httptest.NewRequest(http.MethodPost, "/my-bucket/my-key?uploadId=23423", strings.NewReader(`<root><key>body</key></root>`)),
+				req: httptest.NewRequest(http.MethodPost, "/my-bucket/my-key?uploadId=23423", strings.NewReader(completMpBody)),
 			},
 			wantErr:    false,
 			statusCode: 200,

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -72,6 +72,7 @@ const (
 	ErrInvalidPartNumberMarker
 	ErrInvalidObjectAttributes
 	ErrInvalidPart
+	ErrEmptyParts
 	ErrInvalidPartNumber
 	ErrInternalError
 	ErrInvalidCopyDest
@@ -251,6 +252,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidPart: {
 		Code:           "InvalidPart",
 		Description:    "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrEmptyParts: {
+		Code:           "InvalidRequest",
+		Description:    "You must specify at least one part",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidPartNumber: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -320,6 +320,7 @@ func TestCompleteMultipartUpload(s *S3Conf) {
 	CompletedMultipartUpload_non_existing_bucket(s)
 	CompleteMultipartUpload_invalid_part_number(s)
 	CompleteMultipartUpload_invalid_ETag(s)
+	CompleteMultipartUpload_empty_parts(s)
 	CompleteMultipartUpload_success(s)
 	if !s.azureTests {
 		CompleteMultipartUpload_racey_success(s)
@@ -849,6 +850,7 @@ func GetIntTests() IntTests {
 		"CompletedMultipartUpload_non_existing_bucket":                        CompletedMultipartUpload_non_existing_bucket,
 		"CompleteMultipartUpload_invalid_part_number":                         CompleteMultipartUpload_invalid_part_number,
 		"CompleteMultipartUpload_invalid_ETag":                                CompleteMultipartUpload_invalid_ETag,
+		"CompleteMultipartUpload_empty_parts":                                 CompleteMultipartUpload_empty_parts,
 		"CompleteMultipartUpload_success":                                     CompleteMultipartUpload_success,
 		"CompleteMultipartUpload_racey_success":                               CompleteMultipartUpload_racey_success,
 		"PutBucketAcl_non_existing_bucket":                                    PutBucketAcl_non_existing_bucket,


### PR DESCRIPTION
Fixes #964 

`CompleteMultipartUpload` expects at least one part specified in the request body. 
The implementation adds a check to ensure that the parts list is not empty.