### PR TITLE
Implements object integrity checksums

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -53,8 +53,8 @@ type Backend interface {
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput) error
 	ListMultipartUploads(context.Context, *s3.ListMultipartUploadsInput) (s3response.ListMultipartUploadsResult, error)
 	ListParts(context.Context, *s3.ListPartsInput) (s3response.ListPartsResult, error)
-	UploadPart(context.Context, *s3.UploadPartInput) (etag string, err error)
-	UploadPartCopy(context.Context, *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error)
+	UploadPart(context.Context, *s3.UploadPartInput) (*s3.UploadPartOutput, error)
+	UploadPartCopy(context.Context, *s3.UploadPartCopyInput) (s3response.CopyPartResult, error)
 
 	// standard object operations
 	PutObject(context.Context, *s3.PutObjectInput) (s3response.PutObjectOutput, error)
@@ -166,11 +166,11 @@ func (BackendUnsupported) ListMultipartUploads(context.Context, *s3.ListMultipar
 func (BackendUnsupported) ListParts(context.Context, *s3.ListPartsInput) (s3response.ListPartsResult, error) {
 	return s3response.ListPartsResult{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
-func (BackendUnsupported) UploadPart(context.Context, *s3.UploadPartInput) (etag string, err error) {
-	return "", s3err.GetAPIError(s3err.ErrNotImplemented)
+func (BackendUnsupported) UploadPart(context.Context, *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+	return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
-func (BackendUnsupported) UploadPartCopy(context.Context, *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error) {
-	return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNotImplemented)
+func (BackendUnsupported) UploadPartCopy(context.Context, *s3.UploadPartCopyInput) (s3response.CopyPartResult, error) {
+	return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 
 func (BackendUnsupported) PutObject(context.Context, *s3.PutObjectInput) (s3response.PutObjectOutput, error) {

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"path/filepath"
 	"sort"
@@ -39,6 +40,7 @@ import (
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/backend"
 	"github.com/versity/versitygw/backend/meta"
+	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3err"
 	"github.com/versity/versitygw/s3response"
 )
@@ -87,6 +89,7 @@ const (
 	aclkey              = "acl"
 	ownershipkey        = "ownership"
 	etagkey             = "etag"
+	checksumsKey        = "checksums"
 	policykey           = "policy"
 	bucketLockKey       = "bucket-lock"
 	objectRetentionKey  = "object-retention"
@@ -1308,6 +1311,21 @@ func (p *Posix) CreateMultipartUpload(ctx context.Context, mpu *s3.CreateMultipa
 		}
 	}
 
+	// Set object checksum algorithm
+	if mpu.ChecksumAlgorithm != "" {
+		err := p.storeChecksums(nil, bucket, filepath.Join(objdir, uploadID), s3response.Checksum{
+			Algorithms: []types.ChecksumAlgorithm{
+				mpu.ChecksumAlgorithm,
+			},
+		})
+		if err != nil {
+			// cleanup object if returning error
+			os.RemoveAll(filepath.Join(tmppath, uploadID))
+			os.Remove(tmppath)
+			return s3response.InitiateMultipartUploadResult{}, fmt.Errorf("store mp checksum algorithm: %w", err)
+		}
+	}
+
 	return s3response.InitiateMultipartUploadResult{
 		Bucket:   bucket,
 		Key:      object,
@@ -1373,6 +1391,28 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 
 	objdir := filepath.Join(metaTmpMultipartDir, fmt.Sprintf("%x", sum))
 
+	checksums, err := p.retreiveChecksums(nil, bucket, filepath.Join(objdir, uploadID))
+	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+		return nil, fmt.Errorf("get mp checksums: %w", err)
+	}
+
+	// if len(checksums.Algorithms) != 0 {
+	// 	algorithm := checksums.Algorithms[0]
+
+	// 	if input.ChecksumCRC32 != nil && algorithm != types.ChecksumAlgorithmCrc32 {
+	// 		return nil, s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-crc32")
+	// 	}
+	// 	if input.ChecksumCRC32C != nil && algorithm != types.ChecksumAlgorithmCrc32c {
+	// 		return nil, s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-crc32c")
+	// 	}
+	// 	if input.ChecksumSHA1 != nil && algorithm != types.ChecksumAlgorithmSha1 {
+	// 		return nil, s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-sha1")
+	// 	}
+	// 	if input.ChecksumSHA256 != nil && algorithm != types.ChecksumAlgorithmSha256 {
+	// 		return nil, s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-sha256")
+	// 	}
+	// }
+
 	// check all parts ok
 	last := len(parts) - 1
 	var totalsize int64
@@ -1403,6 +1443,25 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 		if parts[i].ETag == nil || etag != *parts[i].ETag {
 			return nil, s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
+
+		partChecksum, err := p.retreiveChecksums(nil, bucket, partObjPath)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			return nil, fmt.Errorf("get part checksum: %w", err)
+		}
+
+		// If checksum has been provided on mp initalization
+		err = validatePartChecksum(partChecksum, part)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var hashRdr *utils.HashReader
+	if len(checksums.Algorithms) != 0 {
+		hashRdr, err = utils.NewHashReader(nil, "", utils.HashType(strings.ToLower(string(checksums.Algorithms[0]))))
+		if err != nil {
+			return nil, fmt.Errorf("initialize hash reader: %w", err)
+		}
 	}
 
 	f, err := p.openTmpFile(filepath.Join(bucket, metaTmpDir), bucket, object,
@@ -1426,7 +1485,14 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 		if err != nil {
 			return nil, fmt.Errorf("open part %v: %v", *part.PartNumber, err)
 		}
-		_, err = io.Copy(f.File(), pf)
+
+		var rdr io.Reader = pf
+		if hashRdr != nil {
+			hashRdr.SetReader(rdr)
+			rdr = hashRdr
+		}
+
+		_, err = io.Copy(f.File(), rdr)
 		pf.Close()
 		if err != nil {
 			if errors.Is(err, syscall.EDQUOT) {
@@ -1524,6 +1590,53 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 		}
 	}
 
+	var crc32 *string
+	var crc32c *string
+	var sha1 *string
+	var sha256 *string
+
+	// set checksum
+	if hashRdr != nil {
+		algo := checksums.Algorithms[0]
+		checksum := s3response.Checksum{
+			Algorithms: []types.ChecksumAlgorithm{
+				algo,
+			},
+		}
+
+		sum := hashRdr.Sum()
+		switch hashRdr.Type() {
+		case utils.HashTypeCRC32:
+			if input.ChecksumCRC32 != nil && *input.ChecksumCRC32 != sum {
+				return nil, s3err.GetChecksumBadDigestErr(algo)
+			}
+			checksum.CRC32 = &sum
+			crc32 = &sum
+		case utils.HashTypeCRC32C:
+			if input.ChecksumCRC32C != nil && *input.ChecksumCRC32C != sum {
+				return nil, s3err.GetChecksumBadDigestErr(algo)
+			}
+			checksum.CRC32C = &sum
+			crc32c = &sum
+		case utils.HashTypeSha1:
+			if input.ChecksumSHA1 != nil && *input.ChecksumSHA1 != sum {
+				return nil, s3err.GetChecksumBadDigestErr(algo)
+			}
+			checksum.SHA1 = &sum
+			sha1 = &sum
+		case utils.HashTypeSha256:
+			if input.ChecksumSHA256 != nil && *input.ChecksumSHA256 != sum {
+				return nil, s3err.GetChecksumBadDigestErr(algo)
+			}
+			checksum.SHA256 = &sum
+			sha256 = &sum
+		}
+		err := p.storeChecksums(f.File(), bucket, object, checksum)
+		if err != nil {
+			return nil, fmt.Errorf("store object checksum: %w", err)
+		}
+	}
+
 	// load and set retention
 	ret, err := p.meta.RetrieveAttribute(nil, bucket, upiddir, objectRetentionKey)
 	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
@@ -1556,11 +1669,128 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 	os.Remove(filepath.Join(bucket, objdir))
 
 	return &s3.CompleteMultipartUploadOutput{
-		Bucket:    &bucket,
-		ETag:      &s3MD5,
-		Key:       &object,
-		VersionId: &versionID,
+		Bucket:         &bucket,
+		ETag:           &s3MD5,
+		Key:            &object,
+		VersionId:      &versionID,
+		ChecksumCRC32:  crc32,
+		ChecksumCRC32C: crc32c,
+		ChecksumSHA1:   sha1,
+		ChecksumSHA256: sha256,
 	}, nil
+}
+
+func validatePartChecksum(checksum s3response.Checksum, part types.CompletedPart) error {
+	n := numberOfChecksums(part)
+
+	if len(checksum.Algorithms) != 0 {
+		algo := checksum.Algorithms[0]
+		if n == 0 {
+			return s3err.APIError{
+				Code:           "InvalidRequest",
+				Description:    fmt.Sprintf("The upload was created using a %v checksum. The complete request must include the checksum for each part. It was missing for part %v in the request.", strings.ToLower(string(algo)), *part.PartNumber),
+				HTTPStatusCode: http.StatusBadRequest,
+			}
+		}
+		if n > 1 {
+			return s3err.GetAPIError(s3err.ErrInvalidChecksumPart)
+		}
+
+		if part.ChecksumCRC32 != nil {
+			if ok := utils.IsValidChecksum(*part.ChecksumCRC32, types.ChecksumAlgorithmCrc32); !ok {
+				return s3err.GetAPIError(s3err.ErrInvalidChecksumPart)
+			}
+
+			if *part.ChecksumCRC32 != getString(checksum.CRC32) {
+				if algo == types.ChecksumAlgorithmCrc32 {
+					return s3err.GetAPIError(s3err.ErrInvalidPart)
+				} else {
+					return s3err.APIError{
+						Code:           "BadDigest",
+						Description:    fmt.Sprintf("The crc32 you specified for part %v did not match what we received.", *part.PartNumber),
+						HTTPStatusCode: http.StatusBadRequest,
+					}
+				}
+			}
+		}
+		if part.ChecksumCRC32C != nil {
+			if ok := utils.IsValidChecksum(*part.ChecksumCRC32C, types.ChecksumAlgorithmCrc32c); !ok {
+				return s3err.GetAPIError(s3err.ErrInvalidChecksumPart)
+			}
+
+			if *part.ChecksumCRC32C != getString(checksum.CRC32C) {
+				if algo == types.ChecksumAlgorithmCrc32c {
+					return s3err.GetAPIError(s3err.ErrInvalidPart)
+				} else {
+					return s3err.APIError{
+						Code:           "BadDigest",
+						Description:    fmt.Sprintf("The crc32c you specified for part %v did not match what we received.", *part.PartNumber),
+						HTTPStatusCode: http.StatusBadRequest,
+					}
+				}
+			}
+		}
+		if part.ChecksumSHA1 != nil {
+			if ok := utils.IsValidChecksum(*part.ChecksumSHA1, types.ChecksumAlgorithmSha1); !ok {
+				return s3err.GetAPIError(s3err.ErrInvalidChecksumPart)
+			}
+
+			if *part.ChecksumSHA1 != getString(checksum.SHA1) {
+				if algo == types.ChecksumAlgorithmSha1 {
+					return s3err.GetAPIError(s3err.ErrInvalidPart)
+				} else {
+					return s3err.APIError{
+						Code:           "BadDigest",
+						Description:    fmt.Sprintf("The sha1 you specified for part %v did not match what we received.", *part.PartNumber),
+						HTTPStatusCode: http.StatusBadRequest,
+					}
+				}
+			}
+		}
+		if part.ChecksumSHA256 != nil {
+			if ok := utils.IsValidChecksum(*part.ChecksumSHA256, types.ChecksumAlgorithmSha256); !ok {
+				return s3err.GetAPIError(s3err.ErrInvalidChecksumPart)
+			}
+
+			if *part.ChecksumSHA256 != getString(checksum.SHA256) {
+				if algo == types.ChecksumAlgorithmSha256 {
+					return s3err.GetAPIError(s3err.ErrInvalidPart)
+				} else {
+					return s3err.APIError{
+						Code:           "BadDigest",
+						Description:    fmt.Sprintf("The sha256 you specified for part %v did not match what we received.", *part.PartNumber),
+						HTTPStatusCode: http.StatusBadRequest,
+					}
+				}
+			}
+		}
+
+		return nil
+	}
+
+	if n != 0 {
+		return s3err.GetAPIError(s3err.ErrInvalidPart)
+	}
+
+	return nil
+}
+
+func numberOfChecksums(part types.CompletedPart) int {
+	counter := 0
+	if getString(part.ChecksumCRC32) != "" {
+		counter++
+	}
+	if getString(part.ChecksumCRC32C) != "" {
+		counter++
+	}
+	if getString(part.ChecksumSHA1) != "" {
+		counter++
+	}
+	if getString(part.ChecksumSHA256) != "" {
+		counter++
+	}
+
+	return counter
 }
 
 func (p *Posix) checkUploadIDExists(bucket, object, uploadID string) ([32]byte, error) {
@@ -1752,11 +1982,23 @@ func (p *Posix) ListMultipartUploads(_ context.Context, mpu *s3.ListMultipartUpl
 			if keyMarkerInd == -1 && objectName == keyMarker {
 				keyMarkerInd = len(uploads)
 			}
+
+			checksum, err := p.retreiveChecksums(nil, bucket, filepath.Join(metaTmpMultipartDir, obj.Name(), uploadID))
+			if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+				return lmu, fmt.Errorf("get mp checksum: %w", err)
+			}
+
+			var algo types.ChecksumAlgorithm
+			if len(checksum.Algorithms) != 0 {
+				algo = checksum.Algorithms[0]
+			}
+
 			uploads = append(uploads, s3response.Upload{
-				Key:          objectName,
-				UploadID:     uploadID,
-				StorageClass: types.StorageClassStandard,
-				Initiated:    fi.ModTime(),
+				Key:               objectName,
+				UploadID:          uploadID,
+				StorageClass:      types.StorageClassStandard,
+				Initiated:         fi.ModTime(),
+				ChecksumAlgorithm: algo,
 			})
 		}
 	}
@@ -1875,6 +2117,16 @@ func (p *Posix) ListParts(_ context.Context, input *s3.ListPartsInput) (s3respon
 		return lpr, fmt.Errorf("readdir upload: %w", err)
 	}
 
+	checksum, err := p.retreiveChecksums(nil, tmpdir, uploadID)
+	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+		return lpr, fmt.Errorf("get mp checksum: %w", err)
+	}
+
+	var algo types.ChecksumAlgorithm
+	if len(checksum.Algorithms) != 0 {
+		algo = checksum.Algorithms[0]
+	}
+
 	var parts []s3response.Part
 	for _, e := range ents {
 		pn, err := strconv.Atoi(e.Name())
@@ -1893,16 +2145,25 @@ func (p *Posix) ListParts(_ context.Context, input *s3.ListPartsInput) (s3respon
 			etag = ""
 		}
 
+		checksum, err := p.retreiveChecksums(nil, bucket, partPath)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			continue
+		}
+
 		fi, err := os.Lstat(filepath.Join(bucket, partPath))
 		if err != nil {
 			continue
 		}
 
 		parts = append(parts, s3response.Part{
-			PartNumber:   pn,
-			ETag:         etag,
-			LastModified: fi.ModTime(),
-			Size:         fi.Size(),
+			PartNumber:     pn,
+			ETag:           etag,
+			LastModified:   fi.ModTime(),
+			Size:           fi.Size(),
+			ChecksumCRC32:  checksum.CRC32,
+			ChecksumCRC32C: checksum.CRC32C,
+			ChecksumSHA1:   checksum.SHA1,
+			ChecksumSHA256: checksum.SHA256,
 		})
 	}
 
@@ -1934,20 +2195,21 @@ func (p *Posix) ListParts(_ context.Context, input *s3.ListPartsInput) (s3respon
 		Parts:                parts,
 		UploadID:             uploadID,
 		StorageClass:         types.StorageClassStandard,
+		ChecksumAlgorithm:    algo,
 	}, nil
 }
 
-func (p *Posix) UploadPart(ctx context.Context, input *s3.UploadPartInput) (string, error) {
+func (p *Posix) UploadPart(ctx context.Context, input *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
 	acct, ok := ctx.Value("account").(auth.Account)
 	if !ok {
 		acct = auth.Account{}
 	}
 
 	if input.Bucket == nil {
-		return "", s3err.GetAPIError(s3err.ErrInvalidBucketName)
+		return nil, s3err.GetAPIError(s3err.ErrInvalidBucketName)
 	}
 	if input.Key == nil {
-		return "", s3err.GetAPIError(s3err.ErrNoSuchKey)
+		return nil, s3err.GetAPIError(s3err.ErrNoSuchKey)
 	}
 
 	bucket := *input.Bucket
@@ -1962,79 +2224,185 @@ func (p *Posix) UploadPart(ctx context.Context, input *s3.UploadPartInput) (stri
 
 	_, err := os.Stat(bucket)
 	if errors.Is(err, fs.ErrNotExist) {
-		return "", s3err.GetAPIError(s3err.ErrNoSuchBucket)
+		return nil, s3err.GetAPIError(s3err.ErrNoSuchBucket)
 	}
 	if err != nil {
-		return "", fmt.Errorf("stat bucket: %w", err)
+		return nil, fmt.Errorf("stat bucket: %w", err)
 	}
 
 	sum := sha256.Sum256([]byte(object))
 	objdir := filepath.Join(metaTmpMultipartDir, fmt.Sprintf("%x", sum))
+	mpPath := filepath.Join(objdir, uploadID)
 
-	_, err = os.Stat(filepath.Join(bucket, objdir, uploadID))
+	_, err = os.Stat(filepath.Join(bucket, mpPath))
 	if errors.Is(err, fs.ErrNotExist) {
-		return "", s3err.GetAPIError(s3err.ErrNoSuchUpload)
+		return nil, s3err.GetAPIError(s3err.ErrNoSuchUpload)
 	}
 	if err != nil {
-		return "", fmt.Errorf("stat uploadid: %w", err)
+		return nil, fmt.Errorf("stat uploadid: %w", err)
 	}
 
-	partPath := filepath.Join(objdir, uploadID, fmt.Sprintf("%v", *part))
+	partPath := filepath.Join(mpPath, fmt.Sprintf("%v", *part))
 
 	f, err := p.openTmpFile(filepath.Join(bucket, objdir),
 		bucket, partPath, length, acct, doFalloc)
 	if err != nil {
 		if errors.Is(err, syscall.EDQUOT) {
-			return "", s3err.GetAPIError(s3err.ErrQuotaExceeded)
+			return nil, s3err.GetAPIError(s3err.ErrQuotaExceeded)
 		}
-		return "", fmt.Errorf("open temp file: %w", err)
+		return nil, fmt.Errorf("open temp file: %w", err)
 	}
 	defer f.cleanup()
 
 	hash := md5.New()
 	tr := io.TeeReader(r, hash)
+
+	var hashRdr *utils.HashReader
+	if input.ChecksumCRC32 != nil {
+		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumCRC32, utils.HashTypeCRC32)
+		if err != nil {
+			return nil, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		tr = hashRdr
+	}
+	if input.ChecksumCRC32C != nil {
+		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumCRC32C, utils.HashTypeCRC32C)
+		if err != nil {
+			return nil, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		tr = hashRdr
+	}
+	if input.ChecksumSHA1 != nil {
+		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumSHA1, utils.HashTypeSha1)
+		if err != nil {
+			return nil, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		tr = hashRdr
+	}
+	if input.ChecksumSHA256 != nil {
+		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumSHA256, utils.HashTypeSha256)
+		if err != nil {
+			return nil, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		tr = hashRdr
+	}
+
+	// If only the checksum algorithm is provided register
+	// a new HashReader to calculate the object checksum
+	if hashRdr == nil && input.ChecksumAlgorithm != "" {
+		hashRdr, err = utils.NewHashReader(tr, "", utils.HashType(strings.ToLower(string(input.ChecksumAlgorithm))))
+		if err != nil {
+			return nil, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		tr = hashRdr
+	}
+
+	checksums, chErr := p.retreiveChecksums(nil, bucket, mpPath)
+	if chErr != nil && !errors.Is(chErr, meta.ErrNoSuchKey) {
+		return nil, fmt.Errorf("retreive mp checksum: %w", chErr)
+	}
+
+	// If checksum isn't provided for the part,
+	// but it has been provided on mp initalization
+	if hashRdr == nil && chErr == nil && len(checksums.Algorithms) != 0 {
+		return nil, s3err.GetChecksumTypeMismatchErr(checksums.Algorithms[0], "null")
+	}
+
+	// Check if the provided checksum algorithm match
+	// the one specified on mp initialization
+	if hashRdr != nil {
+		algo := types.ChecksumAlgorithm(strings.ToUpper(string(hashRdr.Type())))
+		if chErr != nil {
+			return nil, s3err.GetChecksumTypeMismatchErr("null", algo)
+		}
+
+		if len(checksums.Algorithms) == 0 {
+			return nil, s3err.GetChecksumTypeMismatchErr("null", algo)
+		}
+
+		if checksums.Algorithms[0] != algo {
+			return nil, s3err.GetChecksumTypeMismatchErr(checksums.Algorithms[0], algo)
+		}
+	}
+
 	_, err = io.Copy(f, tr)
 	if err != nil {
 		if errors.Is(err, syscall.EDQUOT) {
-			return "", s3err.GetAPIError(s3err.ErrQuotaExceeded)
+			return nil, s3err.GetAPIError(s3err.ErrQuotaExceeded)
 		}
-		return "", fmt.Errorf("write part data: %w", err)
+		return nil, fmt.Errorf("write part data: %w", err)
 	}
 
 	dataSum := hash.Sum(nil)
 	etag := hex.EncodeToString(dataSum)
 	err = p.meta.StoreAttribute(f.File(), bucket, partPath, etagkey, []byte(etag))
 	if err != nil {
-		return "", fmt.Errorf("set etag attr: %w", err)
+		return nil, fmt.Errorf("set etag attr: %w", err)
+	}
+
+	res := &s3.UploadPartOutput{
+		ETag: &etag,
+	}
+
+	// Store the calculated checksum in the object metadata
+	if hashRdr != nil {
+		checksum := s3response.Checksum{
+			Algorithms: []types.ChecksumAlgorithm{input.ChecksumAlgorithm},
+		}
+		sum := hashRdr.Sum()
+		switch hashRdr.Type() {
+		case utils.HashTypeCRC32:
+			checksum.CRC32 = &sum
+			res.ChecksumCRC32 = &sum
+		case utils.HashTypeCRC32C:
+			checksum.CRC32C = &sum
+			res.ChecksumCRC32C = &sum
+		case utils.HashTypeSha1:
+			checksum.SHA1 = &sum
+			res.ChecksumSHA1 = &sum
+		case utils.HashTypeSha256:
+			checksum.SHA256 = &sum
+			res.ChecksumSHA256 = &sum
+		}
+
+		err := p.storeChecksums(f.File(), bucket, partPath, checksum)
+		if err != nil {
+			return nil, fmt.Errorf("store checksum: %w", err)
+		}
 	}
 
 	err = f.link()
 	if err != nil {
-		return "", fmt.Errorf("link object in namespace: %w", err)
+		return nil, fmt.Errorf("link object in namespace: %w", err)
 	}
 
-	return etag, nil
+	return res, nil
 }
 
-func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error) {
+func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput) (s3response.CopyPartResult, error) {
 	acct, ok := ctx.Value("account").(auth.Account)
 	if !ok {
 		acct = auth.Account{}
 	}
 
 	if upi.Bucket == nil {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrInvalidBucketName)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrInvalidBucketName)
 	}
 	if upi.Key == nil {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
 	}
 
 	_, err := os.Stat(*upi.Bucket)
 	if errors.Is(err, fs.ErrNotExist) {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchBucket)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchBucket)
 	}
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("stat bucket: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("stat bucket: %w", err)
 	}
 
 	sum := sha256.Sum256([]byte(*upi.Key))
@@ -2042,46 +2410,46 @@ func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput)
 
 	_, err = os.Stat(filepath.Join(*upi.Bucket, objdir, *upi.UploadId))
 	if errors.Is(err, fs.ErrNotExist) {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchUpload)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchUpload)
 	}
 	if errors.Is(err, syscall.ENAMETOOLONG) {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrKeyTooLong)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrKeyTooLong)
 	}
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("stat uploadid: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("stat uploadid: %w", err)
 	}
 
 	partPath := filepath.Join(objdir, *upi.UploadId, fmt.Sprintf("%v", *upi.PartNumber))
 
 	srcBucket, srcObject, srcVersionId, err := backend.ParseCopySource(*upi.CopySource)
 	if err != nil {
-		return s3response.CopyObjectResult{}, err
+		return s3response.CopyPartResult{}, err
 	}
 
 	_, err = os.Stat(srcBucket)
 	if errors.Is(err, fs.ErrNotExist) {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchBucket)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchBucket)
 	}
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("stat bucket: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("stat bucket: %w", err)
 	}
 
 	vStatus, err := p.getBucketVersioningStatus(ctx, srcBucket)
 	if err != nil {
-		return s3response.CopyObjectResult{}, err
+		return s3response.CopyPartResult{}, err
 	}
 	vEnabled := p.isBucketVersioningEnabled(vStatus)
 
 	if srcVersionId != "" {
 		if !p.versioningEnabled() || !vEnabled {
-			return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrInvalidVersionId)
+			return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrInvalidVersionId)
 		}
 		vId, err := p.meta.RetrieveAttribute(nil, srcBucket, srcObject, versionIdKey)
 		if errors.Is(err, fs.ErrNotExist) {
-			return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
+			return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
 		}
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
-			return s3response.CopyObjectResult{}, fmt.Errorf("get src object version id: %w", err)
+			return s3response.CopyPartResult{}, fmt.Errorf("get src object version id: %w", err)
 		}
 
 		if string(vId) != srcVersionId {
@@ -2094,20 +2462,20 @@ func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput)
 	fi, err := os.Stat(objPath)
 	if errors.Is(err, fs.ErrNotExist) {
 		if p.versioningEnabled() && vEnabled {
-			return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchVersion)
+			return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchVersion)
 		}
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
 	}
 	if errors.Is(err, syscall.ENAMETOOLONG) {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrKeyTooLong)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrKeyTooLong)
 	}
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("stat object: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("stat object: %w", err)
 	}
 
 	startOffset, length, err := backend.ParseRange(fi.Size(), *upi.CopySourceRange)
 	if err != nil {
-		return s3response.CopyObjectResult{}, err
+		return s3response.CopyPartResult{}, err
 	}
 
 	if length == -1 {
@@ -2115,25 +2483,25 @@ func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput)
 	}
 
 	if startOffset+length > fi.Size()+1 {
-		return s3response.CopyObjectResult{}, backend.CreateExceedingRangeErr(fi.Size())
+		return s3response.CopyPartResult{}, backend.CreateExceedingRangeErr(fi.Size())
 	}
 
 	f, err := p.openTmpFile(filepath.Join(*upi.Bucket, objdir),
 		*upi.Bucket, partPath, length, acct, doFalloc)
 	if err != nil {
 		if errors.Is(err, syscall.EDQUOT) {
-			return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrQuotaExceeded)
+			return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrQuotaExceeded)
 		}
