### PR TITLE
fix: Fixes the AccessControlPolicy Grantee Type unmarshalling, Adds r…

### DIFF
--- a/s3api/controllers/admin.go
+++ b/s3api/controllers/admin.go
@@ -167,7 +167,7 @@ func (c AdminController) ChangeBucketOwner(ctx *fiber.Ctx) error {
 		Owner: owner,
 		Grantees: []auth.Grantee{
 			{
-				Permission: types.PermissionFullControl,
+				Permission: auth.PermissionFullControl,
 				Access:     owner,
 				Type:       types.TypeCanonicalUser,
 			},

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -126,7 +126,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -175,7 +175,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -217,7 +217,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -282,7 +282,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		err = auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -319,7 +319,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionReadAcp,
+			AclPermission: auth.PermissionReadAcp,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -352,7 +352,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -468,7 +468,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 	err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 		Readonly:      c.readonly,
 		Acl:           parsedAcl,
-		AclPermission: types.PermissionRead,
+		AclPermission: auth.PermissionRead,
 		IsRoot:        isRoot,
 		Acc:           acct,
 		Bucket:        bucket,
@@ -637,7 +637,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -685,7 +685,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -722,7 +722,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -762,7 +762,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -792,7 +792,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -845,7 +845,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -886,7 +886,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionReadAcp,
+			AclPermission: auth.PermissionReadAcp,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -926,7 +926,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -977,7 +977,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1027,7 +1027,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 	err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 		Readonly:      c.readonly,
 		Acl:           parsedAcl,
-		AclPermission: types.PermissionRead,
+		AclPermission: auth.PermissionRead,
 		IsRoot:        isRoot,
 		Acc:           acct,
 		Bucket:        bucket,
@@ -1127,7 +1127,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 		err = auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1180,7 +1180,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 		if err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1210,7 +1210,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1272,7 +1272,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 		if err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1313,7 +1313,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 		err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1384,7 +1384,7 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWriteAcp,
+				AclPermission: auth.PermissionWriteAcp,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -1415,13 +1415,12 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 					})
 			}
 
