### PR TITLE
chore: tie functional tests to aws cli version linux-x86_64-2.22.35

### DIFF
--- a/.github/workflows/docker-bats.yml
+++ b/.github/workflows/docker-bats.yml
@@ -16,7 +16,7 @@ jobs:
           cp tests/.secrets.default tests/.secrets
           docker build \
             --build-arg="GO_LIBRARY=go1.23.1.linux-amd64.tar.gz" \
-            --build-arg="AWS_CLI=awscli-exe-linux-x86_64.zip" \
+            --build-arg="AWS_CLI=awscli-exe-linux-x86_64-2.22.35.zip" \
             --build-arg="MC_FOLDER=linux-amd64" \
             --progress=plain \
             -f tests/Dockerfile_test_bats \


### PR DESCRIPTION
There was a breaking change in latest awscli. This will tie the tests to the known working version until we can get a more permanenet fix for aws cli in place.