-		return s3response.CopyObjectResult{}, fmt.Errorf("open temp file: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("open temp file: %w", err)
 	}
 	defer f.cleanup()
 
 	srcf, err := os.Open(objPath)
 	if errors.Is(err, fs.ErrNotExist) {
-		return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
+		return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
 	}
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("open object: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("open object: %w", err)
 	}
 	defer srcf.Close()
 
@@ -2141,35 +2509,97 @@ func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput)
 	hash := md5.New()
 	tr := io.TeeReader(rdr, hash)
 
+	mpChecksums, err := p.retreiveChecksums(nil, *upi.Bucket, filepath.Join(objdir, *upi.UploadId))
+	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+		return s3response.CopyPartResult{}, fmt.Errorf("retreive mp checksums: %w", err)
+	}
+
+	checksums, err := p.retreiveChecksums(nil, objPath, "")
+	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+		return s3response.CopyPartResult{}, fmt.Errorf("retreive object part checksums: %w", err)
+	}
+
+	var hashRdr *utils.HashReader
+	if len(mpChecksums.Algorithms) != 0 {
+		if len(checksums.Algorithms) == 0 || (mpChecksums.Algorithms[0] != checksums.Algorithms[0]) {
+			hashRdr, err = utils.NewHashReader(tr, "", utils.HashType(strings.ToLower(string(mpChecksums.Algorithms[0]))))
+			if err != nil {
+				return s3response.CopyPartResult{}, fmt.Errorf("initialize hash reader: %w", err)
+			}
+
+			tr = hashRdr
+		}
+	}
+
 	_, err = io.Copy(f, tr)
 	if err != nil {
 		if errors.Is(err, syscall.EDQUOT) {
-			return s3response.CopyObjectResult{}, s3err.GetAPIError(s3err.ErrQuotaExceeded)
+			return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrQuotaExceeded)
 		}
-		return s3response.CopyObjectResult{}, fmt.Errorf("copy part data: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("copy part data: %w", err)
+	}
+
+	if len(checksums.Algorithms) != 0 {
+		if len(mpChecksums.Algorithms) == 0 {
+			checksums = s3response.Checksum{}
+		} else {
+			if hashRdr == nil {
+				err := p.storeChecksums(f.File(), objPath, "", checksums)
+				if err != nil {
+					return s3response.CopyPartResult{}, fmt.Errorf("store part checksum: %w", err)
+				}
+			}
+		}
+	}
+	if hashRdr != nil {
+		algo := types.ChecksumAlgorithm(strings.ToUpper(string(hashRdr.Type())))
+		checksums = s3response.Checksum{
+			Algorithms: []types.ChecksumAlgorithm{algo},
+		}
+
+		sum := hashRdr.Sum()
+		switch algo {
+		case types.ChecksumAlgorithmCrc32:
+			checksums.CRC32 = &sum
+		case types.ChecksumAlgorithmCrc32c:
+			checksums.CRC32C = &sum
+		case types.ChecksumAlgorithmSha1:
+			checksums.SHA1 = &sum
+		case types.ChecksumAlgorithmSha256:
+			checksums.SHA256 = &sum
+		}
+
+		err := p.storeChecksums(f.File(), objPath, "", checksums)
+		if err != nil {
+			return s3response.CopyPartResult{}, fmt.Errorf("store part checksum: %w", err)
+		}
 	}
 
 	dataSum := hash.Sum(nil)
 	etag := hex.EncodeToString(dataSum)
 	err = p.meta.StoreAttribute(f.File(), *upi.Bucket, partPath, etagkey, []byte(etag))
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("set etag attr: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("set etag attr: %w", err)
 	}
 
 	err = f.link()
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("link object in namespace: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("link object in namespace: %w", err)
 	}
 
 	fi, err = os.Stat(filepath.Join(*upi.Bucket, partPath))
 	if err != nil {
-		return s3response.CopyObjectResult{}, fmt.Errorf("stat part path: %w", err)
+		return s3response.CopyPartResult{}, fmt.Errorf("stat part path: %w", err)
 	}
 
-	return s3response.CopyObjectResult{
-		ETag:                etag,
+	return s3response.CopyPartResult{
+		ETag:                &etag,
 		LastModified:        fi.ModTime(),
 		CopySourceVersionId: srcVersionId,
+		ChecksumCRC32:       checksums.CRC32,
+		ChecksumCRC32C:      checksums.CRC32C,
+		ChecksumSHA1:        checksums.SHA1,
+		ChecksumSHA256:      checksums.SHA256,
 	}, nil
 }
 
@@ -2307,6 +2737,52 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (s3respons
 
 	hash := md5.New()
 	rdr := io.TeeReader(po.Body, hash)
+
+	var hashRdr *utils.HashReader
+	if po.ChecksumCRC32 != nil {
+		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumCRC32, utils.HashTypeCRC32)
+		if err != nil {
+			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		rdr = hashRdr
+	}
+	if po.ChecksumCRC32C != nil {
+		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumCRC32C, utils.HashTypeCRC32C)
+		if err != nil {
+			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		rdr = hashRdr
+	}
+	if po.ChecksumSHA1 != nil {
+		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumSHA1, utils.HashTypeSha1)
+		if err != nil {
+			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		rdr = hashRdr
+	}
+	if po.ChecksumSHA256 != nil {
+		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumSHA256, utils.HashTypeSha256)
+		if err != nil {
+			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		rdr = hashRdr
+	}
+
+	// If only the checksum algorithm is provided register
+	// a new HashReader to calculate the object checksum
+	if hashRdr == nil && po.ChecksumAlgorithm != "" {
+		hashRdr, err = utils.NewHashReader(rdr, "", utils.HashType(strings.ToLower(string(po.ChecksumAlgorithm))))
+		if err != nil {
+			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+		}
+
+		rdr = hashRdr
+	}
+
 	_, err = io.Copy(f, rdr)
 	if err != nil {
 		if errors.Is(err, syscall.EDQUOT) {
@@ -2348,6 +2824,33 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (s3respons
 			fmt.Sprintf("%v.%v", metaHdr, k), []byte(v))
 		if err != nil {
 			return s3response.PutObjectOutput{}, fmt.Errorf("set user attr %q: %w", k, err)
+		}
+	}
+
+	// Store the calculated checksum in the object metadata
+	if hashRdr != nil {
+		checksum := s3response.Checksum{
+			Algorithms: []types.ChecksumAlgorithm{po.ChecksumAlgorithm},
+		}
+		sum := hashRdr.Sum()
+		switch hashRdr.Type() {
+		case utils.HashTypeCRC32:
+			checksum.CRC32 = &sum
+			po.ChecksumCRC32 = &sum
+		case utils.HashTypeCRC32C:
+			checksum.CRC32C = &sum
+			po.ChecksumCRC32C = &sum
+		case utils.HashTypeSha1:
+			checksum.SHA1 = &sum
+			po.ChecksumSHA1 = &sum
+		case utils.HashTypeSha256:
+			checksum.SHA256 = &sum
+			po.ChecksumSHA256 = &sum
+		}
+
+		err := p.storeChecksums(f.File(), *po.Bucket, *po.Key, checksum)
+		if err != nil {
+			return s3response.PutObjectOutput{}, fmt.Errorf("store checksum: %w", err)
 		}
 	}
 
@@ -2431,8 +2934,12 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (s3respons
 	}
 
 	return s3response.PutObjectOutput{
-		ETag:      etag,
-		VersionID: versionID,
+		ETag:           etag,
+		VersionID:      versionID,
+		ChecksumCRC32:  po.ChecksumCRC32,
+		ChecksumCRC32C: po.ChecksumCRC32C,
+		ChecksumSHA1:   po.ChecksumSHA1,
+		ChecksumSHA256: po.ChecksumSHA256,
 	}, nil
 }
 
@@ -2968,6 +3475,14 @@ func (p *Posix) GetObject(_ context.Context, input *s3.GetObjectInput) (*s3.GetO
 		return nil, fmt.Errorf("open object: %w", err)
 	}
 
+	var checksums s3response.Checksum
+	if input.ChecksumMode == types.ChecksumModeEnabled {
+		checksums, err = p.retreiveChecksums(f, bucket, object)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			return nil, fmt.Errorf("get object checksums: %w", err)
+		}
+	}
+
 	// using an os.File allows zero-copy sendfile via io.Copy(os.File, net.Conn)
 	var body io.ReadCloser = f
 	if startOffset != 0 || length != objSize {
@@ -2988,6 +3503,10 @@ func (p *Posix) GetObject(_ context.Context, input *s3.GetObjectInput) (*s3.GetO
 		StorageClass:    types.StorageClassStandard,
 		VersionId:       &versionId,
 		Body:            body,
+		ChecksumCRC32:   checksums.CRC32,
+		ChecksumCRC32C:  checksums.CRC32C,
+		ChecksumSHA1:    checksums.SHA1,
+		ChecksumSHA256:  checksums.SHA256,
 	}, nil
 }
 
@@ -3161,6 +3680,14 @@ func (p *Posix) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.
 		}
 	}
 
+	var checksums s3response.Checksum
+	if input.ChecksumMode == types.ChecksumModeEnabled {
+		checksums, err = p.retreiveChecksums(nil, bucket, object)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			return nil, fmt.Errorf("get object checksums: %w", err)
+		}
+	}
+
 	return &s3.HeadObjectOutput{
 		ContentLength:             &size,
 		ContentType:               &contentType,
@@ -3173,14 +3700,19 @@ func (p *Posix) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.
 		ObjectLockRetainUntilDate: objectLockRetainUntilDate,
 		StorageClass:              types.StorageClassStandard,
 		VersionId:                 &versionId,
+		ChecksumCRC32:             checksums.CRC32,
+		ChecksumCRC32C:            checksums.CRC32C,
+		ChecksumSHA1:              checksums.SHA1,
+		ChecksumSHA256:            checksums.SHA256,
 	}, nil
 }
 
 func (p *Posix) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
 	data, err := p.HeadObject(ctx, &s3.HeadObjectInput{
-		Bucket:    input.Bucket,
-		Key:       input.Key,
-		VersionId: input.VersionId,
+		Bucket:       input.Bucket,
+		Key:          input.Key,
+		VersionId:    input.VersionId,
+		ChecksumMode: types.ChecksumModeEnabled,
 	})
 	if err != nil {
 		if errors.Is(err, s3err.GetAPIError(s3err.ErrMethodNotAllowed)) && data != nil {
@@ -3200,6 +3732,12 @@ func (p *Posix) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttr
 		LastModified: data.LastModified,
 		VersionId:    data.VersionId,
 		DeleteMarker: data.DeleteMarker,
+		Checksum: &types.Checksum{
+			ChecksumCRC32:  data.ChecksumCRC32,
+			ChecksumCRC32C: data.ChecksumCRC32C,
+			ChecksumSHA1:   data.ChecksumSHA1,
+			ChecksumSHA256: data.ChecksumSHA256,
+		},
 	}, nil
 }
 
@@ -3296,6 +3834,10 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 
 	var etag string
 	var version *string
+	var crc32 *string
+	var crc32c *string
+	var sha1 *string
+	var sha256 *string
 
 	dstObjdPath := filepath.Join(dstBucket, dstObject)
 	if dstObjdPath == objPath {
@@ -3318,6 +3860,62 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 			}
 		}
 
+		checksums, err := p.retreiveChecksums(nil, dstBucket, dstObject)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			return nil, fmt.Errorf("get obj checksums: %w", err)
+		}
+
+		if input.ChecksumAlgorithm != "" {
+			var algo types.ChecksumAlgorithm
+			if len(checksums.Algorithms) != 0 {
+				algo = checksums.Algorithms[0]
+			}
+
+			// If a different checksum algorith is specified
+			// first caclculate and store the checksum
+			if algo != input.ChecksumAlgorithm {
+				f, err := os.Open(dstObjdPath)
+				if err != nil {
+					return nil, fmt.Errorf("open obj file: %w", err)
+				}
+				defer f.Close()
+
+				hashReader, err := utils.NewHashReader(f, "", utils.HashType(strings.ToLower(string(input.ChecksumAlgorithm))))
+				if err != nil {
+					return nil, fmt.Errorf("initialize hash reader: %w", err)
+				}
+
+				_, err = hashReader.Read(nil)
+				if err != nil {
+					return nil, fmt.Errorf("read err: %w", err)
+				}
+
+				checksums = s3response.Checksum{
+					Algorithms: []types.ChecksumAlgorithm{input.ChecksumAlgorithm},
+				}
+				sum := hashReader.Sum()
+				switch hashReader.Type() {
+				case utils.HashTypeCRC32:
+					checksums.CRC32 = &sum
+					crc32 = &sum
+				case utils.HashTypeCRC32C:
+					checksums.CRC32C = &sum
+					crc32c = &sum
+				case utils.HashTypeSha1:
+					checksums.SHA1 = &sum
+					sha1 = &sum
+				case utils.HashTypeSha256:
+					checksums.SHA256 = &sum
+					sha256 = &sum
+				}
+
+				err = p.storeChecksums(f, dstBucket, dstObject, checksums)
+				if err != nil {
+					return nil, fmt.Errorf("store checksum: %w", err)
+				}
+			}
+		}
+
 		b, _ := p.meta.RetrieveAttribute(nil, dstBucket, dstObject, etagkey)
 		etag = string(b)
 		vId, _ := p.meta.RetrieveAttribute(nil, dstBucket, dstObject, versionIdKey)
@@ -3327,19 +3925,40 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 		version = backend.GetPtrFromString(string(vId))
 	} else {
 		contentLength := fi.Size()
+
+		checksums, err := p.retreiveChecksums(f, srcBucket, srcObject)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			return nil, fmt.Errorf("get obj checksum: %w", err)
+		}
+
+		// If any checksum algorithm is provided, replace, otherwise
+		// use the existing one
+		if input.ChecksumAlgorithm != "" {
+			checksums.Algorithms = []types.ChecksumAlgorithm{input.ChecksumAlgorithm}
+		}
+		var chAlgorithm types.ChecksumAlgorithm
+		if len(checksums.Algorithms) != 0 {
+			chAlgorithm = checksums.Algorithms[0]
+		}
+
 		res, err := p.PutObject(ctx,
 			&s3.PutObjectInput{
-				Bucket:        &dstBucket,
-				Key:           &dstObject,
-				Body:          f,
-				ContentLength: &contentLength,
-				Metadata:      input.Metadata,
+				Bucket:            &dstBucket,
+				Key:               &dstObject,
+				Body:              f,
+				ContentLength:     &contentLength,
+				Metadata:          input.Metadata,
+				ChecksumAlgorithm: chAlgorithm,
 			})
 		if err != nil {
 			return nil, err
 		}
 		etag = res.ETag
 		version = &res.VersionID
+		crc32 = res.ChecksumCRC32
+		crc32c = res.ChecksumCRC32C
+		sha1 = res.ChecksumSHA1
+		sha256 = res.ChecksumSHA256
 	}
 
 	fi, err = os.Stat(dstObjdPath)
@@ -3349,8 +3968,12 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 
 	return &s3.CopyObjectOutput{
 		CopyObjectResult: &types.CopyObjectResult{
-			ETag:         &etag,
-			LastModified: backend.GetTimePtr(fi.ModTime()),
+			ETag:           &etag,
+			LastModified:   backend.GetTimePtr(fi.ModTime()),
+			ChecksumCRC32:  crc32,
+			ChecksumCRC32C: crc32c,
+			ChecksumSHA1:   sha1,
+			ChecksumSHA256: sha256,
 		},
 		VersionId:           version,
 		CopySourceVersionId: &srcVersionId,
@@ -3447,6 +4070,12 @@ func (p *Posix) fileToObj(bucket string) backend.GetObjFunc {
 			return s3response.Object{}, backend.ErrSkipObj
 		}
 
+		// Retreive the object checksum algorithm
+		checksums, err := p.retreiveChecksums(nil, bucket, path)
+		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
+			return s3response.Object{}, backend.ErrSkipObj
+		}
+
 		// file object, get object info and fill out object data
 		etagBytes, err := p.meta.RetrieveAttribute(nil, bucket, path, etagkey)
 		if errors.Is(err, fs.ErrNotExist) {
@@ -3472,11 +4101,12 @@ func (p *Posix) fileToObj(bucket string) backend.GetObjFunc {
 		mtime := fi.ModTime()
 
 		return s3response.Object{
-			ETag:         &etag,
-			Key:          &path,
-			LastModified: &mtime,
-			Size:         &size,
-			StorageClass: types.ObjectStorageClassStandard,
+			ETag:              &etag,
+			Key:               &path,
+			LastModified:      &mtime,
+			Size:              &size,
+			StorageClass:      types.ObjectStorageClassStandard,
+			ChecksumAlgorithm: checksums.Algorithms,
 		}, nil
 	}
 }
@@ -4105,6 +4735,25 @@ func (p *Posix) ListBucketsAndOwners(ctx context.Context) (buckets []s3response.
 	})
 
 	return buckets, nil
+}
+
+func (p *Posix) storeChecksums(f *os.File, bucket, object string, chs s3response.Checksum) error {
+	checksums, err := json.Marshal(chs)
+	if err != nil {
+		return fmt.Errorf("parse checksum: %w", err)
+	}
+
+	return p.meta.StoreAttribute(f, bucket, object, checksumsKey, checksums)
+}
+
+func (p *Posix) retreiveChecksums(f *os.File, bucket, object string) (checksums s3response.Checksum, err error) {
+	checksumsAtr, err := p.meta.RetrieveAttribute(f, bucket, object, checksumsKey)
+	if err != nil {
+		return checksums, err
+	}
+
+	err = json.Unmarshal(checksumsAtr, &checksums)
+	return checksums, err
 }
 
 func getString(str *string) string {

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1405,7 +1405,7 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 
 	objdir := filepath.Join(metaTmpMultipartDir, fmt.Sprintf("%x", sum))
 
-	checksums, err := p.retreiveChecksums(nil, bucket, filepath.Join(objdir, uploadID))
+	checksums, err := p.retrieveChecksums(nil, bucket, filepath.Join(objdir, uploadID))
 	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 		return nil, fmt.Errorf("get mp checksums: %w", err)
 	}
@@ -1466,7 +1466,7 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 			return nil, s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
 
-		partChecksum, err := p.retreiveChecksums(nil, bucket, partObjPath)
+		partChecksum, err := p.retrieveChecksums(nil, bucket, partObjPath)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			return nil, fmt.Errorf("get part checksum: %w", err)
 		}
@@ -1992,7 +1992,7 @@ func (p *Posix) ListMultipartUploads(_ context.Context, mpu *s3.ListMultipartUpl
 				keyMarkerInd = len(uploads)
 			}
 
-			checksum, err := p.retreiveChecksums(nil, bucket, filepath.Join(metaTmpMultipartDir, obj.Name(), uploadID))
+			checksum, err := p.retrieveChecksums(nil, bucket, filepath.Join(metaTmpMultipartDir, obj.Name(), uploadID))
 			if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 				return lmu, fmt.Errorf("get mp checksum: %w", err)
 			}
@@ -2122,7 +2122,7 @@ func (p *Posix) ListParts(_ context.Context, input *s3.ListPartsInput) (s3respon
 		return lpr, fmt.Errorf("readdir upload: %w", err)
 	}
 
-	checksum, err := p.retreiveChecksums(nil, tmpdir, uploadID)
+	checksum, err := p.retrieveChecksums(nil, tmpdir, uploadID)
 	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 		return lpr, fmt.Errorf("get mp checksum: %w", err)
 	}
@@ -2145,7 +2145,7 @@ func (p *Posix) ListParts(_ context.Context, input *s3.ListPartsInput) (s3respon
 			etag = ""
 		}
 
-		checksum, err := p.retreiveChecksums(nil, bucket, partPath)
+		checksum, err := p.retrieveChecksums(nil, bucket, partPath)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			continue
 		}
@@ -2199,6 +2199,11 @@ func (p *Posix) ListParts(_ context.Context, input *s3.ListPartsInput) (s3respon
 		ChecksumAlgorithm:    checksum.Algorithm,
 		ChecksumType:         checksum.Type,
 	}, nil
+}
+
+type hashConfig struct {
+	value    *string
+	hashType utils.HashType
 }
 
 func (p *Posix) UploadPart(ctx context.Context, input *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
@@ -2259,46 +2264,24 @@ func (p *Posix) UploadPart(ctx context.Context, input *s3.UploadPartInput) (*s3.
 	hash := md5.New()
 	tr := io.TeeReader(r, hash)
 
+	hashConfigs := []hashConfig{
+		{input.ChecksumCRC32, utils.HashTypeCRC32},
+		{input.ChecksumCRC32C, utils.HashTypeCRC32C},
+		{input.ChecksumSHA1, utils.HashTypeSha1},
+		{input.ChecksumSHA256, utils.HashTypeSha256},
+		{input.ChecksumCRC64NVME, utils.HashTypeCRC64NVME},
+	}
+
 	var hashRdr *utils.HashReader
-	if input.ChecksumCRC32 != nil {
-		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumCRC32, utils.HashTypeCRC32)
-		if err != nil {
-			return nil, fmt.Errorf("initialize hash reader: %w", err)
-		}
+	for _, config := range hashConfigs {
+		if config.value != nil {
+			hashRdr, err = utils.NewHashReader(tr, *config.value, config.hashType)
+			if err != nil {
+				return nil, fmt.Errorf("initialize hash reader: %w", err)
+			}
 
-		tr = hashRdr
-	}
-	if input.ChecksumCRC32C != nil {
-		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumCRC32C, utils.HashTypeCRC32C)
-		if err != nil {
-			return nil, fmt.Errorf("initialize hash reader: %w", err)
+			tr = hashRdr
 		}
-
-		tr = hashRdr
-	}
-	if input.ChecksumSHA1 != nil {
-		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumSHA1, utils.HashTypeSha1)
-		if err != nil {
-			return nil, fmt.Errorf("initialize hash reader: %w", err)
-		}
-
-		tr = hashRdr
-	}
-	if input.ChecksumSHA256 != nil {
-		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumSHA256, utils.HashTypeSha256)
-		if err != nil {
-			return nil, fmt.Errorf("initialize hash reader: %w", err)
-		}
-
-		tr = hashRdr
-	}
-	if input.ChecksumCRC64NVME != nil {
-		hashRdr, err = utils.NewHashReader(tr, *input.ChecksumCRC64NVME, utils.HashTypeCRC64NVME)
-		if err != nil {
-			return nil, fmt.Errorf("initialize hash reader: %w", err)
-		}
-
-		tr = hashRdr
 	}
 
 	// If only the checksum algorithm is provided register
@@ -2312,7 +2295,7 @@ func (p *Posix) UploadPart(ctx context.Context, input *s3.UploadPartInput) (*s3.
 		tr = hashRdr
 	}
 
-	checksums, chErr := p.retreiveChecksums(nil, bucket, mpPath)
+	checksums, chErr := p.retrieveChecksums(nil, bucket, mpPath)
 	if chErr != nil && !errors.Is(chErr, meta.ErrNoSuchKey) {
 		return nil, fmt.Errorf("retreive mp checksum: %w", chErr)
 	}