-			if accessControlPolicy.Owner == nil ||
-				accessControlPolicy.Owner.ID == nil ||
-				*accessControlPolicy.Owner.ID == "" {
+			err = accessControlPolicy.Validate()
+			if err != nil {
 				if c.debug {
-					log.Println("empty access control policy owner")
+					log.Printf("invalid access control policy: %v\n", err)
 				}
-				return SendResponse(ctx, s3err.GetAPIError(s3err.ErrMalformedACL),
+				return SendResponse(ctx, err,
 					&MetaOpts{
 						Logger:      c.logger,
 						Action:      metrics.ActionPutBucketAcl,
@@ -1733,7 +1732,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		err = auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1766,7 +1765,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		if err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1839,7 +1838,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		if err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -1903,7 +1902,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		err = auth.VerifyObjectCopyAccess(ctx.Context(), c.be, copySource,
 			auth.AccessOptions{
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -1967,7 +1966,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2073,7 +2072,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 						ID:   &grt.Grantee.ID,
 						Type: grt.Grantee.Type,
 					},
-					Permission: grt.Permission,
+					Permission: types.Permission(grt.Permission),
 				})
 			}
 
@@ -2174,7 +2173,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		err = auth.VerifyObjectCopyAccess(ctx.Context(), c.be, copySource,
 			auth.AccessOptions{
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2306,7 +2305,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -2437,7 +2436,7 @@ func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2469,7 +2468,7 @@ func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2501,7 +2500,7 @@ func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2532,7 +2531,7 @@ func (c S3ApiController) DeleteBucket(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -2585,7 +2584,7 @@ func (c S3ApiController) DeleteObjects(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -2658,7 +2657,7 @@ func (c S3ApiController) DeleteActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2696,7 +2695,7 @@ func (c S3ApiController) DeleteActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -2737,7 +2736,7 @@ func (c S3ApiController) DeleteActions(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -2826,7 +2825,7 @@ func (c S3ApiController) HeadBucket(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -2909,7 +2908,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionRead,
+			AclPermission: auth.PermissionRead,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,
@@ -3080,7 +3079,7 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -3135,7 +3134,7 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionRead,
+				AclPermission: auth.PermissionRead,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -3207,7 +3206,7 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 			auth.AccessOptions{
 				Readonly:      c.readonly,
 				Acl:           parsedAcl,
-				AclPermission: types.PermissionWrite,
+				AclPermission: auth.PermissionWrite,
 				IsRoot:        isRoot,
 				Acc:           acct,
 				Bucket:        bucket,
@@ -3267,7 +3266,7 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,
-			AclPermission: types.PermissionWrite,
+			AclPermission: auth.PermissionWrite,
 			IsRoot:        isRoot,
 			Acc:           acct,
 			Bucket:        bucket,

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -336,6 +336,10 @@ func TestPutBucketAcl(s *S3Conf) {
 	PutBucketAcl_invalid_acl_acp_and_grants(s)
 	PutBucketAcl_invalid_owner(s)
 	PutBucketAcl_invalid_owner_not_in_body(s)
+	PutBucketAcl_invalid_empty_owner_id_in_body(s)
+	PutBucketAcl_invalid_permission_in_body(s)
+	PutBucketAcl_invalid_grantee_type_in_body(s)
+	PutBucketAcl_empty_grantee_ID_in_body(s)
 	PutBucketAcl_success_access_denied(s)
 	PutBucketAcl_success_grants(s)
 	PutBucketAcl_success_canned_acl(s)
@@ -861,6 +865,10 @@ func GetIntTests() IntTests {
 		"PutBucketAcl_invalid_acl_acp_and_grants":                             PutBucketAcl_invalid_acl_acp_and_grants,
 		"PutBucketAcl_invalid_owner":                                          PutBucketAcl_invalid_owner,
 		"PutBucketAcl_invalid_owner_not_in_body":                              PutBucketAcl_invalid_owner_not_in_body,
+		"PutBucketAcl_invalid_empty_owner_id_in_body":                         PutBucketAcl_invalid_empty_owner_id_in_body,
+		"PutBucketAcl_invalid_permission_in_body":                             PutBucketAcl_invalid_permission_in_body,
+		"PutBucketAcl_invalid_grantee_type_in_body":                           PutBucketAcl_invalid_grantee_type_in_body,
+		"PutBucketAcl_empty_grantee_ID_in_body":                               PutBucketAcl_empty_grantee_ID_in_body,
 		"PutBucketAcl_success_access_denied":                                  PutBucketAcl_success_access_denied,
 		"PutBucketAcl_success_grants":                                         PutBucketAcl_success_grants,
 		"PutBucketAcl_success_canned_acl":                                     PutBucketAcl_success_canned_acl,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -7653,6 +7653,7 @@ func PutBucketAcl_invalid_acl_canned_and_grants(s *S3Conf) error {
 							ID:   getPtr("awsID"),
 							Type: types.TypeCanonicalUser,
 						},
+						Permission: types.PermissionFullControl,
 					},
 				},
 				Owner: &types.Owner{
@@ -7683,6 +7684,7 @@ func PutBucketAcl_invalid_acl_acp_and_grants(s *S3Conf) error {
 							ID:   getPtr("awsID"),
 							Type: types.TypeCanonicalUser,
 						},
+						Permission: types.PermissionFullControl,
 					},
 				},
 				Owner: &types.Owner{
@@ -7728,6 +7730,7 @@ func PutBucketAcl_invalid_owner(s *S3Conf) error {
 							ID:   getPtr(usr.access),
 							Type: types.TypeCanonicalUser,
 						},
+						Permission: types.PermissionRead,
 					},
 				},
 				Owner: &types.Owner{
@@ -7763,6 +7766,124 @@ func PutBucketAcl_invalid_owner_not_in_body(s *S3Conf) error {
 						},
 						Permission: types.PermissionRead,
 					},
+				},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedACL)); err != nil {
+			return err
+		}
+
+		return nil
+	}, withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
+}
+
+func PutBucketAcl_invalid_empty_owner_id_in_body(s *S3Conf) error {
+	testName := "PutBucketAcl_invalid_empty_owner_id_in_body"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+			Bucket: &bucket,
+			AccessControlPolicy: &types.AccessControlPolicy{
+				Grants: []types.Grant{
+					{
+						Grantee: &types.Grantee{
+							Type: types.TypeCanonicalUser,
+							ID:   getPtr("grt1"),
+						},
+						Permission: types.PermissionRead,
+					},
+				},
+				// Empty owner ID
+				Owner: &types.Owner{},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedACL)); err != nil {
+			return err
+		}
+
+		return nil
+	}, withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
+}
+
+func PutBucketAcl_invalid_permission_in_body(s *S3Conf) error {
+	testName := "PutBucketAcl_invalid_permission_in_body"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+			Bucket: &bucket,
+			AccessControlPolicy: &types.AccessControlPolicy{
+				Grants: []types.Grant{
+					{
+						Grantee: &types.Grantee{
+							Type: types.TypeCanonicalUser,
+							ID:   getPtr("grt1"),
+						},
+						Permission: types.Permission("invalid_permission"),
+					},
+				},
+				Owner: &types.Owner{
+					ID: &s.awsID,
+				},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedACL)); err != nil {
+			return err
+		}
+
+		return nil
+	}, withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
+}
+
+func PutBucketAcl_invalid_grantee_type_in_body(s *S3Conf) error {
+	testName := "PutBucketAcl_invalid_grantee_type_in_body"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+			Bucket: &bucket,
+			AccessControlPolicy: &types.AccessControlPolicy{
+				Grants: []types.Grant{
+					{
+						Grantee: &types.Grantee{
+							Type: types.Type("invalid_type"),
+							ID:   getPtr("grt1"),
+						},
+						Permission: types.PermissionRead,
+					},
+				},
+				Owner: &types.Owner{
+					ID: &s.awsID,
+				},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedACL)); err != nil {
+			return err
+		}
+
+		return nil
+	}, withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
+}
+
+func PutBucketAcl_empty_grantee_ID_in_body(s *S3Conf) error {
+	testName := "PutBucketAcl_empty_grantee_ID_in_body"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+			Bucket: &bucket,
+			AccessControlPolicy: &types.AccessControlPolicy{
+				Grants: []types.Grant{
+					{
+						Grantee: &types.Grantee{
+							Type: types.TypeCanonicalUser,
+						},
+						Permission: types.PermissionRead,
+					},
+				},
+				Owner: &types.Owner{
+					ID: &s.awsID,
 				},
 			},
 		})


### PR DESCRIPTION
Fixes #986 

- Adds custom unmarshalling logic for `AccessControlPolicy` to properly handle the `xsi:type` XML attribute.  
- Adds request body schema validation for the `PutBucketAcl` action.