@@ -2519,12 +2502,12 @@ func (p *Posix) UploadPartCopy(ctx context.Context, upi *s3.UploadPartCopyInput)
 	hash := md5.New()
 	tr := io.TeeReader(rdr, hash)
 
-	mpChecksums, err := p.retreiveChecksums(nil, *upi.Bucket, filepath.Join(objdir, *upi.UploadId))
+	mpChecksums, err := p.retrieveChecksums(nil, *upi.Bucket, filepath.Join(objdir, *upi.UploadId))
 	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 		return s3response.CopyPartResult{}, fmt.Errorf("retreive mp checksums: %w", err)
 	}
 
-	checksums, err := p.retreiveChecksums(nil, objPath, "")
+	checksums, err := p.retrieveChecksums(nil, objPath, "")
 	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 		return s3response.CopyPartResult{}, fmt.Errorf("retreive object part checksums: %w", err)
 	}
@@ -2752,46 +2735,24 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (s3respons
 	hash := md5.New()
 	rdr := io.TeeReader(po.Body, hash)
 
+	hashConfigs := []hashConfig{
+		{po.ChecksumCRC32, utils.HashTypeCRC32},
+		{po.ChecksumCRC32C, utils.HashTypeCRC32C},
+		{po.ChecksumSHA1, utils.HashTypeSha1},
+		{po.ChecksumSHA256, utils.HashTypeSha256},
+		{po.ChecksumCRC64NVME, utils.HashTypeCRC64NVME},
+	}
 	var hashRdr *utils.HashReader
-	if po.ChecksumCRC32 != nil {
-		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumCRC32, utils.HashTypeCRC32)
-		if err != nil {
-			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
-		}
 
-		rdr = hashRdr
-	}
-	if po.ChecksumCRC32C != nil {
-		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumCRC32C, utils.HashTypeCRC32C)
-		if err != nil {
-			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
-		}
+	for _, config := range hashConfigs {
+		if config.value != nil {
+			hashRdr, err = utils.NewHashReader(rdr, *config.value, config.hashType)
+			if err != nil {
+				return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+			}
 
-		rdr = hashRdr
-	}
-	if po.ChecksumSHA1 != nil {
-		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumSHA1, utils.HashTypeSha1)
-		if err != nil {
-			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
+			rdr = hashRdr
 		}
-
-		rdr = hashRdr
-	}
-	if po.ChecksumSHA256 != nil {
-		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumSHA256, utils.HashTypeSha256)
-		if err != nil {
-			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
-		}
-
-		rdr = hashRdr
-	}
-	if po.ChecksumCRC64NVME != nil {
-		hashRdr, err = utils.NewHashReader(rdr, *po.ChecksumCRC64NVME, utils.HashTypeCRC64NVME)
-		if err != nil {
-			return s3response.PutObjectOutput{}, fmt.Errorf("initialize hash reader: %w", err)
-		}
-
-		rdr = hashRdr
 	}
 
 	// If only the checksum algorithm is provided register
@@ -3508,7 +3469,7 @@ func (p *Posix) GetObject(_ context.Context, input *s3.GetObjectInput) (*s3.GetO
 	var cType types.ChecksumType
 	// Skip the checksums retreival if object isn't requested fully
 	if input.ChecksumMode == types.ChecksumModeEnabled && length-startOffset == objSize {
-		checksums, err = p.retreiveChecksums(f, bucket, object)
+		checksums, err = p.retrieveChecksums(f, bucket, object)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			return nil, fmt.Errorf("get object checksums: %w", err)
 		}
@@ -3719,7 +3680,7 @@ func (p *Posix) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.
 	var checksums s3response.Checksum
 	var cType types.ChecksumType
 	if input.ChecksumMode == types.ChecksumModeEnabled {
-		checksums, err = p.retreiveChecksums(nil, bucket, object)
+		checksums, err = p.retrieveChecksums(nil, bucket, object)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			return nil, fmt.Errorf("get object checksums: %w", err)
 		}
@@ -3905,7 +3866,7 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 			}
 		}
 
-		checksums, err := p.retreiveChecksums(nil, dstBucket, dstObject)
+		checksums, err := p.retrieveChecksums(nil, dstBucket, dstObject)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			return nil, fmt.Errorf("get obj checksums: %w", err)
 		}
@@ -3968,7 +3929,7 @@ func (p *Posix) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.
 	} else {
 		contentLength := fi.Size()
 
-		checksums, err := p.retreiveChecksums(f, srcBucket, srcObject)
+		checksums, err := p.retrieveChecksums(f, srcBucket, srcObject)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			return nil, fmt.Errorf("get obj checksum: %w", err)
 		}
@@ -4111,7 +4072,7 @@ func (p *Posix) fileToObj(bucket string) backend.GetObjFunc {
 		}
 
 		// Retreive the object checksum algorithm
-		checksums, err := p.retreiveChecksums(nil, bucket, path)
+		checksums, err := p.retrieveChecksums(nil, bucket, path)
 		if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 			return s3response.Object{}, backend.ErrSkipObj
 		}
@@ -4787,7 +4748,7 @@ func (p *Posix) storeChecksums(f *os.File, bucket, object string, chs s3response
 	return p.meta.StoreAttribute(f, bucket, object, checksumsKey, checksums)
 }
 
-func (p *Posix) retreiveChecksums(f *os.File, bucket, object string) (checksums s3response.Checksum, err error) {
+func (p *Posix) retrieveChecksums(f *os.File, bucket, object string) (checksums s3response.Checksum, err error) {
 	checksumsAtr, err := p.meta.RetrieveAttribute(f, bucket, object, checksumsKey)
 	if err != nil {
 		return checksums, err

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -256,8 +256,10 @@ func (s *S3Proxy) ListMultipartUploads(ctx context.Context, input *s3.ListMultip
 				ID:          *u.Owner.ID,
 				DisplayName: *u.Owner.DisplayName,
 			},
-			StorageClass: u.StorageClass,
-			Initiated:    *u.Initiated,
+			StorageClass:      u.StorageClass,
+			Initiated:         *u.Initiated,
+			ChecksumAlgorithm: u.ChecksumAlgorithm,
+			ChecksumType:      u.ChecksumType,
 		})
 	}
 
@@ -293,10 +295,15 @@ func (s *S3Proxy) ListParts(ctx context.Context, input *s3.ListPartsInput) (s3re
 	var parts []s3response.Part
 	for _, p := range output.Parts {
 		parts = append(parts, s3response.Part{
-			PartNumber:   int(*p.PartNumber),
-			LastModified: *p.LastModified,
-			ETag:         *p.ETag,
-			Size:         *p.Size,
+			PartNumber:        int(*p.PartNumber),
+			LastModified:      *p.LastModified,
+			ETag:              *p.ETag,
+			Size:              *p.Size,
+			ChecksumCRC32:     p.ChecksumCRC32,
+			ChecksumCRC32C:    p.ChecksumCRC32C,
+			ChecksumCRC64NVME: p.ChecksumCRC64NVME,
+			ChecksumSHA1:      p.ChecksumSHA1,
+			ChecksumSHA256:    p.ChecksumSHA256,
 		})
 	}
 	pnm, err := strconv.Atoi(*output.PartNumberMarker)
@@ -329,6 +336,8 @@ func (s *S3Proxy) ListParts(ctx context.Context, input *s3.ListPartsInput) (s3re
 		MaxParts:             int(*output.MaxParts),
 		IsTruncated:          *output.IsTruncated,
 		Parts:                parts,
+		ChecksumAlgorithm:    output.ChecksumAlgorithm,
+		ChecksumType:         output.ChecksumType,
 	}, nil
 }
 
@@ -348,8 +357,13 @@ func (s *S3Proxy) UploadPartCopy(ctx context.Context, input *s3.UploadPartCopyIn
 	}
 
 	return s3response.CopyPartResult{
-		LastModified: *output.CopyPartResult.LastModified,
-		ETag:         output.CopyPartResult.ETag,
+		LastModified:      *output.CopyPartResult.LastModified,
+		ETag:              output.CopyPartResult.ETag,
+		ChecksumCRC32:     output.CopyPartResult.ChecksumCRC32,
+		ChecksumCRC32C:    output.CopyPartResult.ChecksumCRC32C,
+		ChecksumCRC64NVME: output.CopyPartResult.ChecksumCRC64NVME,
+		ChecksumSHA1:      output.CopyPartResult.ChecksumSHA1,
+		ChecksumSHA256:    output.CopyPartResult.ChecksumSHA256,
 	}, nil
 }
 
@@ -369,8 +383,13 @@ func (s *S3Proxy) PutObject(ctx context.Context, input *s3.PutObjectInput) (s3re
 	}
 
 	return s3response.PutObjectOutput{
-		ETag:      *output.ETag,
-		VersionID: versionID,
+		ETag:              *output.ETag,
+		VersionID:         versionID,
+		ChecksumCRC32:     output.ChecksumCRC32,
+		ChecksumCRC32C:    output.ChecksumCRC32C,
+		ChecksumCRC64NVME: output.ChecksumCRC64NVME,
+		ChecksumSHA1:      output.ChecksumSHA1,
+		ChecksumSHA256:    output.ChecksumSHA256,
 	}, nil
 }
 
@@ -421,6 +440,7 @@ func (s *S3Proxy) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAt
 		ObjectSize:   out.ObjectSize,
 		StorageClass: out.StorageClass,
 		ObjectParts:  &parts,
+		Checksum:     out.Checksum,
 	}, handleError(err)
 }
 
@@ -833,13 +853,15 @@ func convertObjects(objs []types.Object) []s3response.Object {
 
 	for _, obj := range objs {
 		result = append(result, s3response.Object{
-			ETag:          obj.ETag,
-			Key:           obj.Key,
-			LastModified:  obj.LastModified,
-			Owner:         obj.Owner,
-			Size:          obj.Size,
-			RestoreStatus: obj.RestoreStatus,
-			StorageClass:  obj.StorageClass,
+			ETag:              obj.ETag,
+			Key:               obj.Key,
+			LastModified:      obj.LastModified,
+			Owner:             obj.Owner,
+			Size:              obj.Size,
+			RestoreStatus:     obj.RestoreStatus,
+			StorageClass:      obj.StorageClass,
+			ChecksumAlgorithm: obj.ChecksumAlgorithm,
+			ChecksumType:      obj.ChecksumType,
 		})
 	}
 

--- a/s3api/controllers/backend_moq_test.go
+++ b/s3api/controllers/backend_moq_test.go
@@ -170,10 +170,10 @@ var _ backend.Backend = &BackendMock{}
 //			StringFunc: func() string {
 //				panic("mock out the String method")
 //			},
-//			UploadPartFunc: func(contextMoqParam context.Context, uploadPartInput *s3.UploadPartInput) (string, error) {
+//			UploadPartFunc: func(contextMoqParam context.Context, uploadPartInput *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
 //				panic("mock out the UploadPart method")
 //			},
-//			UploadPartCopyFunc: func(contextMoqParam context.Context, uploadPartCopyInput *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error) {
+//			UploadPartCopyFunc: func(contextMoqParam context.Context, uploadPartCopyInput *s3.UploadPartCopyInput) (s3response.CopyPartResult, error) {
 //				panic("mock out the UploadPartCopy method")
 //			},
 //		}
@@ -331,10 +331,10 @@ type BackendMock struct {
 	StringFunc func() string
 
 	// UploadPartFunc mocks the UploadPart method.
-	UploadPartFunc func(contextMoqParam context.Context, uploadPartInput *s3.UploadPartInput) (string, error)
+	UploadPartFunc func(contextMoqParam context.Context, uploadPartInput *s3.UploadPartInput) (*s3.UploadPartOutput, error)
 
 	// UploadPartCopyFunc mocks the UploadPartCopy method.
-	UploadPartCopyFunc func(contextMoqParam context.Context, uploadPartCopyInput *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error)
+	UploadPartCopyFunc func(contextMoqParam context.Context, uploadPartCopyInput *s3.UploadPartCopyInput) (s3response.CopyPartResult, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -2620,7 +2620,7 @@ func (mock *BackendMock) StringCalls() []struct {
 }
 
 // UploadPart calls UploadPartFunc.
-func (mock *BackendMock) UploadPart(contextMoqParam context.Context, uploadPartInput *s3.UploadPartInput) (string, error) {
+func (mock *BackendMock) UploadPart(contextMoqParam context.Context, uploadPartInput *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
 	if mock.UploadPartFunc == nil {
 		panic("BackendMock.UploadPartFunc: method is nil but Backend.UploadPart was just called")
 	}
@@ -2656,7 +2656,7 @@ func (mock *BackendMock) UploadPartCalls() []struct {
 }
 
 // UploadPartCopy calls UploadPartCopyFunc.
-func (mock *BackendMock) UploadPartCopy(contextMoqParam context.Context, uploadPartCopyInput *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error) {
+func (mock *BackendMock) UploadPartCopy(contextMoqParam context.Context, uploadPartCopyInput *s3.UploadPartCopyInput) (s3response.CopyPartResult, error) {
 	if mock.UploadPartCopyFunc == nil {
 		panic("BackendMock.UploadPartCopyFunc: method is nil but Backend.UploadPartCopy was just called")
 	}

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -485,12 +485,27 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 			})
 	}
 
+	checksumMode := types.ChecksumMode(ctx.Get("x-amz-checksum-mode"))
+	if checksumMode != "" && checksumMode != types.ChecksumModeEnabled {
+		if c.debug {
+			log.Printf("invalid x-amz-checksum-mode header value: %v\n", checksumMode)
+		}
+		return SendResponse(ctx, s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-mode"),
+			&MetaOpts{
+				Logger:      c.logger,
+				MetricsMng:  c.mm,
+				Action:      metrics.ActionGetObject,
+				BucketOwner: parsedAcl.Owner,
+			})
+	}
+
 	ctx.Locals("logResBody", false)
 	res, err := c.be.GetObject(ctx.Context(), &s3.GetObjectInput{
-		Bucket:    &bucket,
-		Key:       &key,
-		Range:     &acceptRange,
-		VersionId: &versionId,
+		Bucket:       &bucket,
+		Key:          &key,
+		Range:        &acceptRange,
+		VersionId:    &versionId,
+		ChecksumMode: checksumMode,
 	})
 	if err != nil {
 		if res != nil {
@@ -566,6 +581,30 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "x-amz-storage-class",
 			Value: string(res.StorageClass),
+		})
+	}
+	if res.ChecksumCRC32 != nil {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc32",
+			Value: *res.ChecksumCRC32,
+		})
+	}
+	if res.ChecksumCRC32C != nil {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc32c",
+			Value: *res.ChecksumCRC32C,
+		})
+	}
+	if res.ChecksumSHA1 != nil {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha1",
+			Value: *res.ChecksumSHA1,
+		})
+	}
+	if res.ChecksumSHA256 != nil {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha256",
+			Value: *res.ChecksumSHA256,
 		})
 	}
 
@@ -2007,6 +2046,17 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 				})
 		}
 
+		algorithm, checksums, err := utils.ParseChecksumHeaders(ctx)
+		if err != nil {
+			return SendResponse(ctx, err,
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionPutObject,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
 		var body io.Reader
 		bodyi := ctx.Locals("body-reader")
 		if bodyi != nil {
@@ -2016,16 +2066,55 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		}
 
 		ctx.Locals("logReqBody", false)
-		etag, err := c.be.UploadPart(ctx.Context(),
+		res, err := c.be.UploadPart(ctx.Context(),
 			&s3.UploadPartInput{
-				Bucket:        &bucket,
-				Key:           &keyStart,
-				UploadId:      &uploadId,
-				PartNumber:    &partNumber,
-				ContentLength: &contentLength,
-				Body:          body,
+				Bucket:            &bucket,
+				Key:               &keyStart,
+				UploadId:          &uploadId,
+				PartNumber:        &partNumber,
+				ContentLength:     &contentLength,
+				Body:              body,
+				ChecksumAlgorithm: algorithm,
+				ChecksumCRC32:     backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32]),
+				ChecksumCRC32C:    backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32c]),
+				ChecksumSHA1:      backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha1]),
+				ChecksumSHA256:    backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha256]),
 			})
-		ctx.Response().Header.Set("Etag", etag)
+		if err == nil {
+			headers := []utils.CustomHeader{}
+			if res.ETag != nil {
+				headers = append(headers, utils.CustomHeader{
+					Key:   "ETag",
+					Value: *res.ETag,
+				})
+			}
+			if res.ChecksumCRC32 != nil {
+				headers = append(headers, utils.CustomHeader{
+					Key:   "x-amz-checksum-crc32",
+					Value: *res.ChecksumCRC32,
+				})
+			}
+			if res.ChecksumCRC32C != nil {
+				headers = append(headers, utils.CustomHeader{
+					Key:   "x-amz-checksum-crc32c",
+					Value: *res.ChecksumCRC32C,
+				})
+			}
+			if res.ChecksumSHA1 != nil {
+				headers = append(headers, utils.CustomHeader{
+					Key:   "x-amz-checksum-sha1",
+					Value: *res.ChecksumSHA1,
+				})
+			}
+			if res.ChecksumSHA256 != nil {
+				headers = append(headers, utils.CustomHeader{
+					Key:   "x-amz-checksum-sha256",
+					Value: *res.ChecksumSHA256,
+				})
+			}
+
+			utils.SetResponseHeaders(ctx, headers)
+		}
 		return SendResponse(ctx, err,
 			&MetaOpts{
 				Logger:        c.logger,
@@ -2256,6 +2345,21 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			metaDirective = types.MetadataDirectiveReplace
 		}
 
+		checksumAlgorithm := types.ChecksumAlgorithm(ctx.Get("x-amz-checksum-algorithm"))
+		err = utils.IsChecksumAlgorithmValid(checksumAlgorithm)
+		if err != nil {
+			if c.debug {
+				log.Printf("invalid checksum algorithm: %v", checksumAlgorithm)
+			}
+			return SendXMLResponse(ctx, nil, err,
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionCopyObject,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
 		res, err := c.be.CopyObject(ctx.Context(),
 			&s3.CopyObjectInput{
 				Bucket:                      &bucket,
@@ -2269,6 +2373,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 				Metadata:                    metadata,
 				MetadataDirective:           metaDirective,
 				StorageClass:                types.StorageClass(storageClass),
+				ChecksumAlgorithm:           checksumAlgorithm,
 			})
 		if err == nil {
 			hdrs := []utils.CustomHeader{}
@@ -2368,6 +2473,17 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			})
 	}
 
+	algorithm, checksums, err := utils.ParseChecksumHeaders(ctx)
+	if err != nil {
+		return SendResponse(ctx, err,
+			&MetaOpts{
+				Logger:      c.logger,
+				MetricsMng:  c.mm,
+				Action:      metrics.ActionPutObject,
+				BucketOwner: parsedAcl.Owner,
+			})
+	}
+
 	var body io.Reader
 	bodyi := ctx.Locals("body-reader")
 	if bodyi != nil {
@@ -2390,6 +2506,11 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			ObjectLockRetainUntilDate: &objLock.RetainUntilDate,
 			ObjectLockMode:            objLock.ObjectLockMode,
 			ObjectLockLegalHoldStatus: objLock.LegalHoldStatus,
+			ChecksumAlgorithm:         algorithm,
+			ChecksumCRC32:             backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32]),
+			ChecksumCRC32C:            backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32c]),
+			ChecksumSHA1:              backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha1]),
+			ChecksumSHA256:            backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha256]),
 		})
 	if err != nil {
 		return SendResponse(ctx, err,
@@ -2415,6 +2536,30 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "x-amz-version-id",
 			Value: res.VersionID,
+		})
+	}
+	if getstring(res.ChecksumCRC32) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc32",
+			Value: getstring(res.ChecksumCRC32),
+		})
+	}
+	if getstring(res.ChecksumCRC32C) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc32c",
+			Value: getstring(res.ChecksumCRC32C),
+		})
+	}
+	if getstring(res.ChecksumSHA1) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha1",
+			Value: getstring(res.ChecksumSHA1),
+		})
+	}
+	if getstring(res.ChecksumSHA256) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha256",
+			Value: getstring(res.ChecksumSHA256),
 		})
 	}
 
@@ -2934,12 +3079,27 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 			})
 	}
 
+	checksumMode := types.ChecksumMode(ctx.Get("x-amz-checksum-mode"))
+	if checksumMode != "" && checksumMode != types.ChecksumModeEnabled {
+		if c.debug {
+			log.Printf("invalid x-amz-checksum-mode header value: %v\n", checksumMode)
+		}
+		return SendResponse(ctx, s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-mode"),
+			&MetaOpts{
+				Logger:      c.logger,
+				MetricsMng:  c.mm,
+				Action:      metrics.ActionHeadObject,
+				BucketOwner: parsedAcl.Owner,
+			})
+	}
+
 	res, err := c.be.HeadObject(ctx.Context(),
 		&s3.HeadObjectInput{
-			Bucket:     &bucket,
-			Key:        &key,
-			PartNumber: partNumber,
-			VersionId:  &versionId,
+			Bucket:       &bucket,
+			Key:          &key,
+			PartNumber:   partNumber,
+			VersionId:    &versionId,
+			ChecksumMode: checksumMode,
 		})
 	if err != nil {
 		if res != nil {
@@ -3020,6 +3180,30 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 		headers = append(headers, utils.CustomHeader{
 			Key:   "x-amz-storage-class",
 			Value: string(res.StorageClass),
+		})
+	}
+	if res.ChecksumCRC32 != nil {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc32",
+			Value: *res.ChecksumCRC32,
+		})
+	}
+	if res.ChecksumCRC32C != nil {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc32c",
+			Value: *res.ChecksumCRC32C,
+		})
+	}
+	if res.ChecksumSHA1 != nil {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha1",
+			Value: *res.ChecksumSHA1,
+		})
+	}
+	if res.ChecksumSHA256 != nil {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha256",
+			Value: *res.ChecksumSHA256,
 		})
 	}
 
@@ -3232,6 +3416,20 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 				})
 		}
 
+		_, checksums, err := utils.ParseChecksumHeaders(ctx)
+		if err != nil {
+			if c.debug {
+				log.Printf("err parsing checksum headers: %v", err)
+			}
+			return SendXMLResponse(ctx, nil, err,
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionCompleteMultipartUpload,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
 		res, err := c.be.CompleteMultipartUpload(ctx.Context(),
 			&s3.CompleteMultipartUploadInput{
 				Bucket:   &bucket,
@@ -3240,6 +3438,10 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 				MultipartUpload: &types.CompletedMultipartUpload{
 					Parts: data.Parts,
 				},
+				ChecksumCRC32:  backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32]),
+				ChecksumCRC32C: backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32c]),
+				ChecksumSHA1:   backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha1]),
+				ChecksumSHA256: backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha256]),
 			})
 		if err == nil {
 			if getstring(res.VersionId) != "" {
@@ -3305,6 +3507,21 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 
 	metadata := utils.GetUserMetaData(&ctx.Request().Header)
 
+	checksumAlgorithm := types.ChecksumAlgorithm(ctx.Get("x-amz-checksum-algorithm"))
+	err = utils.IsChecksumAlgorithmValid(checksumAlgorithm)
+	if err != nil {
+		if c.debug {
+			log.Printf("invalid checksum algorithm: %v", checksumAlgorithm)
+		}
+		return SendXMLResponse(ctx, nil, err,
+			&MetaOpts{
+				Logger:      c.logger,
+				MetricsMng:  c.mm,
+				Action:      metrics.ActionCreateMultipartUpload,
+				BucketOwner: parsedAcl.Owner,
+			})
+	}
+
 	res, err := c.be.CreateMultipartUpload(ctx.Context(),
 		&s3.CreateMultipartUploadInput{
 			Bucket:                    &bucket,
@@ -3316,7 +3533,18 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 			ObjectLockMode:            objLockState.ObjectLockMode,
 			ObjectLockLegalHoldStatus: objLockState.LegalHoldStatus,
 			Metadata:                  metadata,
+			ChecksumAlgorithm:         checksumAlgorithm,
 		})
+	if err == nil {
+		if checksumAlgorithm != "" {
+			utils.SetResponseHeaders(ctx, []utils.CustomHeader{
+				{
+					Key:   "x-amz-checksum-algorithm",
+					Value: string(checksumAlgorithm),
+				},
+			})
+		}
+	}
 	return SendXMLResponse(ctx, res, err,
 		&MetaOpts{
 			Logger:      c.logger,

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -2101,34 +2101,31 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 					Value: *res.ETag,
 				})
 			}
-			if res.ChecksumCRC32 != nil {
+			switch {
+			case res.ChecksumCRC32 != nil:
 				headers = append(headers, utils.CustomHeader{
 					Key:   "x-amz-checksum-crc32",
 					Value: *res.ChecksumCRC32,
 				})
-			}
-			if res.ChecksumCRC32C != nil {
+			case res.ChecksumCRC32C != nil:
 				headers = append(headers, utils.CustomHeader{
 					Key:   "x-amz-checksum-crc32c",
 					Value: *res.ChecksumCRC32C,
 				})
-			}
-			if res.ChecksumSHA1 != nil {
+			case res.ChecksumCRC64NVME != nil:
+				headers = append(headers, utils.CustomHeader{
+					Key:   "x-amz-checksum-crc64nvme",
+					Value: *res.ChecksumCRC64NVME,
+				})
+			case res.ChecksumSHA1 != nil:
 				headers = append(headers, utils.CustomHeader{
 					Key:   "x-amz-checksum-sha1",
 					Value: *res.ChecksumSHA1,
 				})
-			}
-			if res.ChecksumSHA256 != nil {
+			case res.ChecksumSHA256 != nil:
 				headers = append(headers, utils.CustomHeader{
 					Key:   "x-amz-checksum-sha256",
 					Value: *res.ChecksumSHA256,
-				})
-			}
-			if res.ChecksumCRC64NVME != nil {
-				headers = append(headers, utils.CustomHeader{
-					Key:   "x-amz-checksum-crc64nvme",
-					Value: *res.ChecksumCRC64NVME,
 				})
 			}
 
@@ -2558,34 +2555,31 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			Value: res.VersionID,
 		})
 	}
-	if getstring(res.ChecksumCRC32) != "" {
+	switch {
+	case res.ChecksumCRC32 != nil:
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "x-amz-checksum-crc32",
-			Value: getstring(res.ChecksumCRC32),
+			Value: *res.ChecksumCRC32,
 		})
-	}
-	if getstring(res.ChecksumCRC32C) != "" {
+	case res.ChecksumCRC32C != nil:
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "x-amz-checksum-crc32c",
-			Value: getstring(res.ChecksumCRC32C),
+			Value: *res.ChecksumCRC32C,
 		})
-	}
-	if getstring(res.ChecksumSHA1) != "" {
-		hdrs = append(hdrs, utils.CustomHeader{
-			Key:   "x-amz-checksum-sha1",
-			Value: getstring(res.ChecksumSHA1),
-		})
-	}
-	if getstring(res.ChecksumSHA256) != "" {
-		hdrs = append(hdrs, utils.CustomHeader{
-			Key:   "x-amz-checksum-sha256",
-			Value: getstring(res.ChecksumSHA256),
-		})
-	}
-	if getstring(res.ChecksumCRC64NVME) != "" {
+	case res.ChecksumCRC64NVME != nil:
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "x-amz-checksum-crc64nvme",
-			Value: getstring(res.ChecksumCRC64NVME),
+			Value: *res.ChecksumCRC64NVME,
+		})
+	case res.ChecksumSHA1 != nil:
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha1",
+			Value: *res.ChecksumSHA1,
+		})
+	case res.ChecksumSHA256 != nil:
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "x-amz-checksum-sha256",
+			Value: *res.ChecksumSHA256,
 		})
 	}
 	if res.ChecksumType != "" {
@@ -3214,34 +3208,31 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 			Value: string(res.StorageClass),
 		})
 	}
-	if res.ChecksumCRC32 != nil {
+	switch {
+	case res.ChecksumCRC32 != nil:
 		headers = append(headers, utils.CustomHeader{
 			Key:   "x-amz-checksum-crc32",
 			Value: *res.ChecksumCRC32,
 		})
-	}
-	if res.ChecksumCRC32C != nil {
+	case res.ChecksumCRC32C != nil:
 		headers = append(headers, utils.CustomHeader{
 			Key:   "x-amz-checksum-crc32c",
 			Value: *res.ChecksumCRC32C,
 		})
-	}
-	if res.ChecksumSHA1 != nil {
+	case res.ChecksumCRC64NVME != nil:
+		headers = append(headers, utils.CustomHeader{
+			Key:   "x-amz-checksum-crc64nvme",
+			Value: *res.ChecksumCRC64NVME,
+		})
+	case res.ChecksumSHA1 != nil:
 		headers = append(headers, utils.CustomHeader{
 			Key:   "x-amz-checksum-sha1",
 			Value: *res.ChecksumSHA1,
 		})
-	}
-	if res.ChecksumSHA256 != nil {
+	case res.ChecksumSHA256 != nil:
 		headers = append(headers, utils.CustomHeader{
 			Key:   "x-amz-checksum-sha256",
 			Value: *res.ChecksumSHA256,
-		})
-	}
-	if res.ChecksumCRC64NVME != nil {
-		headers = append(headers, utils.CustomHeader{
-			Key:   "x-amz-checksum-crc64nvme",
-			Value: *res.ChecksumCRC64NVME,
 		})
 	}
 	if res.ChecksumType != "" {

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -232,6 +232,9 @@ func TestS3ApiController_GetActions(t *testing.T) {
 	getObjAttrs := httptest.NewRequest(http.MethodGet, "/my-bucket/key", nil)
 	getObjAttrs.Header.Set("X-Amz-Object-Attributes", "hello")
 
+	invalidChecksumMode := httptest.NewRequest(http.MethodGet, "/my-bucket/key", nil)
+	invalidChecksumMode.Header.Set("x-amz-checksum-mode", "invalid_checksum_mode")
+
 	tests := []struct {
 		name       string
 		app        *fiber.App
@@ -328,6 +331,15 @@ func TestS3ApiController_GetActions(t *testing.T) {
 			},
 			wantErr:    false,
 			statusCode: 200,
+		},
+		{
+			name: "Get-actions-get-object-invalid-checksum-mode",
+			app:  app,
+			args: args{
+				req: invalidChecksumMode,
+			},
+			wantErr:    false,
+			statusCode: 400,
 		},
 		{
 			name: "Get-actions-get-object-success",
@@ -971,14 +983,14 @@ func TestS3ApiController_PutActions(t *testing.T) {
 			PutObjectFunc: func(context.Context, *s3.PutObjectInput) (s3response.PutObjectOutput, error) {
 				return s3response.PutObjectOutput{}, nil
 			},
-			UploadPartFunc: func(context.Context, *s3.UploadPartInput) (string, error) {
-				return "hello", nil
+			UploadPartFunc: func(context.Context, *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
+				return &s3.UploadPartOutput{}, nil
 			},
 			PutObjectTaggingFunc: func(_ context.Context, bucket, object string, tags map[string]string) error {
 				return nil
 			},
-			UploadPartCopyFunc: func(context.Context, *s3.UploadPartCopyInput) (s3response.CopyObjectResult, error) {
-				return s3response.CopyObjectResult{}, nil
+			UploadPartCopyFunc: func(context.Context, *s3.UploadPartCopyInput) (s3response.CopyPartResult, error) {
+				return s3response.CopyPartResult{}, nil
 			},
 			PutObjectLegalHoldFunc: func(contextMoqParam context.Context, bucket, object, versionId string, status bool) error {
 				return nil
@@ -1012,6 +1024,11 @@ func TestS3ApiController_PutActions(t *testing.T) {
 	cpySrcReq := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
 	cpySrcReq.Header.Set("X-Amz-Copy-Source", "srcBucket/srcObject")
 
+	// CopyObject invalid checksum algorithm
+	cpyInvChecksumAlgo := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	cpyInvChecksumAlgo.Header.Set("X-Amz-Copy-Source", "srcBucket/srcObject")
+	cpyInvChecksumAlgo.Header.Set("X-Amz-Checksum-Algorithm", "invalid_checksum_algorithm")
+
 	// PutObjectAcl success
 	aclReq := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
 	aclReq.Header.Set("X-Amz-Acl", "private")
@@ -1032,6 +1049,40 @@ func TestS3ApiController_PutActions(t *testing.T) {
 	// invalid body & grt case
 	invAclBodyGrtReq := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key?acl", strings.NewReader(body))
 	invAclBodyGrtReq.Header.Set("X-Amz-Grant-Read", "hello")
+
+	// PutObject invalid checksum algorithm
+	invChecksumAlgo := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	invChecksumAlgo.Header.Set("X-Amz-Checksum-Algorithm", "invalid_checksum_algorithm")
+
+	// PutObject invalid base64 checksum
+	invBase64Checksum := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	invBase64Checksum.Header.Set("X-Amz-Checksum-Crc32", "invalid_base64")
+
+	// PutObject invalid crc32
+	invCrc32 := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	invCrc32.Header.Set("X-Amz-Checksum-Crc32", "YXNkZmFkc2Zhc2Rm")
+
+	// PutObject invalid crc32c
+	invCrc32c := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	invCrc32c.Header.Set("X-Amz-Checksum-Crc32c", "YXNkZmFkc2Zhc2RmYXNkZg==")
+
+	// PutObject invalid sha1
+	invSha1 := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	invSha1.Header.Set("X-Amz-Checksum-Sha1", "YXNkZmFkc2Zhc2RmYXNkZnNkYWZkYXNmZGFzZg==")
+
+	// PutObject invalid sha256
+	invSha256 := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	invSha256.Header.Set("X-Amz-Checksum-Sha256", "YXNkZmFkc2Zhc2RmYXNkZnNkYWZkYXNmZGFzZmFkc2Zhc2Rm")
+
+	// PutObject multiple checksum headers
+	mulChecksumHdrs := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	mulChecksumHdrs.Header.Set("X-Amz-Checksum-Sha256", "d1SPCd/kZ2rAzbbLUC0n/bEaOSx70FNbXbIqoIxKuPY=")
+	mulChecksumHdrs.Header.Set("X-Amz-Checksum-Crc32c", "ww2FVQ==")
+
+	// PutObject checksum algorithm and header mismatch
+	checksumHdrMismatch := httptest.NewRequest(http.MethodPut, "/my-bucket/my-key", nil)
+	checksumHdrMismatch.Header.Set("X-Amz-Checksum-Algorithm", "SHA1")
+	checksumHdrMismatch.Header.Set("X-Amz-Checksum-Crc32c", "ww2FVQ==")
 
 	tests := []struct {
 		name       string
@@ -1174,6 +1225,15 @@ func TestS3ApiController_PutActions(t *testing.T) {
 			},
 			wantErr:    false,
 			statusCode: 200,
+		},
+		{
+			name: "Copy-object-invalid-checksum-algorithm",
+			app:  app,
+			args: args{
+				req: cpyInvChecksumAlgo,
+			},
+			wantErr:    false,
+			statusCode: 400,
 		},
 		{
 			name: "Copy-object-success",
@@ -1642,6 +1702,9 @@ func TestS3ApiController_HeadObject(t *testing.T) {
 	})
 	appErr.Head("/:bucket/:key/*", s3ApiControllerErr.HeadObject)
 
+	invChecksumMode := httptest.NewRequest(http.MethodHead, "/my-bucket/my-key", nil)
+	invChecksumMode.Header.Set("X-Amz-Checksum-Mode", "invalid_checksum_mode")
+
 	tests := []struct {
 		name       string
 		app        *fiber.App
@@ -1657,6 +1720,15 @@ func TestS3ApiController_HeadObject(t *testing.T) {
 			},
 			wantErr:    false,
 			statusCode: 200,
+		},
+		{
+			name: "Head-object-invalid-checksum-mode",
+			app:  app,
+			args: args{
+				req: invChecksumMode,
+			},
+			wantErr:    false,
+			statusCode: 400,
 		},
 		{
 			name: "Head-object-error",
@@ -1735,6 +1807,9 @@ func TestS3ApiController_CreateActions(t *testing.T) {
 	})
 	app.Post("/:bucket/:key/*", s3ApiController.CreateActions)
 
+	invChecksumAlgo := httptest.NewRequest(http.MethodPost, "/my-bucket/my-key", nil)
+	invChecksumAlgo.Header.Set("X-Amz-Checksum-Algorithm", "invalid_checksum_algorithm")
+
 	tests := []struct {
 		name       string
 		app        *fiber.App
@@ -1795,6 +1870,15 @@ func TestS3ApiController_CreateActions(t *testing.T) {
 			},
 			wantErr:    false,
 			statusCode: 200,
+		},
+		{
+			name: "Create-multipart-upload-invalid-checksum-algorithm",
+			app:  app,
+			args: args{
+				req: invChecksumAlgo,
+			},
+			wantErr:    false,
+			statusCode: 400,
 		},
 		{
 			name: "Create-multipart-upload-success",

--- a/s3api/middlewares/md5.go
+++ b/s3api/middlewares/md5.go
@@ -45,7 +45,7 @@ func VerifyMD5Body(logger s3log.AuditLogger) fiber.Handler {
 		}
 
 		sum := md5.Sum(ctx.Body())
-		calculatedSum := utils.Md5SumString(sum[:])
+		calculatedSum := utils.Base64SumString(sum[:])
 
 		if incomingSum != calculatedSum {
 			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidDigest), &controllers.MetaOpts{Logger: logger})

--- a/s3api/utils/auth-reader.go
+++ b/s3api/utils/auth-reader.go
@@ -56,7 +56,7 @@ func NewAuthReader(ctx *fiber.Ctx, r io.Reader, auth AuthData, secret string, de
 	var hr *HashReader
 	hashPayload := ctx.Get("X-Amz-Content-Sha256")
 	if !IsSpecialPayload(hashPayload) {
-		hr, _ = NewHashReader(r, "", HashTypeSha256)
+		hr, _ = NewHashReader(r, "", HashTypeSha256Hex)
 	} else {
 		hr, _ = NewHashReader(r, "", HashTypeNone)
 	}

--- a/s3api/utils/utils.go
+++ b/s3api/utils/utils.go
@@ -16,6 +16,7 @@ package utils
 
 import (
 	"bytes"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -296,7 +297,9 @@ func FilterObjectAttributes(attrs map[s3response.ObjectAttributes]struct{}, outp
 	if _, ok := attrs[s3response.ObjectAttributesStorageClass]; !ok {
 		output.StorageClass = ""
 	}
-	fmt.Printf("%+v\n", output)
+	if _, ok := attrs[s3response.ObjectAttributesChecksum]; !ok {
+		output.Checksum = nil
+	}
 
 	return output
 }
@@ -455,4 +458,75 @@ func shouldEscape(c byte) bool {
 	}
 
 	return true
+}
+
+func ParseChecksumHeaders(ctx *fiber.Ctx) (types.ChecksumAlgorithm, map[types.ChecksumAlgorithm]string, error) {
+	sdkAlgorithm := types.ChecksumAlgorithm(ctx.Get("x-amz-sdk-checksum-algorithm"))
+
+	err := IsChecksumAlgorithmValid(sdkAlgorithm)
+	if err != nil {
+		return "", nil, err
+	}
+
+	checksums := map[types.ChecksumAlgorithm]string{
+		types.ChecksumAlgorithmCrc32:  ctx.Get("x-amz-checksum-crc32"),
+		types.ChecksumAlgorithmCrc32c: ctx.Get("x-amz-checksum-crc32c"),
+		types.ChecksumAlgorithmSha1:   ctx.Get("x-amz-checksum-sha1"),
+		types.ChecksumAlgorithmSha256: ctx.Get("x-amz-checksum-sha256"),
+	}
+
+	headerCtr := 0
+
+	for al, val := range checksums {
+		if val != "" && !IsValidChecksum(val, al) {
+			return sdkAlgorithm, checksums, s3err.GetInvalidChecksumHeaderErr(fmt.Sprintf("x-amz-checksum-%v", strings.ToLower(string(al))))
+		}
+		// If any other checksum value is provided,
+		// rather than x-amz-sdk-checksum-algorithm
+		if sdkAlgorithm != "" && sdkAlgorithm != al && val != "" {
+			return sdkAlgorithm, checksums, s3err.GetAPIError(s3err.ErrMultipleChecksumHeaders)
+		}
+		if val != "" {
+			headerCtr++
+		}
+
+		if headerCtr > 1 {
+			return sdkAlgorithm, checksums, s3err.GetAPIError(s3err.ErrMultipleChecksumHeaders)
+		}
+	}
+
+	return sdkAlgorithm, checksums, nil
+}
+
+var checksumLengths = map[types.ChecksumAlgorithm]int{
+	types.ChecksumAlgorithmCrc32:  4,
+	types.ChecksumAlgorithmCrc32c: 4,
+	types.ChecksumAlgorithmSha1:   20,
+	types.ChecksumAlgorithmSha256: 32,
+}
+
+func IsValidChecksum(checksum string, algorithm types.ChecksumAlgorithm) bool {
+	decoded, err := base64.StdEncoding.DecodeString(checksum)
+	if err != nil {
+		return false
+	}
+
+	expectedLength, exists := checksumLengths[algorithm]
+	if !exists {
+		return false
+	}
+
+	return len(decoded) == expectedLength
+}
+
+func IsChecksumAlgorithmValid(alg types.ChecksumAlgorithm) error {
+	if alg != "" &&
+		alg != types.ChecksumAlgorithmCrc32 &&
+		alg != types.ChecksumAlgorithmCrc32c &&
+		alg != types.ChecksumAlgorithmSha1 &&
+		alg != types.ChecksumAlgorithmSha256 {
+		return s3err.GetAPIError(s3err.ErrInvalidChecksumAlgorithm)
+	}
+
+	return nil
 }

--- a/s3api/utils/utils_test.go
+++ b/s3api/utils/utils_test.go
@@ -527,3 +527,156 @@ func Test_escapePath(t *testing.T) {
 		})
 	}
 }
+
+func TestIsChecksumAlgorithmValid(t *testing.T) {
+	type args struct {
+		alg types.ChecksumAlgorithm
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "empty",
+			args: args{
+				alg: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "crc32",
+			args: args{
+				alg: types.ChecksumAlgorithmCrc32,
+			},
+			wantErr: false,
+		},
+		{
+			name: "crc32c",
+			args: args{
+				alg: types.ChecksumAlgorithmCrc32c,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sha1",
+			args: args{
+				alg: types.ChecksumAlgorithmSha1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "sha256",
+			args: args{
+				alg: types.ChecksumAlgorithmSha256,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid",
+			args: args{
+				alg: types.ChecksumAlgorithm("invalid_checksum_algorithm"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := IsChecksumAlgorithmValid(tt.args.alg); (err != nil) != tt.wantErr {
+				t.Errorf("IsChecksumAlgorithmValid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsValidChecksum(t *testing.T) {
+	type args struct {
+		checksum  string
+		algorithm types.ChecksumAlgorithm
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "invalid-base64",
+			args: args{
+				checksum:  "invalid_base64_string",
+				algorithm: types.ChecksumAlgorithmCrc32,
+			},
+			want: false,
+		},
+		{
+			name: "invalid-crc32",
+			args: args{
+				checksum:  "YXNkZmFzZGZhc2Rm",
+				algorithm: types.ChecksumAlgorithmCrc32,
+			},
+			want: false,
+		},
+		{
+			name: "valid-crc32",
+			args: args{
+				checksum:  "ww2FVQ==",
+				algorithm: types.ChecksumAlgorithmCrc32,
+			},
+			want: true,
+		},
+		{
+			name: "invalid-crc32c",
+			args: args{
+				checksum:  "Zmdoa2doZmtnZmhr",
+				algorithm: types.ChecksumAlgorithmCrc32c,
+			},
+			want: false,
+		},
+		{
+			name: "valid-crc32c",
+			args: args{
+				checksum:  "DOsb4w==",
+				algorithm: types.ChecksumAlgorithmCrc32c,
+			},
+			want: true,
+		},
+		{
+			name: "invalid-sha1",
+			args: args{
+				checksum:  "YXNkZmFzZGZhc2RmYXNkZnNhZGZzYWRm",
+				algorithm: types.ChecksumAlgorithmSha1,
+			},
+			want: false,
+		},
+		{
+			name: "valid-sha1",
+			args: args{
+				checksum:  "L4q6V59Zcwn12wyLIytoE2c1ugk=",
+				algorithm: types.ChecksumAlgorithmSha1,
+			},
+			want: true,
+		},
+		{
+			name: "invalid-sha256",
+			args: args{
+				checksum:  "Zmdoa2doZmtnZmhrYXNkZmFzZGZhc2RmZHNmYXNkZg==",
+				algorithm: types.ChecksumAlgorithmSha256,
+			},
+			want: false,
+		},
+		{
+			name: "valid-sha256",
+			args: args{
+				checksum:  "d1SPCd/kZ2rAzbbLUC0n/bEaOSx70FNbXbIqoIxKuPY=",
+				algorithm: types.ChecksumAlgorithmSha256,
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidChecksum(tt.args.checksum, tt.args.algorithm); got != tt.want {
+				t.Errorf("IsValidChecksum() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/s3api/utils/utils_test.go
+++ b/s3api/utils/utils_test.go
@@ -573,6 +573,13 @@ func TestIsChecksumAlgorithmValid(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "crc64nvme",
+			args: args{
+				alg: types.ChecksumAlgorithmCrc64nvme,
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid",
 			args: args{
 				alg: types.ChecksumAlgorithm("invalid_checksum_algorithm"),
@@ -676,6 +683,168 @@ func TestIsValidChecksum(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := IsValidChecksum(tt.args.checksum, tt.args.algorithm); got != tt.want {
 				t.Errorf("IsValidChecksum() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsChecksumTypeValid(t *testing.T) {
+	type args struct {
+		t types.ChecksumType
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "valid_FULL_OBJECT",
+			args: args{
+				t: types.ChecksumTypeFullObject,
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid_COMPOSITE",
+			args: args{
+				t: types.ChecksumTypeComposite,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid",
+			args: args{
+				t: types.ChecksumType("invalid_checksum_type"),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := IsChecksumTypeValid(tt.args.t); (err != nil) != tt.wantErr {
+				t.Errorf("IsChecksumTypeValid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_checkChecksumTypeAndAlgo(t *testing.T) {
+	type args struct {
+		algo types.ChecksumAlgorithm
+		t    types.ChecksumType
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "full_object-crc32",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc32,
+				t:    types.ChecksumTypeFullObject,
+			},
+			wantErr: false,
+		},
+		{
+			name: "full_object-crc32c",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc32c,
+				t:    types.ChecksumTypeFullObject,
+			},
+			wantErr: false,
+		},
+		{
+			name: "full_object-sha1",
+			args: args{
+				algo: types.ChecksumAlgorithmSha1,
+				t:    types.ChecksumTypeFullObject,
+			},
+			wantErr: true,
+		},
+		{
+			name: "full_object-sha256",
+			args: args{
+				algo: types.ChecksumAlgorithmSha1,
+				t:    types.ChecksumTypeFullObject,
+			},
+			wantErr: true,
+		},
+		{
+			name: "full_object-crc64nvme",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc64nvme,
+				t:    types.ChecksumTypeFullObject,
+			},
+			wantErr: false,
+		},
+		{
+			name: "full_object-crc32",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc32,
+				t:    types.ChecksumTypeFullObject,
+			},
+			wantErr: false,
+		},
+		{
+			name: "composite-crc32",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc32,
+				t:    types.ChecksumTypeComposite,
+			},
+			wantErr: false,
+		},
+		{
+			name: "composite-crc32c",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc32c,
+				t:    types.ChecksumTypeComposite,
+			},
+			wantErr: false,
+		},
+		{
+			name: "composite-sha1",
+			args: args{
+				algo: types.ChecksumAlgorithmSha1,
+				t:    types.ChecksumTypeComposite,
+			},
+			wantErr: false,
+		},
+		{
+			name: "composite-sha256",
+			args: args{
+				algo: types.ChecksumAlgorithmSha256,
+				t:    types.ChecksumTypeComposite,
+			},
+			wantErr: false,
+		},
+		{
+			name: "composite-crc64nvme",
+			args: args{
+				algo: types.ChecksumAlgorithmCrc64nvme,
+				t:    types.ChecksumTypeComposite,
+			},
+			wantErr: true,
+		},
+		{
+			name: "composite-empty",
+			args: args{
+				t: types.ChecksumTypeComposite,
+			},
+			wantErr: true,
+		},
+		{
+			name: "full_object-empty",
+			args: args{
+				t: types.ChecksumTypeFullObject,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := checkChecksumTypeAndAlgo(tt.args.algo, tt.args.t); (err != nil) != tt.wantErr {
+				t.Errorf("checkChecksumTypeAndAlgo() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -17,7 +17,11 @@ package s3err
 import (
 	"bytes"
 	"encoding/xml"
+	"fmt"
 	"net/http"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 // APIError structure
@@ -140,6 +144,9 @@ const (
 	ErrInvalidVersionId
 	ErrNoSuchVersion
 	ErrSuspendedVersioningNotAllowed
+	ErrMultipleChecksumHeaders
+	ErrInvalidChecksumAlgorithm
+	ErrInvalidChecksumPart
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -584,6 +591,21 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "An Object Lock configuration is present on this bucket, so the versioning state cannot be changed.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
+	ErrMultipleChecksumHeaders: {
+		Code:           "InvalidRequest",
+		Description:    "Expecting a single x-amz-checksum- header. Multiple checksum Types are not allowed.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidChecksumAlgorithm: {
+		Code:           "InvalidRequest",
+		Description:    "Checksum algorithm provided is unsupported. Please try again with any of the valid types: [CRC32, CRC32C, SHA1, SHA256]",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidChecksumPart: {
+		Code:           "InvalidArgument",
+		Description:    "Invalid Base64 or multiple checksums present in request",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
 
 	// non aws errors
 	ErrExistingObjectIsDirectory: {
@@ -677,4 +699,31 @@ func encodeResponse(response interface{}) []byte {
 	e := xml.NewEncoder(&bytesBuffer)
 	e.Encode(response)
 	return bytesBuffer.Bytes()
+}
+
+// Returns invalid checksum error with the provided header in the error description
+func GetInvalidChecksumHeaderErr(header string) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf("Value for %v header is invalid.", header),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+// Returns checksum type mismatch APIError
+func GetChecksumTypeMismatchErr(expected, actual types.ChecksumAlgorithm) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf("Checksum Type mismatch occurred, expected checksum Type: %v, actual checksum Type: %v", expected, actual),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+// Return incorrect checksum APIError
+func GetChecksumBadDigestErr(algo types.ChecksumAlgorithm) APIError {
+	return APIError{
+		Code:           "BadDigest",
+		Description:    fmt.Sprintf("The %v you specified did not match the calculated checksum.", strings.ToLower(string(algo))),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
 }

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -29,16 +29,24 @@ const (
 )
 
 type PutObjectOutput struct {
-	ETag      string
-	VersionID string
+	ETag           string
+	VersionID      string
+	ChecksumCRC32  *string
+	ChecksumCRC32C *string
+	ChecksumSHA1   *string
+	ChecksumSHA256 *string
 }
 
 // Part describes part metadata.
 type Part struct {
-	PartNumber   int
-	LastModified time.Time
-	ETag         string
-	Size         int64
+	PartNumber     int
+	LastModified   time.Time
+	ETag           string
+	Size           int64
+	ChecksumCRC32  *string
+	ChecksumCRC32C *string
+	ChecksumSHA1   *string
+	ChecksumSHA256 *string
 }
 
 func (p Part) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -59,9 +67,10 @@ func (p Part) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 type ListPartsResult struct {
 	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ ListPartsResult" json:"-"`
 
-	Bucket   string
-	Key      string
-	UploadID string `xml:"UploadId"`
+	Bucket            string
+	Key               string
+	UploadID          string `xml:"UploadId"`
+	ChecksumAlgorithm types.ChecksumAlgorithm
 
 	Initiator Initiator
 	Owner     Owner
@@ -101,6 +110,7 @@ type GetObjectAttributesResponse struct {
 	ObjectSize   *int64
 	StorageClass types.StorageClass `xml:",omitempty"`
 	ObjectParts  *ObjectParts
+	Checksum     *types.Checksum
 
 	// Not included in the response body
 	VersionId    *string
@@ -169,13 +179,14 @@ type ListObjectsV2Result struct {
 }
 
 type Object struct {
-	ETag          *string
-	Key           *string
-	LastModified  *time.Time
-	Owner         *types.Owner
-	RestoreStatus *types.RestoreStatus
-	Size          *int64
-	StorageClass  types.ObjectStorageClass
+	ChecksumAlgorithm []types.ChecksumAlgorithm
+	ETag              *string
+	Key               *string
+	LastModified      *time.Time
+	Owner             *types.Owner
+	RestoreStatus     *types.RestoreStatus
+	Size              *int64
+	StorageClass      types.ObjectStorageClass
 }
 
 func (o Object) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -197,12 +208,13 @@ func (o Object) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Upload describes in progress multipart upload
 type Upload struct {
-	Key          string
-	UploadID     string `xml:"UploadId"`
-	Initiator    Initiator
-	Owner        Owner
-	StorageClass types.StorageClass
-	Initiated    time.Time
+	Key               string
+	UploadID          string `xml:"UploadId"`
+	Initiator         Initiator
+	Owner             Owner
+	StorageClass      types.StorageClass
+	Initiated         time.Time
+	ChecksumAlgorithm types.ChecksumAlgorithm
 }
 
 func (u Upload) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -329,6 +341,19 @@ type CopyObjectResult struct {
 	XMLName             xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CopyObjectResult" json:"-"`
 	LastModified        time.Time
 	ETag                string
+	CopySourceVersionId string `xml:"-"`
+}
+
+type CopyPartResult struct {
+	XMLName        xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CopyPartResult" json:"-"`
+	LastModified   time.Time
+	ETag           *string
+	ChecksumCRC32  *string
+	ChecksumCRC32C *string
+	ChecksumSHA1   *string
+	ChecksumSHA256 *string
+
+	// not included in the body
 	CopySourceVersionId string `xml:"-"`
 }
 
@@ -466,4 +491,13 @@ func (AmzDate) ISO8601Parse(date string) (t time.Time, err error) {
 // Admin api response types
 type ListBucketsResult struct {
 	Buckets []Bucket
+}
+
+type Checksum struct {
+	Algorithms []types.ChecksumAlgorithm
+
+	CRC32  *string
+	CRC32C *string
+	SHA1   *string
+	SHA256 *string
 }

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -29,24 +29,27 @@ const (
 )
 
 type PutObjectOutput struct {
-	ETag           string
-	VersionID      string
-	ChecksumCRC32  *string
-	ChecksumCRC32C *string
-	ChecksumSHA1   *string
-	ChecksumSHA256 *string
+	ETag              string
+	VersionID         string
+	ChecksumCRC32     *string
+	ChecksumCRC32C    *string
+	ChecksumSHA1      *string
+	ChecksumSHA256    *string
+	ChecksumCRC64NVME *string
+	ChecksumType      types.ChecksumType
 }
 
 // Part describes part metadata.
 type Part struct {
-	PartNumber     int
-	LastModified   time.Time
-	ETag           string
-	Size           int64
-	ChecksumCRC32  *string
-	ChecksumCRC32C *string
-	ChecksumSHA1   *string
-	ChecksumSHA256 *string
+	PartNumber        int
+	LastModified      time.Time
+	ETag              string
+	Size              int64
+	ChecksumCRC32     *string
+	ChecksumCRC32C    *string
+	ChecksumSHA1      *string
+	ChecksumSHA256    *string
+	ChecksumCRC64NVME *string
 }
 
 func (p Part) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -71,6 +74,7 @@ type ListPartsResult struct {
 	Key               string
 	UploadID          string `xml:"UploadId"`
 	ChecksumAlgorithm types.ChecksumAlgorithm
+	ChecksumType      types.ChecksumType
 
 	Initiator Initiator
 	Owner     Owner
@@ -180,6 +184,7 @@ type ListObjectsV2Result struct {
 
 type Object struct {
 	ChecksumAlgorithm []types.ChecksumAlgorithm
+	ChecksumType      types.ChecksumType
 	ETag              *string
 	Key               *string
 	LastModified      *time.Time
@@ -215,6 +220,7 @@ type Upload struct {
 	StorageClass      types.StorageClass
 	Initiated         time.Time
 	ChecksumAlgorithm types.ChecksumAlgorithm
+	ChecksumType      types.ChecksumType
 }
 
 func (u Upload) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
@@ -345,13 +351,14 @@ type CopyObjectResult struct {
 }
 
 type CopyPartResult struct {
-	XMLName        xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CopyPartResult" json:"-"`
-	LastModified   time.Time
-	ETag           *string
-	ChecksumCRC32  *string
-	ChecksumCRC32C *string
-	ChecksumSHA1   *string
-	ChecksumSHA256 *string
+	XMLName           xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ CopyPartResult" json:"-"`
+	LastModified      time.Time
+	ETag              *string
+	ChecksumCRC32     *string
+	ChecksumCRC32C    *string
+	ChecksumSHA1      *string
+	ChecksumSHA256    *string
+	ChecksumCRC64NVME *string
 
 	// not included in the body
 	CopySourceVersionId string `xml:"-"`
@@ -494,10 +501,12 @@ type ListBucketsResult struct {
 }
 
 type Checksum struct {
-	Algorithms []types.ChecksumAlgorithm
+	Algorithm types.ChecksumAlgorithm
+	Type      types.ChecksumType
 
-	CRC32  *string
-	CRC32C *string
-	SHA1   *string
-	SHA256 *string
+	CRC32     *string
+	CRC32C    *string
+	SHA1      *string
+	SHA256    *string
+	CRC64NVME *string
 }

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -138,11 +138,14 @@ func TestPutObject(s *S3Conf) {
 	PutObject_invalid_long_tags(s)
 	PutObject_missing_object_lock_retention_config(s)
 	PutObject_with_object_lock(s)
-	PutObject_checksum_algorithm_and_header_mismatch(s)
-	PutObject_multiple_checksum_headers(s)
-	PutObject_invalid_checksum_header(s)
-	PutObject_incorrect_checksums(s)
-	PutObject_checksums_success(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		PutObject_checksum_algorithm_and_header_mismatch(s)
+		PutObject_multiple_checksum_headers(s)
+		PutObject_invalid_checksum_header(s)
+		PutObject_incorrect_checksums(s)
+		PutObject_checksums_success(s)
+	}
 	PutObject_success(s)
 	if !s.versioningEnabled {
 		PutObject_racey_success(s)
@@ -159,8 +162,11 @@ func TestHeadObject(s *S3Conf) {
 	HeadObject_non_existing_dir_object(s)
 	HeadObject_with_contenttype(s)
 	HeadObject_invalid_parent_dir(s)
-	HeadObject_not_enabled_checksum_mode(s)
-	HeadObject_checksums(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		HeadObject_not_enabled_checksum_mode(s)
+		HeadObject_checksums(s)
+	}
 	HeadObject_success(s)
 }
 
@@ -171,7 +177,11 @@ func TestGetObjectAttributes(s *S3Conf) {
 	GetObjectAttributes_invalid_parent(s)
 	GetObjectAttributes_empty_attrs(s)
 	GetObjectAttributes_existing_object(s)
-	GetObjectAttributes_checksums(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+
+		GetObjectAttributes_checksums(s)
+	}
 }
 
 func TestGetObject(s *S3Conf) {
@@ -181,8 +191,10 @@ func TestGetObject(s *S3Conf) {
 	GetObject_invalid_parent(s)
 	GetObject_with_meta(s)
 	GetObject_large_object(s)
-	GetObject_not_enabled_checksum_mode(s)
-	GetObject_checksums(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		GetObject_checksums(s)
+	}
 	GetObject_success(s)
 	GetObject_directory_success(s)
 	GetObject_by_range_success(s)
@@ -201,7 +213,10 @@ func TestListObjects(s *S3Conf) {
 	ListObjects_max_keys_none(s)
 	ListObjects_marker_not_from_obj_list(s)
 	ListObjects_list_all_objs(s)
-	ListObjects_with_checksum(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		ListObjects_with_checksum(s)
+	}
 }
 
 func TestListObjectsV2(s *S3Conf) {
@@ -214,7 +229,10 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_truncated_common_prefixes(s)
 	ListObjectsV2_all_objs_max_keys(s)
 	ListObjectsV2_list_all_objs(s)
-	ListObjectsV2_with_checksum(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		ListObjectsV2_with_checksum(s)
+	}
 	ListObjectsV2_invalid_parent_prefix(s)
 }
 
@@ -245,11 +263,14 @@ func TestCopyObject(s *S3Conf) {
 	CopyObject_to_itself_with_new_metadata(s)
 	CopyObject_CopySource_starting_with_slash(s)
 	CopyObject_non_existing_dir_object(s)
-	CopyObject_invalid_checksum_algorithm(s)
-	CopyObject_create_checksum_on_copy(s)
-	CopyObject_should_copy_the_existing_checksum(s)
-	CopyObject_should_replace_the_existing_checksum(s)
-	CopyObject_to_itself_by_replacing_the_checksum(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		CopyObject_invalid_checksum_algorithm(s)
+		CopyObject_create_checksum_on_copy(s)
+		CopyObject_should_copy_the_existing_checksum(s)
+		CopyObject_should_replace_the_existing_checksum(s)
+		CopyObject_to_itself_by_replacing_the_checksum(s)
+	}
 	CopyObject_success(s)
 }
 
@@ -282,8 +303,13 @@ func TestCreateMultipartUpload(s *S3Conf) {
 	CreateMultipartUpload_with_object_lock_not_enabled(s)
 	CreateMultipartUpload_with_object_lock_invalid_retention(s)
 	CreateMultipartUpload_past_retain_until_date(s)
-	CreateMultipartUpload_invalid_checksum_algorithm(s)
-	CreateMultipartUpload_valid_checksum_algorithm(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		CreateMultipartUpload_invalid_checksum_algorithm(s)
+		CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type(s)
+		CreateMultipartUpload_invalid_checksum_type(s)
+		CreateMultipartUpload_valid_checksum_algorithm(s)
+	}
 	CreateMultipartUpload_success(s)
 }
 
@@ -292,15 +318,16 @@ func TestUploadPart(s *S3Conf) {
 	UploadPart_invalid_part_number(s)
 	UploadPart_non_existing_key(s)
 	UploadPart_non_existing_mp_upload(s)
-	UploadPart_checksum_algorithm_and_header_mismatch(s)
-	UploadPart_multiple_checksum_headers(s)
-	UploadPart_invalid_checksum_header(s)
-	UploadPart_checksum_algorithm_mistmatch_on_initialization(s)
-	UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value(s)
-	UploadPart_required_checksum(s)
-	UploadPart_null_checksum(s)
-	UploadPart_incorrect_checksums(s)
-	UploadPart_with_checksums_success(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		UploadPart_checksum_algorithm_and_header_mismatch(s)
+		UploadPart_multiple_checksum_headers(s)
+		UploadPart_invalid_checksum_header(s)
+		UploadPart_checksum_algorithm_mistmatch_on_initialization(s)
+		UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value(s)
+		UploadPart_incorrect_checksums(s)
+		UploadPart_with_checksums_success(s)
+	}
 	UploadPart_success(s)
 }
 
@@ -316,9 +343,12 @@ func TestUploadPartCopy(s *S3Conf) {
 	UploadPartCopy_by_range_invalid_range(s)
 	UploadPartCopy_greater_range_than_obj_size(s)
 	UploadPartCopy_by_range_success(s)
-	UploadPartCopy_should_copy_the_checksum(s)
-	UploadPartCopy_should_not_copy_the_checksum(s)
-	UploadPartCopy_should_calculate_the_checksum(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		UploadPartCopy_should_copy_the_checksum(s)
+		UploadPartCopy_should_not_copy_the_checksum(s)
+		UploadPartCopy_should_calculate_the_checksum(s)
+	}
 }
 
 func TestListParts(s *S3Conf) {
@@ -327,7 +357,10 @@ func TestListParts(s *S3Conf) {
 	ListParts_invalid_max_parts(s)
 	ListParts_default_max_parts(s)
 	ListParts_truncated(s)
-	ListParts_with_checksums(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		ListParts_with_checksums(s)
+	}
 	ListParts_success(s)
 }
 
@@ -338,7 +371,10 @@ func TestListMultipartUploads(s *S3Conf) {
 	ListMultipartUploads_max_uploads(s)
 	ListMultipartUploads_incorrect_next_key_marker(s)
 	ListMultipartUploads_ignore_upload_id_marker(s)
-	ListMultipartUploads_with_checksums(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		ListMultipartUploads_with_checksums(s)
+	}
 	ListMultipartUploads_success(s)
 }
 
@@ -356,6 +392,22 @@ func TestCompleteMultipartUpload(s *S3Conf) {
 	CompleteMultipartUpload_invalid_ETag(s)
 	CompleteMultipartUpload_small_upload_size(s)
 	CompleteMultipartUpload_empty_parts(s)
+	//TODO: remove the condition after implementing checksums in azure
+	if !s.azureTests {
+		CompleteMultipartUpload_invalid_checksum_type(s)
+		CompleteMultipartUpload_invalid_checksum_part(s)
+		CompleteMultipartUpload_multiple_checksum_part(s)
+		CompleteMultipartUpload_incorrect_checksum_part(s)
+		CompleteMultipartUpload_different_checksum_part(s)
+		CompleteMultipartUpload_missing_part_checksum(s)
+		CompleteMultipartUpload_multiple_final_checksums(s)
+		CompleteMultipartUpload_invalid_final_checksums(s)
+		CompleteMultipartUpload_incorrect_final_checksums(s)
+		CompleteMultipartUpload_should_calculate_the_final_checksum_full_object(s)
+		CompleteMultipartUpload_should_verify_the_final_checksum(s)
+		CompleteMultipartUpload_checksum_type_mismatch(s)
+		CompleteMultipartUpload_should_ignore_the_final_checksum(s)
+	}
 	CompleteMultipartUpload_success(s)
 	if !s.azureTests {
 		CompleteMultipartUpload_racey_success(s)
@@ -677,396 +729,441 @@ type IntTests map[string]func(s *S3Conf) error
 
 func GetIntTests() IntTests {
 	return IntTests{
-		"Authentication_empty_auth_header":                                    Authentication_empty_auth_header,
-		"Authentication_invalid_auth_header":                                  Authentication_invalid_auth_header,
-		"Authentication_unsupported_signature_version":                        Authentication_unsupported_signature_version,
-		"Authentication_malformed_credentials":                                Authentication_malformed_credentials,
-		"Authentication_malformed_credentials_invalid_parts":                  Authentication_malformed_credentials_invalid_parts,
-		"Authentication_credentials_terminated_string":                        Authentication_credentials_terminated_string,
-		"Authentication_credentials_incorrect_service":                        Authentication_credentials_incorrect_service,
-		"Authentication_credentials_incorrect_region":                         Authentication_credentials_incorrect_region,
-		"Authentication_credentials_invalid_date":                             Authentication_credentials_invalid_date,
-		"Authentication_credentials_future_date":                              Authentication_credentials_future_date,
-		"Authentication_credentials_past_date":                                Authentication_credentials_past_date,
-		"Authentication_credentials_non_existing_access_key":                  Authentication_credentials_non_existing_access_key,
-		"Authentication_invalid_signed_headers":                               Authentication_invalid_signed_headers,
-		"Authentication_missing_date_header":                                  Authentication_missing_date_header,
-		"Authentication_invalid_date_header":                                  Authentication_invalid_date_header,
-		"Authentication_date_mismatch":                                        Authentication_date_mismatch,
-		"Authentication_incorrect_payload_hash":                               Authentication_incorrect_payload_hash,
-		"Authentication_incorrect_md5":                                        Authentication_incorrect_md5,
-		"Authentication_signature_error_incorrect_secret_key":                 Authentication_signature_error_incorrect_secret_key,
-		"PresignedAuth_missing_algo_query_param":                              PresignedAuth_missing_algo_query_param,
-		"PresignedAuth_unsupported_algorithm":                                 PresignedAuth_unsupported_algorithm,
-		"PresignedAuth_missing_credentials_query_param":                       PresignedAuth_missing_credentials_query_param,
-		"PresignedAuth_malformed_creds_invalid_parts":                         PresignedAuth_malformed_creds_invalid_parts,
-		"PresignedAuth_creds_invalid_terminator":                              PresignedAuth_creds_invalid_terminator,
-		"PresignedAuth_creds_incorrect_service":                               PresignedAuth_creds_incorrect_service,
-		"PresignedAuth_creds_incorrect_region":                                PresignedAuth_creds_incorrect_region,
-		"PresignedAuth_creds_invalid_date":                                    PresignedAuth_creds_invalid_date,
-		"PresignedAuth_missing_date_query":                                    PresignedAuth_missing_date_query,
-		"PresignedAuth_dates_mismatch":                                        PresignedAuth_dates_mismatch,
-		"PresignedAuth_non_existing_access_key_id":                            PresignedAuth_non_existing_access_key_id,
-		"PresignedAuth_missing_signed_headers_query_param":                    PresignedAuth_missing_signed_headers_query_param,
-		"PresignedAuth_missing_expiration_query_param":                        PresignedAuth_missing_expiration_query_param,
-		"PresignedAuth_invalid_expiration_query_param":                        PresignedAuth_invalid_expiration_query_param,
-		"PresignedAuth_negative_expiration_query_param":                       PresignedAuth_negative_expiration_query_param,
-		"PresignedAuth_exceeding_expiration_query_param":                      PresignedAuth_exceeding_expiration_query_param,
-		"PresignedAuth_expired_request":                                       PresignedAuth_expired_request,
-		"PresignedAuth_incorrect_secret_key":                                  PresignedAuth_incorrect_secret_key,
-		"PresignedAuth_PutObject_success":                                     PresignedAuth_PutObject_success,
-		"PutObject_missing_object_lock_retention_config":                      PutObject_missing_object_lock_retention_config,
-		"PutObject_name_too_long":                                             PutObject_name_too_long,
-		"PutObject_with_object_lock":                                          PutObject_with_object_lock,
-		"PresignedAuth_Put_GetObject_with_data":                               PresignedAuth_Put_GetObject_with_data,
-		"PresignedAuth_Put_GetObject_with_UTF8_chars":                         PresignedAuth_Put_GetObject_with_UTF8_chars,
-		"PresignedAuth_UploadPart":                                            PresignedAuth_UploadPart,
-		"CreateBucket_invalid_bucket_name":                                    CreateBucket_invalid_bucket_name,
-		"CreateBucket_existing_bucket":                                        CreateBucket_existing_bucket,
-		"CreateBucket_owned_by_you":                                           CreateBucket_owned_by_you,
-		"CreateBucket_invalid_ownership":                                      CreateBucket_invalid_ownership,
-		"CreateBucket_ownership_with_acl":                                     CreateBucket_ownership_with_acl,
-		"CreateBucket_as_user":                                                CreateBucket_as_user,
-		"CreateDeleteBucket_success":                                          CreateDeleteBucket_success,
-		"CreateBucket_default_acl":                                            CreateBucket_default_acl,
-		"CreateBucket_non_default_acl":                                        CreateBucket_non_default_acl,
-		"CreateBucket_default_object_lock":                                    CreateBucket_default_object_lock,
-		"HeadBucket_non_existing_bucket":                                      HeadBucket_non_existing_bucket,
-		"HeadBucket_success":                                                  HeadBucket_success,
-		"ListBuckets_as_user":                                                 ListBuckets_as_user,
-		"ListBuckets_as_admin":                                                ListBuckets_as_admin,
-		"ListBuckets_with_prefix":                                             ListBuckets_with_prefix,
-		"ListBuckets_invalid_max_buckets":                                     ListBuckets_invalid_max_buckets,
-		"ListBuckets_truncated":                                               ListBuckets_truncated,
-		"ListBuckets_success":                                                 ListBuckets_success,
-		"DeleteBucket_non_existing_bucket":                                    DeleteBucket_non_existing_bucket,
-		"DeleteBucket_non_empty_bucket":                                       DeleteBucket_non_empty_bucket,
-		"DeleteBucket_success_status_code":                                    DeleteBucket_success_status_code,
-		"PutBucketOwnershipControls_non_existing_bucket":                      PutBucketOwnershipControls_non_existing_bucket,
-		"PutBucketOwnershipControls_multiple_rules":                           PutBucketOwnershipControls_multiple_rules,
-		"PutBucketOwnershipControls_invalid_ownership":                        PutBucketOwnershipControls_invalid_ownership,
-		"PutBucketOwnershipControls_success":                                  PutBucketOwnershipControls_success,
-		"GetBucketOwnershipControls_non_existing_bucket":                      GetBucketOwnershipControls_non_existing_bucket,
-		"GetBucketOwnershipControls_default_ownership":                        GetBucketOwnershipControls_default_ownership,
-		"GetBucketOwnershipControls_success":                                  GetBucketOwnershipControls_success,
-		"DeleteBucketOwnershipControls_non_existing_bucket":                   DeleteBucketOwnershipControls_non_existing_bucket,
-		"DeleteBucketOwnershipControls_success":                               DeleteBucketOwnershipControls_success,
-		"PutBucketTagging_non_existing_bucket":                                PutBucketTagging_non_existing_bucket,
-		"PutBucketTagging_long_tags":                                          PutBucketTagging_long_tags,
-		"PutBucketTagging_success":                                            PutBucketTagging_success,
-		"PutBucketTagging_success_status":                                     PutBucketTagging_success_status,
-		"GetBucketTagging_non_existing_bucket":                                GetBucketTagging_non_existing_bucket,
-		"GetBucketTagging_unset_tags":                                         GetBucketTagging_unset_tags,
-		"GetBucketTagging_success":                                            GetBucketTagging_success,
-		"DeleteBucketTagging_non_existing_object":                             DeleteBucketTagging_non_existing_object,
-		"DeleteBucketTagging_success_status":                                  DeleteBucketTagging_success_status,
-		"DeleteBucketTagging_success":                                         DeleteBucketTagging_success,
-		"PutObject_non_existing_bucket":                                       PutObject_non_existing_bucket,
-		"PutObject_special_chars":                                             PutObject_special_chars,
-		"PutObject_invalid_long_tags":                                         PutObject_invalid_long_tags,
-		"PutObject_success":                                                   PutObject_success,
-		"PutObject_racey_success":                                             PutObject_racey_success,
-		"HeadObject_non_existing_object":                                      HeadObject_non_existing_object,
-		"HeadObject_invalid_part_number":                                      HeadObject_invalid_part_number,
-		"HeadObject_non_existing_mp":                                          HeadObject_non_existing_mp,
-		"HeadObject_mp_success":                                               HeadObject_mp_success,
-		"HeadObject_directory_object_noslash":                                 HeadObject_directory_object_noslash,
-		"HeadObject_non_existing_dir_object":                                  HeadObject_non_existing_dir_object,
-		"HeadObject_name_too_long":                                            HeadObject_name_too_long,
-		"HeadObject_with_contenttype":                                         HeadObject_with_contenttype,
-		"HeadObject_invalid_parent_dir":                                       HeadObject_invalid_parent_dir,
-		"HeadObject_success":                                                  HeadObject_success,
-		"GetObjectAttributes_non_existing_bucket":                             GetObjectAttributes_non_existing_bucket,
-		"GetObjectAttributes_non_existing_object":                             GetObjectAttributes_non_existing_object,
-		"GetObjectAttributes_invalid_attrs":                                   GetObjectAttributes_invalid_attrs,
-		"GetObjectAttributes_invalid_parent":                                  GetObjectAttributes_invalid_parent,
-		"GetObjectAttributes_empty_attrs":                                     GetObjectAttributes_empty_attrs,
-		"GetObjectAttributes_existing_object":                                 GetObjectAttributes_existing_object,
-		"GetObject_non_existing_key":                                          GetObject_non_existing_key,
-		"GetObject_directory_object_noslash":                                  GetObject_directory_object_noslash,
-		"GetObject_invalid_ranges":                                            GetObject_invalid_ranges,
-		"GetObject_invalid_parent":                                            GetObject_invalid_parent,
-		"GetObject_with_meta":                                                 GetObject_with_meta,
-		"GetObject_large_object":                                              GetObject_large_object,
-		"GetObject_success":                                                   GetObject_success,
-		"GetObject_directory_success":                                         GetObject_directory_success,
-		"GetObject_by_range_success":                                          GetObject_by_range_success,
-		"GetObject_by_range_resp_status":                                      GetObject_by_range_resp_status,
-		"GetObject_non_existing_dir_object":                                   GetObject_non_existing_dir_object,
-		"ListObjects_non_existing_bucket":                                     ListObjects_non_existing_bucket,
-		"ListObjects_with_prefix":                                             ListObjects_with_prefix,
-		"ListObjects_truncated":                                               ListObjects_truncated,
-		"ListObjects_paginated":                                               ListObjects_paginated,
-		"ListObjects_invalid_max_keys":                                        ListObjects_invalid_max_keys,
-		"ListObjects_max_keys_0":                                              ListObjects_max_keys_0,
-		"ListObjects_delimiter":                                               ListObjects_delimiter,
-		"ListObjects_max_keys_none":                                           ListObjects_max_keys_none,
-		"ListObjects_marker_not_from_obj_list":                                ListObjects_marker_not_from_obj_list,
-		"ListObjects_list_all_objs":                                           ListObjects_list_all_objs,
-		"ListObjectsV2_start_after":                                           ListObjectsV2_start_after,
-		"ListObjectsV2_both_start_after_and_continuation_token":               ListObjectsV2_both_start_after_and_continuation_token,
-		"ListObjectsV2_start_after_not_in_list":                               ListObjectsV2_start_after_not_in_list,
-		"ListObjectsV2_start_after_empty_result":                              ListObjectsV2_start_after_empty_result,
-		"ListObjectsV2_both_delimiter_and_prefix":                             ListObjectsV2_both_delimiter_and_prefix,
-		"ListObjectsV2_single_dir_object_with_delim_and_prefix":               ListObjectsV2_single_dir_object_with_delim_and_prefix,
-		"ListObjectsV2_truncated_common_prefixes":                             ListObjectsV2_truncated_common_prefixes,
-		"ListObjectsV2_all_objs_max_keys":                                     ListObjectsV2_all_objs_max_keys,
-		"ListObjectsV2_list_all_objs":                                         ListObjectsV2_list_all_objs,
-		"ListObjectVersions_VD_success":                                       ListObjectVersions_VD_success,
-		"DeleteObject_non_existing_object":                                    DeleteObject_non_existing_object,
-		"DeleteObject_directory_object_noslash":                               DeleteObject_directory_object_noslash,
-		"DeleteObject_name_too_long":                                          DeleteObject_name_too_long,
-		"DeleteObject_non_existing_dir_object":                                DeleteObject_non_existing_dir_object,
-		"DeleteObject_success":                                                DeleteObject_success,
-		"DeleteObject_success_status_code":                                    DeleteObject_success_status_code,
-		"DeleteObjects_empty_input":                                           DeleteObjects_empty_input,
-		"DeleteObjects_non_existing_objects":                                  DeleteObjects_non_existing_objects,
-		"DeleteObjects_success":                                               DeleteObjects_success,
-		"CopyObject_non_existing_dst_bucket":                                  CopyObject_non_existing_dst_bucket,
-		"CopyObject_not_owned_source_bucket":                                  CopyObject_not_owned_source_bucket,
-		"CopyObject_copy_to_itself":                                           CopyObject_copy_to_itself,
-		"CopyObject_copy_to_itself_invalid_directive":                         CopyObject_copy_to_itself_invalid_directive,
-		"CopyObject_to_itself_with_new_metadata":                              CopyObject_to_itself_with_new_metadata,
-		"CopyObject_CopySource_starting_with_slash":                           CopyObject_CopySource_starting_with_slash,
-		"CopyObject_non_existing_dir_object":                                  CopyObject_non_existing_dir_object,
-		"CopyObject_success":                                                  CopyObject_success,
-		"PutObjectTagging_non_existing_object":                                PutObjectTagging_non_existing_object,
-		"PutObjectTagging_long_tags":                                          PutObjectTagging_long_tags,
-		"PutObjectTagging_success":                                            PutObjectTagging_success,
-		"GetObjectTagging_non_existing_object":                                GetObjectTagging_non_existing_object,
-		"GetObjectTagging_unset_tags":                                         GetObjectTagging_unset_tags,
-		"GetObjectTagging_invalid_parent":                                     GetObjectTagging_invalid_parent,
-		"GetObjectTagging_success":                                            GetObjectTagging_success,
-		"DeleteObjectTagging_non_existing_object":                             DeleteObjectTagging_non_existing_object,
-		"DeleteObjectTagging_success_status":                                  DeleteObjectTagging_success_status,
-		"DeleteObjectTagging_success":                                         DeleteObjectTagging_success,
-		"CreateMultipartUpload_non_existing_bucket":                           CreateMultipartUpload_non_existing_bucket,
-		"CreateMultipartUpload_with_metadata":                                 CreateMultipartUpload_with_metadata,
-		"CreateMultipartUpload_with_invalid_tagging":                          CreateMultipartUpload_with_invalid_tagging,
-		"CreateMultipartUpload_with_tagging":                                  CreateMultipartUpload_with_tagging,
-		"CreateMultipartUpload_with_content_type":                             CreateMultipartUpload_with_content_type,
-		"CreateMultipartUpload_with_object_lock":                              CreateMultipartUpload_with_object_lock,
-		"CreateMultipartUpload_with_object_lock_not_enabled":                  CreateMultipartUpload_with_object_lock_not_enabled,
-		"CreateMultipartUpload_with_object_lock_invalid_retention":            CreateMultipartUpload_with_object_lock_invalid_retention,
-		"CreateMultipartUpload_past_retain_until_date":                        CreateMultipartUpload_past_retain_until_date,
-		"CreateMultipartUpload_success":                                       CreateMultipartUpload_success,
-		"UploadPart_non_existing_bucket":                                      UploadPart_non_existing_bucket,
-		"UploadPart_invalid_part_number":                                      UploadPart_invalid_part_number,
-		"UploadPart_non_existing_key":                                         UploadPart_non_existing_key,
-		"UploadPart_non_existing_mp_upload":                                   UploadPart_non_existing_mp_upload,
-		"UploadPart_success":                                                  UploadPart_success,
-		"UploadPartCopy_non_existing_bucket":                                  UploadPartCopy_non_existing_bucket,
-		"UploadPartCopy_incorrect_uploadId":                                   UploadPartCopy_incorrect_uploadId,
-		"UploadPartCopy_incorrect_object_key":                                 UploadPartCopy_incorrect_object_key,
-		"UploadPartCopy_invalid_part_number":                                  UploadPartCopy_invalid_part_number,
-		"UploadPartCopy_invalid_copy_source":                                  UploadPartCopy_invalid_copy_source,
-		"UploadPartCopy_non_existing_source_bucket":                           UploadPartCopy_non_existing_source_bucket,
-		"UploadPartCopy_non_existing_source_object_key":                       UploadPartCopy_non_existing_source_object_key,
-		"UploadPartCopy_success":                                              UploadPartCopy_success,
-		"UploadPartCopy_by_range_invalid_range":                               UploadPartCopy_by_range_invalid_range,
-		"UploadPartCopy_greater_range_than_obj_size":                          UploadPartCopy_greater_range_than_obj_size,
-		"UploadPartCopy_by_range_success":                                     UploadPartCopy_by_range_success,
-		"ListParts_incorrect_uploadId":                                        ListParts_incorrect_uploadId,
-		"ListParts_incorrect_object_key":                                      ListParts_incorrect_object_key,
-		"ListParts_invalid_max_parts":                                         ListParts_invalid_max_parts,
-		"ListParts_default_max_parts":                                         ListParts_default_max_parts,
-		"ListParts_truncated":                                                 ListParts_truncated,
-		"ListParts_success":                                                   ListParts_success,
-		"ListMultipartUploads_non_existing_bucket":                            ListMultipartUploads_non_existing_bucket,
-		"ListMultipartUploads_empty_result":                                   ListMultipartUploads_empty_result,
-		"ListMultipartUploads_invalid_max_uploads":                            ListMultipartUploads_invalid_max_uploads,
-		"ListMultipartUploads_max_uploads":                                    ListMultipartUploads_max_uploads,
-		"ListMultipartUploads_incorrect_next_key_marker":                      ListMultipartUploads_incorrect_next_key_marker,
-		"ListMultipartUploads_ignore_upload_id_marker":                        ListMultipartUploads_ignore_upload_id_marker,
-		"ListMultipartUploads_success":                                        ListMultipartUploads_success,
-		"AbortMultipartUpload_non_existing_bucket":                            AbortMultipartUpload_non_existing_bucket,
-		"AbortMultipartUpload_incorrect_uploadId":                             AbortMultipartUpload_incorrect_uploadId,
-		"AbortMultipartUpload_incorrect_object_key":                           AbortMultipartUpload_incorrect_object_key,
-		"AbortMultipartUpload_success":                                        AbortMultipartUpload_success,
-		"AbortMultipartUpload_success_status_code":                            AbortMultipartUpload_success_status_code,
-		"CompletedMultipartUpload_non_existing_bucket":                        CompletedMultipartUpload_non_existing_bucket,
-		"CompleteMultipartUpload_invalid_part_number":                         CompleteMultipartUpload_invalid_part_number,
-		"CompleteMultipartUpload_invalid_ETag":                                CompleteMultipartUpload_invalid_ETag,
-		"CompleteMultipartUpload_success":                                     CompleteMultipartUpload_success,
-		"CompleteMultipartUpload_racey_success":                               CompleteMultipartUpload_racey_success,
-		"PutBucketAcl_non_existing_bucket":                                    PutBucketAcl_non_existing_bucket,
-		"PutBucketAcl_disabled":                                               PutBucketAcl_disabled,
-		"PutBucketAcl_none_of_the_options_specified":                          PutBucketAcl_none_of_the_options_specified,
-		"PutBucketAcl_invalid_acl_canned_and_acp":                             PutBucketAcl_invalid_acl_canned_and_acp,
-		"PutBucketAcl_invalid_acl_canned_and_grants":                          PutBucketAcl_invalid_acl_canned_and_grants,
-		"PutBucketAcl_invalid_acl_acp_and_grants":                             PutBucketAcl_invalid_acl_acp_and_grants,
-		"PutBucketAcl_invalid_owner":                                          PutBucketAcl_invalid_owner,
-		"PutBucketAcl_invalid_owner_not_in_body":                              PutBucketAcl_invalid_owner_not_in_body,
-		"PutBucketAcl_invalid_empty_owner_id_in_body":                         PutBucketAcl_invalid_empty_owner_id_in_body,
-		"PutBucketAcl_invalid_permission_in_body":                             PutBucketAcl_invalid_permission_in_body,
-		"PutBucketAcl_invalid_grantee_type_in_body":                           PutBucketAcl_invalid_grantee_type_in_body,
-		"PutBucketAcl_empty_grantee_ID_in_body":                               PutBucketAcl_empty_grantee_ID_in_body,
-		"PutBucketAcl_success_access_denied":                                  PutBucketAcl_success_access_denied,
-		"PutBucketAcl_success_grants":                                         PutBucketAcl_success_grants,
-		"PutBucketAcl_success_canned_acl":                                     PutBucketAcl_success_canned_acl,
-		"PutBucketAcl_success_acp":                                            PutBucketAcl_success_acp,
-		"GetBucketAcl_non_existing_bucket":                                    GetBucketAcl_non_existing_bucket,
-		"GetBucketAcl_translation_canned_public_read":                         GetBucketAcl_translation_canned_public_read,
-		"GetBucketAcl_translation_canned_public_read_write":                   GetBucketAcl_translation_canned_public_read_write,
-		"GetBucketAcl_translation_canned_private":                             GetBucketAcl_translation_canned_private,
-		"GetBucketAcl_access_denied":                                          GetBucketAcl_access_denied,
-		"GetBucketAcl_success":                                                GetBucketAcl_success,
-		"PutBucketPolicy_non_existing_bucket":                                 PutBucketPolicy_non_existing_bucket,
-		"PutBucketPolicy_empty_statement":                                     PutBucketPolicy_empty_statement,
-		"PutBucketPolicy_invalid_effect":                                      PutBucketPolicy_invalid_effect,
-		"PutBucketPolicy_empty_actions_string":                                PutBucketPolicy_empty_actions_string,
-		"PutBucketPolicy_empty_actions_array":                                 PutBucketPolicy_empty_actions_array,
-		"PutBucketPolicy_invalid_action":                                      PutBucketPolicy_invalid_action,
-		"PutBucketPolicy_unsupported_action":                                  PutBucketPolicy_unsupported_action,
-		"PutBucketPolicy_incorrect_action_wildcard_usage":                     PutBucketPolicy_incorrect_action_wildcard_usage,
-		"PutBucketPolicy_empty_principals_string":                             PutBucketPolicy_empty_principals_string,
-		"PutBucketPolicy_empty_principals_array":                              PutBucketPolicy_empty_principals_array,
-		"PutBucketPolicy_principals_aws_struct_empty_string":                  PutBucketPolicy_principals_aws_struct_empty_string,
-		"PutBucketPolicy_principals_aws_struct_empty_string_slice":            PutBucketPolicy_principals_aws_struct_empty_string_slice,
-		"PutBucketPolicy_principals_incorrect_wildcard_usage":                 PutBucketPolicy_principals_incorrect_wildcard_usage,
-		"PutBucketPolicy_non_existing_principals":                             PutBucketPolicy_non_existing_principals,
-		"PutBucketPolicy_empty_resources_string":                              PutBucketPolicy_empty_resources_string,
-		"PutBucketPolicy_empty_resources_array":                               PutBucketPolicy_empty_resources_array,
-		"PutBucketPolicy_invalid_resource_prefix":                             PutBucketPolicy_invalid_resource_prefix,
-		"PutBucketPolicy_invalid_resource_with_starting_slash":                PutBucketPolicy_invalid_resource_with_starting_slash,
-		"PutBucketPolicy_duplicate_resource":                                  PutBucketPolicy_duplicate_resource,
-		"PutBucketPolicy_incorrect_bucket_name":                               PutBucketPolicy_incorrect_bucket_name,
-		"PutBucketPolicy_object_action_on_bucket_resource":                    PutBucketPolicy_object_action_on_bucket_resource,
-		"PutBucketPolicy_bucket_action_on_object_resource":                    PutBucketPolicy_bucket_action_on_object_resource,
-		"PutBucketPolicy_success":                                             PutBucketPolicy_success,
-		"GetBucketPolicy_non_existing_bucket":                                 GetBucketPolicy_non_existing_bucket,
-		"GetBucketPolicy_not_set":                                             GetBucketPolicy_not_set,
-		"GetBucketPolicy_success":                                             GetBucketPolicy_success,
-		"DeleteBucketPolicy_non_existing_bucket":                              DeleteBucketPolicy_non_existing_bucket,
-		"DeleteBucketPolicy_remove_before_setting":                            DeleteBucketPolicy_remove_before_setting,
-		"DeleteBucketPolicy_success":                                          DeleteBucketPolicy_success,
-		"PutObjectLockConfiguration_non_existing_bucket":                      PutObjectLockConfiguration_non_existing_bucket,
-		"PutObjectLockConfiguration_empty_config":                             PutObjectLockConfiguration_empty_config,
-		"PutObjectLockConfiguration_not_enabled_on_bucket_creation":           PutObjectLockConfiguration_not_enabled_on_bucket_creation,
-		"PutObjectLockConfiguration_invalid_status":                           PutObjectLockConfiguration_invalid_status,
-		"PutObjectLockConfiguration_invalid_mode":                             PutObjectLockConfiguration_invalid_mode,
-		"PutObjectLockConfiguration_both_years_and_days":                      PutObjectLockConfiguration_both_years_and_days,
-		"PutObjectLockConfiguration_invalid_years_days":                       PutObjectLockConfiguration_invalid_years_days,
-		"PutObjectLockConfiguration_success":                                  PutObjectLockConfiguration_success,
-		"GetObjectLockConfiguration_non_existing_bucket":                      GetObjectLockConfiguration_non_existing_bucket,
-		"GetObjectLockConfiguration_unset_config":                             GetObjectLockConfiguration_unset_config,
-		"GetObjectLockConfiguration_success":                                  GetObjectLockConfiguration_success,
-		"PutObjectRetention_non_existing_bucket":                              PutObjectRetention_non_existing_bucket,
-		"PutObjectRetention_non_existing_object":                              PutObjectRetention_non_existing_object,
-		"PutObjectRetention_unset_bucket_object_lock_config":                  PutObjectRetention_unset_bucket_object_lock_config,
-		"PutObjectRetention_disabled_bucket_object_lock_config":               PutObjectRetention_disabled_bucket_object_lock_config,
-		"PutObjectRetention_expired_retain_until_date":                        PutObjectRetention_expired_retain_until_date,
-		"PutObjectRetention_invalid_mode":                                     PutObjectRetention_invalid_mode,
-		"PutObjectRetention_overwrite_compliance_mode":                        PutObjectRetention_overwrite_compliance_mode,
-		"PutObjectRetention_overwrite_governance_without_bypass_specified":    PutObjectRetention_overwrite_governance_without_bypass_specified,
-		"PutObjectRetention_overwrite_governance_with_permission":             PutObjectRetention_overwrite_governance_with_permission,
-		"PutObjectRetention_success":                                          PutObjectRetention_success,
-		"GetObjectRetention_non_existing_bucket":                              GetObjectRetention_non_existing_bucket,
-		"GetObjectRetention_non_existing_object":                              GetObjectRetention_non_existing_object,
-		"GetObjectRetention_disabled_lock":                                    GetObjectRetention_disabled_lock,
-		"GetObjectRetention_unset_config":                                     GetObjectRetention_unset_config,
-		"GetObjectRetention_success":                                          GetObjectRetention_success,
-		"PutObjectLegalHold_non_existing_bucket":                              PutObjectLegalHold_non_existing_bucket,
-		"PutObjectLegalHold_non_existing_object":                              PutObjectLegalHold_non_existing_object,
-		"PutObjectLegalHold_invalid_body":                                     PutObjectLegalHold_invalid_body,
-		"PutObjectLegalHold_invalid_status":                                   PutObjectLegalHold_invalid_status,
-		"PutObjectLegalHold_unset_bucket_object_lock_config":                  PutObjectLegalHold_unset_bucket_object_lock_config,
-		"PutObjectLegalHold_disabled_bucket_object_lock_config":               PutObjectLegalHold_disabled_bucket_object_lock_config,
-		"PutObjectLegalHold_success":                                          PutObjectLegalHold_success,
-		"GetObjectLegalHold_non_existing_bucket":                              GetObjectLegalHold_non_existing_bucket,
-		"GetObjectLegalHold_non_existing_object":                              GetObjectLegalHold_non_existing_object,
-		"GetObjectLegalHold_disabled_lock":                                    GetObjectLegalHold_disabled_lock,
-		"GetObjectLegalHold_unset_config":                                     GetObjectLegalHold_unset_config,
-		"GetObjectLegalHold_success":                                          GetObjectLegalHold_success,
-		"WORMProtection_bucket_object_lock_configuration_compliance_mode":     WORMProtection_bucket_object_lock_configuration_compliance_mode,
-		"WORMProtection_bucket_object_lock_configuration_governance_mode":     WORMProtection_bucket_object_lock_configuration_governance_mode,
-		"WORMProtection_bucket_object_lock_governance_bypass_delete":          WORMProtection_bucket_object_lock_governance_bypass_delete,
-		"WORMProtection_bucket_object_lock_governance_bypass_delete_multiple": WORMProtection_bucket_object_lock_governance_bypass_delete_multiple,
-		"WORMProtection_object_lock_retention_compliance_locked":              WORMProtection_object_lock_retention_compliance_locked,
-		"WORMProtection_object_lock_retention_governance_locked":              WORMProtection_object_lock_retention_governance_locked,
-		"WORMProtection_object_lock_retention_governance_bypass_overwrite":    WORMProtection_object_lock_retention_governance_bypass_overwrite,
-		"WORMProtection_object_lock_retention_governance_bypass_delete":       WORMProtection_object_lock_retention_governance_bypass_delete,
-		"WORMProtection_object_lock_retention_governance_bypass_delete_mul":   WORMProtection_object_lock_retention_governance_bypass_delete_mul,
-		"WORMProtection_object_lock_legal_hold_locked":                        WORMProtection_object_lock_legal_hold_locked,
-		"WORMProtection_root_bypass_governance_retention_delete_object":       WORMProtection_root_bypass_governance_retention_delete_object,
-		"PutObject_overwrite_dir_obj":                                         PutObject_overwrite_dir_obj,
-		"PutObject_overwrite_file_obj":                                        PutObject_overwrite_file_obj,
-		"PutObject_overwrite_file_obj_with_nested_obj":                        PutObject_overwrite_file_obj_with_nested_obj,
-		"PutObject_dir_obj_with_data":                                         PutObject_dir_obj_with_data,
-		"CreateMultipartUpload_dir_obj":                                       CreateMultipartUpload_dir_obj,
-		"IAM_user_access_denied":                                              IAM_user_access_denied,
-		"IAM_userplus_access_denied":                                          IAM_userplus_access_denied,
-		"IAM_userplus_CreateBucket":                                           IAM_userplus_CreateBucket,
-		"IAM_admin_ChangeBucketOwner":                                         IAM_admin_ChangeBucketOwner,
-		"IAM_ChangeBucketOwner_back_to_root":                                  IAM_ChangeBucketOwner_back_to_root,
-		"AccessControl_default_ACL_user_access_denied":                        AccessControl_default_ACL_user_access_denied,
-		"AccessControl_default_ACL_userplus_access_denied":                    AccessControl_default_ACL_userplus_access_denied,
-		"AccessControl_default_ACL_admin_successful_access":                   AccessControl_default_ACL_admin_successful_access,
-		"AccessControl_bucket_resource_single_action":                         AccessControl_bucket_resource_single_action,
-		"AccessControl_bucket_resource_all_action":                            AccessControl_bucket_resource_all_action,
-		"AccessControl_single_object_resource_actions":                        AccessControl_single_object_resource_actions,
-		"AccessControl_multi_statement_policy":                                AccessControl_multi_statement_policy,
-		"AccessControl_bucket_ownership_to_user":                              AccessControl_bucket_ownership_to_user,
-		"AccessControl_root_PutBucketAcl":                                     AccessControl_root_PutBucketAcl,
-		"AccessControl_user_PutBucketAcl_with_policy_access":                  AccessControl_user_PutBucketAcl_with_policy_access,
-		"AccessControl_copy_object_with_starting_slash_for_user":              AccessControl_copy_object_with_starting_slash_for_user,
-		"PutBucketVersioning_non_existing_bucket":                             PutBucketVersioning_non_existing_bucket,
-		"PutBucketVersioning_invalid_status":                                  PutBucketVersioning_invalid_status,
-		"PutBucketVersioning_success_enabled":                                 PutBucketVersioning_success_enabled,
-		"PutBucketVersioning_success_suspended":                               PutBucketVersioning_success_suspended,
-		"GetBucketVersioning_non_existing_bucket":                             GetBucketVersioning_non_existing_bucket,
-		"GetBucketVersioning_empty_response":                                  GetBucketVersioning_empty_response,
-		"GetBucketVersioning_success":                                         GetBucketVersioning_success,
-		"Versioning_DeleteBucket_not_empty":                                   Versioning_DeleteBucket_not_empty,
-		"Versioning_PutObject_suspended_null_versionId_obj":                   Versioning_PutObject_suspended_null_versionId_obj,
-		"Versioning_PutObject_null_versionId_obj":                             Versioning_PutObject_null_versionId_obj,
-		"Versioning_PutObject_overwrite_null_versionId_obj":                   Versioning_PutObject_overwrite_null_versionId_obj,
-		"Versioning_PutObject_success":                                        Versioning_PutObject_success,
-		"Versioning_CopyObject_success":                                       Versioning_CopyObject_success,
-		"Versioning_CopyObject_non_existing_version_id":                       Versioning_CopyObject_non_existing_version_id,
-		"Versioning_CopyObject_from_an_object_version":                        Versioning_CopyObject_from_an_object_version,
-		"Versioning_CopyObject_special_chars":                                 Versioning_CopyObject_special_chars,
-		"Versioning_HeadObject_invalid_versionId":                             Versioning_HeadObject_invalid_versionId,
-		"Versioning_HeadObject_invalid_parent":                                Versioning_HeadObject_invalid_parent,
-		"Versioning_HeadObject_success":                                       Versioning_HeadObject_success,
-		"Versioning_HeadObject_without_versionId":                             Versioning_HeadObject_without_versionId,
-		"Versioning_HeadObject_delete_marker":                                 Versioning_HeadObject_delete_marker,
-		"Versioning_GetObject_invalid_versionId":                              Versioning_GetObject_invalid_versionId,
-		"Versioning_GetObject_success":                                        Versioning_GetObject_success,
-		"Versioning_GetObject_delete_marker_without_versionId":                Versioning_GetObject_delete_marker_without_versionId,
-		"Versioning_GetObject_delete_marker":                                  Versioning_GetObject_delete_marker,
-		"Versioning_GetObject_null_versionId_obj":                             Versioning_GetObject_null_versionId_obj,
-		"Versioning_GetObjectAttributes_object_version":                       Versioning_GetObjectAttributes_object_version,
-		"Versioning_GetObjectAttributes_delete_marker":                        Versioning_GetObjectAttributes_delete_marker,
-		"Versioning_DeleteObject_delete_object_version":                       Versioning_DeleteObject_delete_object_version,
-		"Versioning_DeleteObject_non_existing_object":                         Versioning_DeleteObject_non_existing_object,
-		"Versioning_DeleteObject_delete_a_delete_marker":                      Versioning_DeleteObject_delete_a_delete_marker,
-		"Versioning_Delete_null_versionId_object":                             Versioning_Delete_null_versionId_object,
-		"Versioning_DeleteObject_suspended":                                   Versioning_DeleteObject_suspended,
-		"Versioning_DeleteObjects_success":                                    Versioning_DeleteObjects_success,
-		"Versioning_DeleteObjects_delete_deleteMarkers":                       Versioning_DeleteObjects_delete_deleteMarkers,
-		"ListObjectVersions_non_existing_bucket":                              ListObjectVersions_non_existing_bucket,
-		"ListObjectVersions_list_single_object_versions":                      ListObjectVersions_list_single_object_versions,
-		"ListObjectVersions_list_multiple_object_versions":                    ListObjectVersions_list_multiple_object_versions,
-		"ListObjectVersions_multiple_object_versions_truncated":               ListObjectVersions_multiple_object_versions_truncated,
-		"ListObjectVersions_with_delete_markers":                              ListObjectVersions_with_delete_markers,
-		"ListObjectVersions_containing_null_versionId_obj":                    ListObjectVersions_containing_null_versionId_obj,
-		"ListObjectVersions_single_null_versionId_object":                     ListObjectVersions_single_null_versionId_object,
-		"Versioning_Multipart_Upload_success":                                 Versioning_Multipart_Upload_success,
-		"Versioning_Multipart_Upload_overwrite_an_object":                     Versioning_Multipart_Upload_overwrite_an_object,
-		"Versioning_UploadPartCopy_non_existing_versionId":                    Versioning_UploadPartCopy_non_existing_versionId,
-		"Versioning_UploadPartCopy_from_an_object_version":                    Versioning_UploadPartCopy_from_an_object_version,
-		"Versioning_Enable_object_lock":                                       Versioning_Enable_object_lock,
-		"Versioning_status_switch_to_suspended_with_object_lock":              Versioning_status_switch_to_suspended_with_object_lock,
-		"Versioning_PutObjectRetention_invalid_versionId":                     Versioning_PutObjectRetention_invalid_versionId,
-		"Versioning_GetObjectRetention_invalid_versionId":                     Versioning_GetObjectRetention_invalid_versionId,
-		"Versioning_Put_GetObjectRetention_success":                           Versioning_Put_GetObjectRetention_success,
-		"Versioning_PutObjectLegalHold_invalid_versionId":                     Versioning_PutObjectLegalHold_invalid_versionId,
-		"Versioning_GetObjectLegalHold_invalid_versionId":                     Versioning_GetObjectLegalHold_invalid_versionId,
-		"Versioning_Put_GetObjectLegalHold_success":                           Versioning_Put_GetObjectLegalHold_success,
-		"Versioning_WORM_obj_version_locked_with_legal_hold":                  Versioning_WORM_obj_version_locked_with_legal_hold,
-		"Versioning_WORM_obj_version_locked_with_governance_retention":        Versioning_WORM_obj_version_locked_with_governance_retention,
-		"Versioning_WORM_obj_version_locked_with_compliance_retention":        Versioning_WORM_obj_version_locked_with_compliance_retention,
-		"Versioning_concurrent_upload_object":                                 Versioning_concurrent_upload_object,
+		"Authentication_empty_auth_header":                                        Authentication_empty_auth_header,
+		"Authentication_invalid_auth_header":                                      Authentication_invalid_auth_header,
+		"Authentication_unsupported_signature_version":                            Authentication_unsupported_signature_version,
+		"Authentication_malformed_credentials":                                    Authentication_malformed_credentials,
+		"Authentication_malformed_credentials_invalid_parts":                      Authentication_malformed_credentials_invalid_parts,
+		"Authentication_credentials_terminated_string":                            Authentication_credentials_terminated_string,
+		"Authentication_credentials_incorrect_service":                            Authentication_credentials_incorrect_service,
+		"Authentication_credentials_incorrect_region":                             Authentication_credentials_incorrect_region,
+		"Authentication_credentials_invalid_date":                                 Authentication_credentials_invalid_date,
+		"Authentication_credentials_future_date":                                  Authentication_credentials_future_date,
+		"Authentication_credentials_past_date":                                    Authentication_credentials_past_date,
+		"Authentication_credentials_non_existing_access_key":                      Authentication_credentials_non_existing_access_key,
+		"Authentication_invalid_signed_headers":                                   Authentication_invalid_signed_headers,
+		"Authentication_missing_date_header":                                      Authentication_missing_date_header,
+		"Authentication_invalid_date_header":                                      Authentication_invalid_date_header,
+		"Authentication_date_mismatch":                                            Authentication_date_mismatch,
+		"Authentication_incorrect_payload_hash":                                   Authentication_incorrect_payload_hash,
+		"Authentication_incorrect_md5":                                            Authentication_incorrect_md5,
+		"Authentication_signature_error_incorrect_secret_key":                     Authentication_signature_error_incorrect_secret_key,
+		"PresignedAuth_missing_algo_query_param":                                  PresignedAuth_missing_algo_query_param,
+		"PresignedAuth_unsupported_algorithm":                                     PresignedAuth_unsupported_algorithm,
+		"PresignedAuth_missing_credentials_query_param":                           PresignedAuth_missing_credentials_query_param,
+		"PresignedAuth_malformed_creds_invalid_parts":                             PresignedAuth_malformed_creds_invalid_parts,
+		"PresignedAuth_creds_invalid_terminator":                                  PresignedAuth_creds_invalid_terminator,
+		"PresignedAuth_creds_incorrect_service":                                   PresignedAuth_creds_incorrect_service,
+		"PresignedAuth_creds_incorrect_region":                                    PresignedAuth_creds_incorrect_region,
+		"PresignedAuth_creds_invalid_date":                                        PresignedAuth_creds_invalid_date,
+		"PresignedAuth_missing_date_query":                                        PresignedAuth_missing_date_query,
+		"PresignedAuth_dates_mismatch":                                            PresignedAuth_dates_mismatch,
+		"PresignedAuth_non_existing_access_key_id":                                PresignedAuth_non_existing_access_key_id,
+		"PresignedAuth_missing_signed_headers_query_param":                        PresignedAuth_missing_signed_headers_query_param,
+		"PresignedAuth_missing_expiration_query_param":                            PresignedAuth_missing_expiration_query_param,
+		"PresignedAuth_invalid_expiration_query_param":                            PresignedAuth_invalid_expiration_query_param,
+		"PresignedAuth_negative_expiration_query_param":                           PresignedAuth_negative_expiration_query_param,
+		"PresignedAuth_exceeding_expiration_query_param":                          PresignedAuth_exceeding_expiration_query_param,
+		"PresignedAuth_expired_request":                                           PresignedAuth_expired_request,
+		"PresignedAuth_incorrect_secret_key":                                      PresignedAuth_incorrect_secret_key,
+		"PresignedAuth_PutObject_success":                                         PresignedAuth_PutObject_success,
+		"PutObject_missing_object_lock_retention_config":                          PutObject_missing_object_lock_retention_config,
+		"PutObject_name_too_long":                                                 PutObject_name_too_long,
+		"PutObject_with_object_lock":                                              PutObject_with_object_lock,
+		"PutObject_checksum_algorithm_and_header_mismatch":                        PutObject_checksum_algorithm_and_header_mismatch,
+		"PutObject_multiple_checksum_headers":                                     PutObject_multiple_checksum_headers,
+		"PutObject_invalid_checksum_header":                                       PutObject_invalid_checksum_header,
+		"PutObject_incorrect_checksums":                                           PutObject_incorrect_checksums,
+		"PutObject_checksums_success":                                             PutObject_checksums_success,
+		"PresignedAuth_Put_GetObject_with_data":                                   PresignedAuth_Put_GetObject_with_data,
+		"PresignedAuth_Put_GetObject_with_UTF8_chars":                             PresignedAuth_Put_GetObject_with_UTF8_chars,
+		"PresignedAuth_UploadPart":                                                PresignedAuth_UploadPart,
+		"CreateBucket_invalid_bucket_name":                                        CreateBucket_invalid_bucket_name,
+		"CreateBucket_existing_bucket":                                            CreateBucket_existing_bucket,
+		"CreateBucket_owned_by_you":                                               CreateBucket_owned_by_you,
+		"CreateBucket_invalid_ownership":                                          CreateBucket_invalid_ownership,
+		"CreateBucket_ownership_with_acl":                                         CreateBucket_ownership_with_acl,
+		"CreateBucket_as_user":                                                    CreateBucket_as_user,
+		"CreateDeleteBucket_success":                                              CreateDeleteBucket_success,
+		"CreateBucket_default_acl":                                                CreateBucket_default_acl,
+		"CreateBucket_non_default_acl":                                            CreateBucket_non_default_acl,
+		"CreateBucket_default_object_lock":                                        CreateBucket_default_object_lock,
+		"HeadBucket_non_existing_bucket":                                          HeadBucket_non_existing_bucket,
+		"HeadBucket_success":                                                      HeadBucket_success,
+		"ListBuckets_as_user":                                                     ListBuckets_as_user,
+		"ListBuckets_as_admin":                                                    ListBuckets_as_admin,
+		"ListBuckets_with_prefix":                                                 ListBuckets_with_prefix,
+		"ListBuckets_invalid_max_buckets":                                         ListBuckets_invalid_max_buckets,
+		"ListBuckets_truncated":                                                   ListBuckets_truncated,
+		"ListBuckets_success":                                                     ListBuckets_success,
+		"DeleteBucket_non_existing_bucket":                                        DeleteBucket_non_existing_bucket,
+		"DeleteBucket_non_empty_bucket":                                           DeleteBucket_non_empty_bucket,
+		"DeleteBucket_success_status_code":                                        DeleteBucket_success_status_code,
+		"PutBucketOwnershipControls_non_existing_bucket":                          PutBucketOwnershipControls_non_existing_bucket,
+		"PutBucketOwnershipControls_multiple_rules":                               PutBucketOwnershipControls_multiple_rules,
+		"PutBucketOwnershipControls_invalid_ownership":                            PutBucketOwnershipControls_invalid_ownership,
+		"PutBucketOwnershipControls_success":                                      PutBucketOwnershipControls_success,
+		"GetBucketOwnershipControls_non_existing_bucket":                          GetBucketOwnershipControls_non_existing_bucket,
+		"GetBucketOwnershipControls_default_ownership":                            GetBucketOwnershipControls_default_ownership,
+		"GetBucketOwnershipControls_success":                                      GetBucketOwnershipControls_success,
+		"DeleteBucketOwnershipControls_non_existing_bucket":                       DeleteBucketOwnershipControls_non_existing_bucket,
+		"DeleteBucketOwnershipControls_success":                                   DeleteBucketOwnershipControls_success,
+		"PutBucketTagging_non_existing_bucket":                                    PutBucketTagging_non_existing_bucket,
+		"PutBucketTagging_long_tags":                                              PutBucketTagging_long_tags,
+		"PutBucketTagging_success":                                                PutBucketTagging_success,
+		"PutBucketTagging_success_status":                                         PutBucketTagging_success_status,
+		"GetBucketTagging_non_existing_bucket":                                    GetBucketTagging_non_existing_bucket,
+		"GetBucketTagging_unset_tags":                                             GetBucketTagging_unset_tags,
+		"GetBucketTagging_success":                                                GetBucketTagging_success,
+		"DeleteBucketTagging_non_existing_object":                                 DeleteBucketTagging_non_existing_object,
+		"DeleteBucketTagging_success_status":                                      DeleteBucketTagging_success_status,
+		"DeleteBucketTagging_success":                                             DeleteBucketTagging_success,
+		"PutObject_non_existing_bucket":                                           PutObject_non_existing_bucket,
+		"PutObject_special_chars":                                                 PutObject_special_chars,
+		"PutObject_invalid_long_tags":                                             PutObject_invalid_long_tags,
+		"PutObject_success":                                                       PutObject_success,
+		"PutObject_racey_success":                                                 PutObject_racey_success,
+		"HeadObject_non_existing_object":                                          HeadObject_non_existing_object,
+		"HeadObject_invalid_part_number":                                          HeadObject_invalid_part_number,
+		"HeadObject_non_existing_mp":                                              HeadObject_non_existing_mp,
+		"HeadObject_mp_success":                                                   HeadObject_mp_success,
+		"HeadObject_directory_object_noslash":                                     HeadObject_directory_object_noslash,
+		"HeadObject_non_existing_dir_object":                                      HeadObject_non_existing_dir_object,
+		"HeadObject_name_too_long":                                                HeadObject_name_too_long,
+		"HeadObject_with_contenttype":                                             HeadObject_with_contenttype,
+		"HeadObject_invalid_parent_dir":                                           HeadObject_invalid_parent_dir,
+		"HeadObject_not_enabled_checksum_mode":                                    HeadObject_not_enabled_checksum_mode,
+		"HeadObject_checksums":                                                    HeadObject_checksums,
+		"HeadObject_success":                                                      HeadObject_success,
+		"GetObjectAttributes_non_existing_bucket":                                 GetObjectAttributes_non_existing_bucket,
+		"GetObjectAttributes_non_existing_object":                                 GetObjectAttributes_non_existing_object,
+		"GetObjectAttributes_invalid_attrs":                                       GetObjectAttributes_invalid_attrs,
+		"GetObjectAttributes_invalid_parent":                                      GetObjectAttributes_invalid_parent,
+		"GetObjectAttributes_empty_attrs":                                         GetObjectAttributes_empty_attrs,
+		"GetObjectAttributes_existing_object":                                     GetObjectAttributes_existing_object,
+		"GetObjectAttributes_checksums":                                           GetObjectAttributes_checksums,
+		"GetObject_non_existing_key":                                              GetObject_non_existing_key,
+		"GetObject_directory_object_noslash":                                      GetObject_directory_object_noslash,
+		"GetObject_invalid_ranges":                                                GetObject_invalid_ranges,
+		"GetObject_invalid_parent":                                                GetObject_invalid_parent,
+		"GetObject_with_meta":                                                     GetObject_with_meta,
+		"GetObject_large_object":                                                  GetObject_large_object,
+		"GetObject_checksums":                                                     GetObject_checksums,
+		"GetObject_success":                                                       GetObject_success,
+		"GetObject_directory_success":                                             GetObject_directory_success,
+		"GetObject_by_range_success":                                              GetObject_by_range_success,
+		"GetObject_by_range_resp_status":                                          GetObject_by_range_resp_status,
+		"GetObject_non_existing_dir_object":                                       GetObject_non_existing_dir_object,
+		"ListObjects_non_existing_bucket":                                         ListObjects_non_existing_bucket,
+		"ListObjects_with_prefix":                                                 ListObjects_with_prefix,
+		"ListObjects_truncated":                                                   ListObjects_truncated,
+		"ListObjects_paginated":                                                   ListObjects_paginated,
+		"ListObjects_invalid_max_keys":                                            ListObjects_invalid_max_keys,
+		"ListObjects_max_keys_0":                                                  ListObjects_max_keys_0,
+		"ListObjects_delimiter":                                                   ListObjects_delimiter,
+		"ListObjects_max_keys_none":                                               ListObjects_max_keys_none,
+		"ListObjects_marker_not_from_obj_list":                                    ListObjects_marker_not_from_obj_list,
+		"ListObjects_list_all_objs":                                               ListObjects_list_all_objs,
+		"ListObjects_with_checksum":                                               ListObjects_with_checksum,
+		"ListObjectsV2_start_after":                                               ListObjectsV2_start_after,
+		"ListObjectsV2_both_start_after_and_continuation_token":                   ListObjectsV2_both_start_after_and_continuation_token,
+		"ListObjectsV2_start_after_not_in_list":                                   ListObjectsV2_start_after_not_in_list,
+		"ListObjectsV2_start_after_empty_result":                                  ListObjectsV2_start_after_empty_result,
+		"ListObjectsV2_both_delimiter_and_prefix":                                 ListObjectsV2_both_delimiter_and_prefix,
+		"ListObjectsV2_single_dir_object_with_delim_and_prefix":                   ListObjectsV2_single_dir_object_with_delim_and_prefix,
+		"ListObjectsV2_truncated_common_prefixes":                                 ListObjectsV2_truncated_common_prefixes,
+		"ListObjectsV2_all_objs_max_keys":                                         ListObjectsV2_all_objs_max_keys,
+		"ListObjectsV2_list_all_objs":                                             ListObjectsV2_list_all_objs,
+		"ListObjectsV2_with_checksum":                                             ListObjectsV2_with_checksum,
+		"ListObjectVersions_VD_success":                                           ListObjectVersions_VD_success,
+		"DeleteObject_non_existing_object":                                        DeleteObject_non_existing_object,
+		"DeleteObject_directory_object_noslash":                                   DeleteObject_directory_object_noslash,
+		"DeleteObject_name_too_long":                                              DeleteObject_name_too_long,
+		"DeleteObject_non_existing_dir_object":                                    DeleteObject_non_existing_dir_object,
+		"DeleteObject_success":                                                    DeleteObject_success,
+		"DeleteObject_success_status_code":                                        DeleteObject_success_status_code,
+		"DeleteObjects_empty_input":                                               DeleteObjects_empty_input,
+		"DeleteObjects_non_existing_objects":                                      DeleteObjects_non_existing_objects,
+		"DeleteObjects_success":                                                   DeleteObjects_success,
+		"CopyObject_non_existing_dst_bucket":                                      CopyObject_non_existing_dst_bucket,
+		"CopyObject_not_owned_source_bucket":                                      CopyObject_not_owned_source_bucket,
+		"CopyObject_copy_to_itself":                                               CopyObject_copy_to_itself,
+		"CopyObject_copy_to_itself_invalid_directive":                             CopyObject_copy_to_itself_invalid_directive,
+		"CopyObject_to_itself_with_new_metadata":                                  CopyObject_to_itself_with_new_metadata,
+		"CopyObject_CopySource_starting_with_slash":                               CopyObject_CopySource_starting_with_slash,
+		"CopyObject_non_existing_dir_object":                                      CopyObject_non_existing_dir_object,
+		"CopyObject_invalid_checksum_algorithm":                                   CopyObject_invalid_checksum_algorithm,
+		"CopyObject_create_checksum_on_copy":                                      CopyObject_create_checksum_on_copy,
+		"CopyObject_should_copy_the_existing_checksum":                            CopyObject_should_copy_the_existing_checksum,
+		"CopyObject_should_replace_the_existing_checksum":                         CopyObject_should_replace_the_existing_checksum,
+		"CopyObject_to_itself_by_replacing_the_checksum":                          CopyObject_to_itself_by_replacing_the_checksum,
+		"CopyObject_success":                                                      CopyObject_success,
+		"PutObjectTagging_non_existing_object":                                    PutObjectTagging_non_existing_object,
+		"PutObjectTagging_long_tags":                                              PutObjectTagging_long_tags,
+		"PutObjectTagging_success":                                                PutObjectTagging_success,
+		"GetObjectTagging_non_existing_object":                                    GetObjectTagging_non_existing_object,
+		"GetObjectTagging_unset_tags":                                             GetObjectTagging_unset_tags,
+		"GetObjectTagging_invalid_parent":                                         GetObjectTagging_invalid_parent,
+		"GetObjectTagging_success":                                                GetObjectTagging_success,
+		"DeleteObjectTagging_non_existing_object":                                 DeleteObjectTagging_non_existing_object,
+		"DeleteObjectTagging_success_status":                                      DeleteObjectTagging_success_status,
+		"DeleteObjectTagging_success":                                             DeleteObjectTagging_success,
+		"CreateMultipartUpload_non_existing_bucket":                               CreateMultipartUpload_non_existing_bucket,
+		"CreateMultipartUpload_with_metadata":                                     CreateMultipartUpload_with_metadata,
+		"CreateMultipartUpload_with_invalid_tagging":                              CreateMultipartUpload_with_invalid_tagging,
+		"CreateMultipartUpload_with_tagging":                                      CreateMultipartUpload_with_tagging,
+		"CreateMultipartUpload_with_content_type":                                 CreateMultipartUpload_with_content_type,
+		"CreateMultipartUpload_with_object_lock":                                  CreateMultipartUpload_with_object_lock,
+		"CreateMultipartUpload_with_object_lock_not_enabled":                      CreateMultipartUpload_with_object_lock_not_enabled,
+		"CreateMultipartUpload_with_object_lock_invalid_retention":                CreateMultipartUpload_with_object_lock_invalid_retention,
+		"CreateMultipartUpload_past_retain_until_date":                            CreateMultipartUpload_past_retain_until_date,
+		"CreateMultipartUpload_invalid_checksum_algorithm":                        CreateMultipartUpload_invalid_checksum_algorithm,
+		"CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type":       CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type,
+		"CreateMultipartUpload_invalid_checksum_type":                             CreateMultipartUpload_invalid_checksum_type,
+		"CreateMultipartUpload_valid_checksum_algorithm":                          CreateMultipartUpload_valid_checksum_algorithm,
+		"CreateMultipartUpload_success":                                           CreateMultipartUpload_success,
+		"UploadPart_non_existing_bucket":                                          UploadPart_non_existing_bucket,
+		"UploadPart_invalid_part_number":                                          UploadPart_invalid_part_number,
+		"UploadPart_non_existing_key":                                             UploadPart_non_existing_key,
+		"UploadPart_non_existing_mp_upload":                                       UploadPart_non_existing_mp_upload,
+		"UploadPart_checksum_algorithm_and_header_mismatch":                       UploadPart_checksum_algorithm_and_header_mismatch,
+		"UploadPart_multiple_checksum_headers":                                    UploadPart_multiple_checksum_headers,
+		"UploadPart_invalid_checksum_header":                                      UploadPart_invalid_checksum_header,
+		"UploadPart_checksum_algorithm_mistmatch_on_initialization":               UploadPart_checksum_algorithm_mistmatch_on_initialization,
+		"UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value":    UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value,
+		"UploadPart_incorrect_checksums":                                          UploadPart_incorrect_checksums,
+		"UploadPart_with_checksums_success":                                       UploadPart_with_checksums_success,
+		"UploadPart_success":                                                      UploadPart_success,
+		"UploadPartCopy_non_existing_bucket":                                      UploadPartCopy_non_existing_bucket,
+		"UploadPartCopy_incorrect_uploadId":                                       UploadPartCopy_incorrect_uploadId,
+		"UploadPartCopy_incorrect_object_key":                                     UploadPartCopy_incorrect_object_key,
+		"UploadPartCopy_invalid_part_number":                                      UploadPartCopy_invalid_part_number,
+		"UploadPartCopy_invalid_copy_source":                                      UploadPartCopy_invalid_copy_source,
+		"UploadPartCopy_non_existing_source_bucket":                               UploadPartCopy_non_existing_source_bucket,
+		"UploadPartCopy_non_existing_source_object_key":                           UploadPartCopy_non_existing_source_object_key,
+		"UploadPartCopy_success":                                                  UploadPartCopy_success,
+		"UploadPartCopy_by_range_invalid_range":                                   UploadPartCopy_by_range_invalid_range,
+		"UploadPartCopy_greater_range_than_obj_size":                              UploadPartCopy_greater_range_than_obj_size,
+		"UploadPartCopy_by_range_success":                                         UploadPartCopy_by_range_success,
+		"UploadPartCopy_should_copy_the_checksum":                                 UploadPartCopy_should_copy_the_checksum,
+		"UploadPartCopy_should_not_copy_the_checksum":                             UploadPartCopy_should_not_copy_the_checksum,
+		"UploadPartCopy_should_calculate_the_checksum":                            UploadPartCopy_should_calculate_the_checksum,
+		"ListParts_incorrect_uploadId":                                            ListParts_incorrect_uploadId,
+		"ListParts_incorrect_object_key":                                          ListParts_incorrect_object_key,
+		"ListParts_invalid_max_parts":                                             ListParts_invalid_max_parts,
+		"ListParts_default_max_parts":                                             ListParts_default_max_parts,
+		"ListParts_truncated":                                                     ListParts_truncated,
+		"ListParts_with_checksums":                                                ListParts_with_checksums,
+		"ListParts_success":                                                       ListParts_success,
+		"ListMultipartUploads_non_existing_bucket":                                ListMultipartUploads_non_existing_bucket,
+		"ListMultipartUploads_empty_result":                                       ListMultipartUploads_empty_result,
+		"ListMultipartUploads_invalid_max_uploads":                                ListMultipartUploads_invalid_max_uploads,
+		"ListMultipartUploads_max_uploads":                                        ListMultipartUploads_max_uploads,
+		"ListMultipartUploads_incorrect_next_key_marker":                          ListMultipartUploads_incorrect_next_key_marker,
+		"ListMultipartUploads_ignore_upload_id_marker":                            ListMultipartUploads_ignore_upload_id_marker,
+		"ListMultipartUploads_with_checksums":                                     ListMultipartUploads_with_checksums,
+		"ListMultipartUploads_success":                                            ListMultipartUploads_success,
+		"AbortMultipartUpload_non_existing_bucket":                                AbortMultipartUpload_non_existing_bucket,
+		"AbortMultipartUpload_incorrect_uploadId":                                 AbortMultipartUpload_incorrect_uploadId,
+		"AbortMultipartUpload_incorrect_object_key":                               AbortMultipartUpload_incorrect_object_key,
+		"AbortMultipartUpload_success":                                            AbortMultipartUpload_success,
+		"AbortMultipartUpload_success_status_code":                                AbortMultipartUpload_success_status_code,
+		"CompletedMultipartUpload_non_existing_bucket":                            CompletedMultipartUpload_non_existing_bucket,
+		"CompleteMultipartUpload_invalid_part_number":                             CompleteMultipartUpload_invalid_part_number,
+		"CompleteMultipartUpload_invalid_ETag":                                    CompleteMultipartUpload_invalid_ETag,
+		"CompleteMultipartUpload_invalid_checksum_type":                           CompleteMultipartUpload_invalid_checksum_type,
+		"CompleteMultipartUpload_invalid_checksum_part":                           CompleteMultipartUpload_invalid_checksum_part,
+		"CompleteMultipartUpload_multiple_checksum_part":                          CompleteMultipartUpload_multiple_checksum_part,
+		"CompleteMultipartUpload_incorrect_checksum_part":                         CompleteMultipartUpload_incorrect_checksum_part,
+		"CompleteMultipartUpload_different_checksum_part":                         CompleteMultipartUpload_different_checksum_part,
+		"CompleteMultipartUpload_missing_part_checksum":                           CompleteMultipartUpload_missing_part_checksum,
+		"CompleteMultipartUpload_multiple_final_checksums":                        CompleteMultipartUpload_multiple_final_checksums,
+		"CompleteMultipartUpload_invalid_final_checksums":                         CompleteMultipartUpload_invalid_final_checksums,
+		"CompleteMultipartUpload_incorrect_final_checksums":                       CompleteMultipartUpload_incorrect_final_checksums,
+		"CompleteMultipartUpload_should_calculate_the_final_checksum_full_object": CompleteMultipartUpload_should_calculate_the_final_checksum_full_object,
+		"CompleteMultipartUpload_should_verify_the_final_checksum":                CompleteMultipartUpload_should_verify_the_final_checksum,
+		"CompleteMultipartUpload_checksum_type_mismatch":                          CompleteMultipartUpload_checksum_type_mismatch,
+		"CompleteMultipartUpload_should_ignore_the_final_checksum":                CompleteMultipartUpload_should_ignore_the_final_checksum,
+		"CompleteMultipartUpload_success":                                         CompleteMultipartUpload_success,
+		"CompleteMultipartUpload_racey_success":                                   CompleteMultipartUpload_racey_success,
+		"PutBucketAcl_non_existing_bucket":                                        PutBucketAcl_non_existing_bucket,
+		"PutBucketAcl_disabled":                                                   PutBucketAcl_disabled,
+		"PutBucketAcl_none_of_the_options_specified":                              PutBucketAcl_none_of_the_options_specified,
+		"PutBucketAcl_invalid_acl_canned_and_acp":                                 PutBucketAcl_invalid_acl_canned_and_acp,
+		"PutBucketAcl_invalid_acl_canned_and_grants":                              PutBucketAcl_invalid_acl_canned_and_grants,
+		"PutBucketAcl_invalid_acl_acp_and_grants":                                 PutBucketAcl_invalid_acl_acp_and_grants,
+		"PutBucketAcl_invalid_owner":                                              PutBucketAcl_invalid_owner,
+		"PutBucketAcl_invalid_owner_not_in_body":                                  PutBucketAcl_invalid_owner_not_in_body,
+		"PutBucketAcl_invalid_empty_owner_id_in_body":                             PutBucketAcl_invalid_empty_owner_id_in_body,
+		"PutBucketAcl_invalid_permission_in_body":                                 PutBucketAcl_invalid_permission_in_body,
+		"PutBucketAcl_invalid_grantee_type_in_body":                               PutBucketAcl_invalid_grantee_type_in_body,
+		"PutBucketAcl_empty_grantee_ID_in_body":                                   PutBucketAcl_empty_grantee_ID_in_body,
+		"PutBucketAcl_success_access_denied":                                      PutBucketAcl_success_access_denied,
+		"PutBucketAcl_success_grants":                                             PutBucketAcl_success_grants,
+		"PutBucketAcl_success_canned_acl":                                         PutBucketAcl_success_canned_acl,
+		"PutBucketAcl_success_acp":                                                PutBucketAcl_success_acp,
+		"GetBucketAcl_non_existing_bucket":                                        GetBucketAcl_non_existing_bucket,
+		"GetBucketAcl_translation_canned_public_read":                             GetBucketAcl_translation_canned_public_read,
+		"GetBucketAcl_translation_canned_public_read_write":                       GetBucketAcl_translation_canned_public_read_write,
+		"GetBucketAcl_translation_canned_private":                                 GetBucketAcl_translation_canned_private,
+		"GetBucketAcl_access_denied":                                              GetBucketAcl_access_denied,
+		"GetBucketAcl_success":                                                    GetBucketAcl_success,
+		"PutBucketPolicy_non_existing_bucket":                                     PutBucketPolicy_non_existing_bucket,
+		"PutBucketPolicy_empty_statement":                                         PutBucketPolicy_empty_statement,
+		"PutBucketPolicy_invalid_effect":                                          PutBucketPolicy_invalid_effect,
+		"PutBucketPolicy_empty_actions_string":                                    PutBucketPolicy_empty_actions_string,
+		"PutBucketPolicy_empty_actions_array":                                     PutBucketPolicy_empty_actions_array,
+		"PutBucketPolicy_invalid_action":                                          PutBucketPolicy_invalid_action,
+		"PutBucketPolicy_unsupported_action":                                      PutBucketPolicy_unsupported_action,
+		"PutBucketPolicy_incorrect_action_wildcard_usage":                         PutBucketPolicy_incorrect_action_wildcard_usage,
+		"PutBucketPolicy_empty_principals_string":                                 PutBucketPolicy_empty_principals_string,
+		"PutBucketPolicy_empty_principals_array":                                  PutBucketPolicy_empty_principals_array,
+		"PutBucketPolicy_principals_aws_struct_empty_string":                      PutBucketPolicy_principals_aws_struct_empty_string,
+		"PutBucketPolicy_principals_aws_struct_empty_string_slice":                PutBucketPolicy_principals_aws_struct_empty_string_slice,
+		"PutBucketPolicy_principals_incorrect_wildcard_usage":                     PutBucketPolicy_principals_incorrect_wildcard_usage,
+		"PutBucketPolicy_non_existing_principals":                                 PutBucketPolicy_non_existing_principals,
+		"PutBucketPolicy_empty_resources_string":                                  PutBucketPolicy_empty_resources_string,
+		"PutBucketPolicy_empty_resources_array":                                   PutBucketPolicy_empty_resources_array,
+		"PutBucketPolicy_invalid_resource_prefix":                                 PutBucketPolicy_invalid_resource_prefix,
+		"PutBucketPolicy_invalid_resource_with_starting_slash":                    PutBucketPolicy_invalid_resource_with_starting_slash,
+		"PutBucketPolicy_duplicate_resource":                                      PutBucketPolicy_duplicate_resource,
+		"PutBucketPolicy_incorrect_bucket_name":                                   PutBucketPolicy_incorrect_bucket_name,
+		"PutBucketPolicy_object_action_on_bucket_resource":                        PutBucketPolicy_object_action_on_bucket_resource,
+		"PutBucketPolicy_bucket_action_on_object_resource":                        PutBucketPolicy_bucket_action_on_object_resource,
+		"PutBucketPolicy_success":                                                 PutBucketPolicy_success,
+		"GetBucketPolicy_non_existing_bucket":                                     GetBucketPolicy_non_existing_bucket,
+		"GetBucketPolicy_not_set":                                                 GetBucketPolicy_not_set,
+		"GetBucketPolicy_success":                                                 GetBucketPolicy_success,
+		"DeleteBucketPolicy_non_existing_bucket":                                  DeleteBucketPolicy_non_existing_bucket,
+		"DeleteBucketPolicy_remove_before_setting":                                DeleteBucketPolicy_remove_before_setting,
+		"DeleteBucketPolicy_success":                                              DeleteBucketPolicy_success,
+		"PutObjectLockConfiguration_non_existing_bucket":                          PutObjectLockConfiguration_non_existing_bucket,
+		"PutObjectLockConfiguration_empty_config":                                 PutObjectLockConfiguration_empty_config,
+		"PutObjectLockConfiguration_not_enabled_on_bucket_creation":               PutObjectLockConfiguration_not_enabled_on_bucket_creation,
+		"PutObjectLockConfiguration_invalid_status":                               PutObjectLockConfiguration_invalid_status,
+		"PutObjectLockConfiguration_invalid_mode":                                 PutObjectLockConfiguration_invalid_mode,
+		"PutObjectLockConfiguration_both_years_and_days":                          PutObjectLockConfiguration_both_years_and_days,
+		"PutObjectLockConfiguration_invalid_years_days":                           PutObjectLockConfiguration_invalid_years_days,
+		"PutObjectLockConfiguration_success":                                      PutObjectLockConfiguration_success,
+		"GetObjectLockConfiguration_non_existing_bucket":                          GetObjectLockConfiguration_non_existing_bucket,
+		"GetObjectLockConfiguration_unset_config":                                 GetObjectLockConfiguration_unset_config,
+		"GetObjectLockConfiguration_success":                                      GetObjectLockConfiguration_success,
+		"PutObjectRetention_non_existing_bucket":                                  PutObjectRetention_non_existing_bucket,
+		"PutObjectRetention_non_existing_object":                                  PutObjectRetention_non_existing_object,
+		"PutObjectRetention_unset_bucket_object_lock_config":                      PutObjectRetention_unset_bucket_object_lock_config,
+		"PutObjectRetention_disabled_bucket_object_lock_config":                   PutObjectRetention_disabled_bucket_object_lock_config,
+		"PutObjectRetention_expired_retain_until_date":                            PutObjectRetention_expired_retain_until_date,
+		"PutObjectRetention_invalid_mode":                                         PutObjectRetention_invalid_mode,
+		"PutObjectRetention_overwrite_compliance_mode":                            PutObjectRetention_overwrite_compliance_mode,
+		"PutObjectRetention_overwrite_governance_without_bypass_specified":        PutObjectRetention_overwrite_governance_without_bypass_specified,
+		"PutObjectRetention_overwrite_governance_with_permission":                 PutObjectRetention_overwrite_governance_with_permission,
+		"PutObjectRetention_success":                                              PutObjectRetention_success,
+		"GetObjectRetention_non_existing_bucket":                                  GetObjectRetention_non_existing_bucket,
+		"GetObjectRetention_non_existing_object":                                  GetObjectRetention_non_existing_object,
+		"GetObjectRetention_disabled_lock":                                        GetObjectRetention_disabled_lock,
+		"GetObjectRetention_unset_config":                                         GetObjectRetention_unset_config,
+		"GetObjectRetention_success":                                              GetObjectRetention_success,
+		"PutObjectLegalHold_non_existing_bucket":                                  PutObjectLegalHold_non_existing_bucket,
+		"PutObjectLegalHold_non_existing_object":                                  PutObjectLegalHold_non_existing_object,
+		"PutObjectLegalHold_invalid_body":                                         PutObjectLegalHold_invalid_body,
+		"PutObjectLegalHold_invalid_status":                                       PutObjectLegalHold_invalid_status,
+		"PutObjectLegalHold_unset_bucket_object_lock_config":                      PutObjectLegalHold_unset_bucket_object_lock_config,
+		"PutObjectLegalHold_disabled_bucket_object_lock_config":                   PutObjectLegalHold_disabled_bucket_object_lock_config,
+		"PutObjectLegalHold_success":                                              PutObjectLegalHold_success,
+		"GetObjectLegalHold_non_existing_bucket":                                  GetObjectLegalHold_non_existing_bucket,
+		"GetObjectLegalHold_non_existing_object":                                  GetObjectLegalHold_non_existing_object,
+		"GetObjectLegalHold_disabled_lock":                                        GetObjectLegalHold_disabled_lock,
+		"GetObjectLegalHold_unset_config":                                         GetObjectLegalHold_unset_config,
+		"GetObjectLegalHold_success":                                              GetObjectLegalHold_success,
+		"WORMProtection_bucket_object_lock_configuration_compliance_mode":         WORMProtection_bucket_object_lock_configuration_compliance_mode,
+		"WORMProtection_bucket_object_lock_configuration_governance_mode":         WORMProtection_bucket_object_lock_configuration_governance_mode,
+		"WORMProtection_bucket_object_lock_governance_bypass_delete":              WORMProtection_bucket_object_lock_governance_bypass_delete,
+		"WORMProtection_bucket_object_lock_governance_bypass_delete_multiple":     WORMProtection_bucket_object_lock_governance_bypass_delete_multiple,
+		"WORMProtection_object_lock_retention_compliance_locked":                  WORMProtection_object_lock_retention_compliance_locked,
+		"WORMProtection_object_lock_retention_governance_locked":                  WORMProtection_object_lock_retention_governance_locked,
+		"WORMProtection_object_lock_retention_governance_bypass_overwrite":        WORMProtection_object_lock_retention_governance_bypass_overwrite,
+		"WORMProtection_object_lock_retention_governance_bypass_delete":           WORMProtection_object_lock_retention_governance_bypass_delete,
+		"WORMProtection_object_lock_retention_governance_bypass_delete_mul":       WORMProtection_object_lock_retention_governance_bypass_delete_mul,
+		"WORMProtection_object_lock_legal_hold_locked":                            WORMProtection_object_lock_legal_hold_locked,
+		"WORMProtection_root_bypass_governance_retention_delete_object":           WORMProtection_root_bypass_governance_retention_delete_object,
+		"PutObject_overwrite_dir_obj":                                             PutObject_overwrite_dir_obj,
+		"PutObject_overwrite_file_obj":                                            PutObject_overwrite_file_obj,
+		"PutObject_overwrite_file_obj_with_nested_obj":                            PutObject_overwrite_file_obj_with_nested_obj,
+		"PutObject_dir_obj_with_data":                                             PutObject_dir_obj_with_data,
+		"CreateMultipartUpload_dir_obj":                                           CreateMultipartUpload_dir_obj,
+		"IAM_user_access_denied":                                                  IAM_user_access_denied,
+		"IAM_userplus_access_denied":                                              IAM_userplus_access_denied,
+		"IAM_userplus_CreateBucket":                                               IAM_userplus_CreateBucket,
+		"IAM_admin_ChangeBucketOwner":                                             IAM_admin_ChangeBucketOwner,
+		"IAM_ChangeBucketOwner_back_to_root":                                      IAM_ChangeBucketOwner_back_to_root,
+		"AccessControl_default_ACL_user_access_denied":                            AccessControl_default_ACL_user_access_denied,
+		"AccessControl_default_ACL_userplus_access_denied":                        AccessControl_default_ACL_userplus_access_denied,
+		"AccessControl_default_ACL_admin_successful_access":                       AccessControl_default_ACL_admin_successful_access,
+		"AccessControl_bucket_resource_single_action":                             AccessControl_bucket_resource_single_action,
+		"AccessControl_bucket_resource_all_action":                                AccessControl_bucket_resource_all_action,
+		"AccessControl_single_object_resource_actions":                            AccessControl_single_object_resource_actions,
+		"AccessControl_multi_statement_policy":                                    AccessControl_multi_statement_policy,
+		"AccessControl_bucket_ownership_to_user":                                  AccessControl_bucket_ownership_to_user,
+		"AccessControl_root_PutBucketAcl":                                         AccessControl_root_PutBucketAcl,
+		"AccessControl_user_PutBucketAcl_with_policy_access":                      AccessControl_user_PutBucketAcl_with_policy_access,
+		"AccessControl_copy_object_with_starting_slash_for_user":                  AccessControl_copy_object_with_starting_slash_for_user,
+		"PutBucketVersioning_non_existing_bucket":                                 PutBucketVersioning_non_existing_bucket,
+		"PutBucketVersioning_invalid_status":                                      PutBucketVersioning_invalid_status,
+		"PutBucketVersioning_success_enabled":                                     PutBucketVersioning_success_enabled,
+		"PutBucketVersioning_success_suspended":                                   PutBucketVersioning_success_suspended,
+		"GetBucketVersioning_non_existing_bucket":                                 GetBucketVersioning_non_existing_bucket,
+		"GetBucketVersioning_empty_response":                                      GetBucketVersioning_empty_response,
+		"GetBucketVersioning_success":                                             GetBucketVersioning_success,
+		"Versioning_DeleteBucket_not_empty":                                       Versioning_DeleteBucket_not_empty,
+		"Versioning_PutObject_suspended_null_versionId_obj":                       Versioning_PutObject_suspended_null_versionId_obj,
+		"Versioning_PutObject_null_versionId_obj":                                 Versioning_PutObject_null_versionId_obj,
+		"Versioning_PutObject_overwrite_null_versionId_obj":                       Versioning_PutObject_overwrite_null_versionId_obj,
+		"Versioning_PutObject_success":                                            Versioning_PutObject_success,
+		"Versioning_CopyObject_success":                                           Versioning_CopyObject_success,
+		"Versioning_CopyObject_non_existing_version_id":                           Versioning_CopyObject_non_existing_version_id,
+		"Versioning_CopyObject_from_an_object_version":                            Versioning_CopyObject_from_an_object_version,
+		"Versioning_CopyObject_special_chars":                                     Versioning_CopyObject_special_chars,
+		"Versioning_HeadObject_invalid_versionId":                                 Versioning_HeadObject_invalid_versionId,
+		"Versioning_HeadObject_invalid_parent":                                    Versioning_HeadObject_invalid_parent,
+		"Versioning_HeadObject_success":                                           Versioning_HeadObject_success,
+		"Versioning_HeadObject_without_versionId":                                 Versioning_HeadObject_without_versionId,
+		"Versioning_HeadObject_delete_marker":                                     Versioning_HeadObject_delete_marker,
+		"Versioning_GetObject_invalid_versionId":                                  Versioning_GetObject_invalid_versionId,
+		"Versioning_GetObject_success":                                            Versioning_GetObject_success,
+		"Versioning_GetObject_delete_marker_without_versionId":                    Versioning_GetObject_delete_marker_without_versionId,
+		"Versioning_GetObject_delete_marker":                                      Versioning_GetObject_delete_marker,
+		"Versioning_GetObject_null_versionId_obj":                                 Versioning_GetObject_null_versionId_obj,
+		"Versioning_GetObjectAttributes_object_version":                           Versioning_GetObjectAttributes_object_version,
+		"Versioning_GetObjectAttributes_delete_marker":                            Versioning_GetObjectAttributes_delete_marker,
+		"Versioning_DeleteObject_delete_object_version":                           Versioning_DeleteObject_delete_object_version,
+		"Versioning_DeleteObject_non_existing_object":                             Versioning_DeleteObject_non_existing_object,
+		"Versioning_DeleteObject_delete_a_delete_marker":                          Versioning_DeleteObject_delete_a_delete_marker,
+		"Versioning_Delete_null_versionId_object":                                 Versioning_Delete_null_versionId_object,
+		"Versioning_DeleteObject_suspended":                                       Versioning_DeleteObject_suspended,
+		"Versioning_DeleteObjects_success":                                        Versioning_DeleteObjects_success,
+		"Versioning_DeleteObjects_delete_deleteMarkers":                           Versioning_DeleteObjects_delete_deleteMarkers,
+		"ListObjectVersions_non_existing_bucket":                                  ListObjectVersions_non_existing_bucket,
+		"ListObjectVersions_list_single_object_versions":                          ListObjectVersions_list_single_object_versions,
+		"ListObjectVersions_list_multiple_object_versions":                        ListObjectVersions_list_multiple_object_versions,
+		"ListObjectVersions_multiple_object_versions_truncated":                   ListObjectVersions_multiple_object_versions_truncated,
+		"ListObjectVersions_with_delete_markers":                                  ListObjectVersions_with_delete_markers,
+		"ListObjectVersions_containing_null_versionId_obj":                        ListObjectVersions_containing_null_versionId_obj,
+		"ListObjectVersions_single_null_versionId_object":                         ListObjectVersions_single_null_versionId_object,
+		"Versioning_Multipart_Upload_success":                                     Versioning_Multipart_Upload_success,
+		"Versioning_Multipart_Upload_overwrite_an_object":                         Versioning_Multipart_Upload_overwrite_an_object,
+		"Versioning_UploadPartCopy_non_existing_versionId":                        Versioning_UploadPartCopy_non_existing_versionId,
+		"Versioning_UploadPartCopy_from_an_object_version":                        Versioning_UploadPartCopy_from_an_object_version,
+		"Versioning_Enable_object_lock":                                           Versioning_Enable_object_lock,
+		"Versioning_status_switch_to_suspended_with_object_lock":                  Versioning_status_switch_to_suspended_with_object_lock,
+		"Versioning_PutObjectRetention_invalid_versionId":                         Versioning_PutObjectRetention_invalid_versionId,
+		"Versioning_GetObjectRetention_invalid_versionId":                         Versioning_GetObjectRetention_invalid_versionId,
+		"Versioning_Put_GetObjectRetention_success":                               Versioning_Put_GetObjectRetention_success,
+		"Versioning_PutObjectLegalHold_invalid_versionId":                         Versioning_PutObjectLegalHold_invalid_versionId,
+		"Versioning_GetObjectLegalHold_invalid_versionId":                         Versioning_GetObjectLegalHold_invalid_versionId,
+		"Versioning_Put_GetObjectLegalHold_success":                               Versioning_Put_GetObjectLegalHold_success,
+		"Versioning_WORM_obj_version_locked_with_legal_hold":                      Versioning_WORM_obj_version_locked_with_legal_hold,
+		"Versioning_WORM_obj_version_locked_with_governance_retention":            Versioning_WORM_obj_version_locked_with_governance_retention,
+		"Versioning_WORM_obj_version_locked_with_compliance_retention":            Versioning_WORM_obj_version_locked_with_compliance_retention,
+		"Versioning_concurrent_upload_object":                                     Versioning_concurrent_upload_object,
 	}
 }


### PR DESCRIPTION
Fixes #928 

Implements object integrity checksums in `POSIX`.  

The following checksum algorithms are supported (similar to AWS):  
1. **CRC32**  
2. **CRC32C**  
3. **SHA1**  
4. **SHA256**  
5. **CRC64NVME**

The checksums are Base64-encoded.  
- Checksums are calculated during object uploads (`PutObject`, `UploadPart`).  
- A checksum reader is layered on top of the existing readers.  
- When an object is copied (`CopyObject`), the checksum is recalculated if a different checksum type is specified.  

**Constraints:**  
- Multiple checksum types are not allowed for a single object.  
- It is not permitted to upload an object (`PutObject`) or its parts with differing checksum types.  

Checksum data is stored as extended attributes (`xattr`) in JSON format, including the checksum algorithm and its corresponding values. 

The new `checksum-type` support is added in the gateway as stated in [aws docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html)

There are 2 checksum types:
1. **COMPOSITE**
2. **FULL_OBJECT**

`FULL_OBJECT` is calculated based on the object data from the first till the last byte.
`COMPOSITE` checksum is used in multipart uploads, which is calculated based on all the uploaded parts checksums.

All the new changes mentioned in the doc will become available with this PR in the `posix` and `s3proxy` backends
