### PR TITLE
Integration tests over https

### DIFF
--- a/cmd/versitygw/test.go
+++ b/cmd/versitygw/test.go
@@ -38,6 +38,7 @@ var (
 	checksumDisable   bool
 	versioningEnabled bool
 	azureTests        bool
+	tlsStatus         bool
 )
 
 func testCommand() *cli.Command {
@@ -78,6 +79,12 @@ func initTestFlags() []cli.Flag {
 			Usage:       "enable debug mode",
 			Aliases:     []string{"d"},
 			Destination: &debug,
+		},
+		&cli.BoolFlag{
+			Name:        "allow-insecure",
+			Usage:       "skip tls verification",
+			Aliases:     []string{"ai"},
+			Destination: &tlsStatus,
 		},
 	}
 }
@@ -211,6 +218,7 @@ func initTestCommands() []*cli.Command {
 					integration.WithEndpoint(endpoint),
 					integration.WithConcurrency(concurrency),
 					integration.WithPartSize(partSize),
+					integration.WithTLSStatus(tlsStatus),
 				}
 				if debug {
 					opts = append(opts, integration.WithDebug())
@@ -271,6 +279,7 @@ func initTestCommands() []*cli.Command {
 					integration.WithRegion(region),
 					integration.WithEndpoint(endpoint),
 					integration.WithConcurrency(concurrency),
+					integration.WithTLSStatus(tlsStatus),
 				}
 				if debug {
 					opts = append(opts, integration.WithDebug())
@@ -296,6 +305,7 @@ func getAction(tf testFunc) func(*cli.Context) error {
 			integration.WithSecret(awsSecret),
 			integration.WithRegion(region),
 			integration.WithEndpoint(endpoint),
+			integration.WithTLSStatus(tlsStatus),
 		}
 		if debug {
 			opts = append(opts, integration.WithDebug())
@@ -333,6 +343,7 @@ func extractIntTests() (commands []*cli.Command) {
 					integration.WithSecret(awsSecret),
 					integration.WithRegion(region),
 					integration.WithEndpoint(endpoint),
+					integration.WithTLSStatus(tlsStatus),
 				}
 				if debug {
 					opts = append(opts, integration.WithDebug())

--- a/runtests.sh
+++ b/runtests.sh
@@ -10,6 +10,14 @@ mkdir /tmp/versioning.covdata
 rm -rf /tmp/versioningdir
 mkdir /tmp/versioningdir
 
+# setup tls certificate and key
+ECHO "Generating TLS certificate and key in the cert.pem and key.pem files"
+
+openssl genpkey -algorithm RSA -out key.pem -pkeyopt rsa_keygen_bits:2048
+openssl req -new -x509 -key key.pem -out cert.pem -days 365 -subj "/C=US/ST=California/L=San Francisco/O=Versity/OU=Software/CN=versity.com"
+
+
+ECHO "Running the sdk test over http"
 # run server in background not versioning-enabled
 # port: 7070(default)
 GOCOVERDIR=/tmp/covdata ./versitygw -a user -s pass --iam-dir /tmp/gw posix /tmp/gw &
@@ -17,7 +25,7 @@ GW_PID=$!
 
 sleep 1
 
-# check if versioning-enabled gateway process is still running
+# check if gateway process is still running
 if ! kill -0 $GW_PID; then
 	echo "server no longer running"
 	exit 1
@@ -45,9 +53,48 @@ fi
 
 kill $GW_PID
 
+ECHO "Running the sdk test over https"
+
+# run server in background with TLS certificate
+# port: 7071(default)
+GOCOVERDIR=/tmp/https.covdata ./versitygw --cert "$PWD/cert.pem" --key "$PWD/key.pem" -p :7071 -a user -s pass --iam-dir /tmp/gw posix /tmp/gw &
+GW_HTTPS_PID=$!
+
+sleep 1
+
+# check if https gateway process is still running
+if ! kill -0 $GW_HTTPS_PID; then
+	echo "server no longer running"
+	exit 1
+fi
+
+# run tests
+# full flow tests
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7071 full-flow; then
+	echo "full flow tests failed"
+	kill $GW_HTTPS_PID
+	exit 1
+fi
+# posix tests
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7071 posix; then
+	echo "posix tests failed"
+	kill $GW_HTTPS_PID
+	exit 1
+fi
+# iam tests
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7071 iam; then
+	echo "iam tests failed"
+	kill $GW_HTTPS_PID
+	exit 1
+fi
+
+kill $GW_HTTPS_PID
+
+
+ECHO "Running the sdk test over http against the versioning-enabled gateway"
 # run server in background versioning-enabled
-# port: 7071
-GOCOVERDIR=/tmp/versioning.covdata ./versitygw -p :7071 -a user -s pass --iam-dir /tmp/gw posix --versioning-dir /tmp/versioningdir /tmp/gw &
+# port: 7072
+GOCOVERDIR=/tmp/versioning.covdata ./versitygw -p :7072 -a user -s pass --iam-dir /tmp/gw posix --versioning-dir /tmp/versioningdir /tmp/gw &
 GW_VS_PID=$!
 
 # wait a second for server to start up
@@ -61,13 +108,13 @@ fi
 
 # run tests
 # full flow tests
-if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7071 full-flow -vs; then
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7072 full-flow -vs; then
 	echo "versioning-enabled full-flow tests failed"
 	kill $GW_VS_PID
 	exit 1
 fi
 # posix tests
-if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7071 posix -vs; then
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7072 posix -vs; then
 	echo "versiongin-enabled posix tests failed"
 	kill $GW_VS_PID
 	exit 1
@@ -75,6 +122,38 @@ fi
 
 # kill off server
 kill $GW_VS_PID
+
+ECHO "Running the sdk test over https against the versioning-enabled gateway"
+# run server in background versioning-enabled
+# port: 7073
+GOCOVERDIR=/tmp/versioning.https.covdata ./versitygw --cert "$PWD/cert.pem" --key "$PWD/key.pem" -p :7073 -a user -s pass --iam-dir /tmp/gw posix --versioning-dir /tmp/versioningdir /tmp/gw &
+GW_VS_HTTPS_PID=$!
+
+# wait a second for server to start up
+sleep 1
+
+# check if versioning-enabled gateway process is still running
+if ! kill -0 $GW_VS_HTTPS_PID; then
+	echo "versioning-enabled server no longer running"
+	exit 1
+fi
+
+# run tests
+# full flow tests
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7073 full-flow -vs; then
+	echo "versioning-enabled full-flow tests failed"
+	kill $GW_VS_HTTPS_PID
+	exit 1
+fi
+# posix tests
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7073 posix -vs; then
+	echo "versiongin-enabled posix tests failed"
+	kill $GW_VS_HTTPS_PID
+	exit 1
+fi
+
+# kill off server
+kill $GW_VS_HTTPS_PID
 
 exit 0
 

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -56,11 +56,8 @@ func Authentication_empty_auth_header(s *S3Conf) error {
 		date:     time.Now(),
 	}, func(req *http.Request) error {
 		req.Header.Set("Authorization", "")
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -84,11 +81,8 @@ func Authentication_invalid_auth_header(s *S3Conf) error {
 		date:     time.Now(),
 	}, func(req *http.Request) error {
 		req.Header.Set("Authorization", "invalid header")
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -115,11 +109,7 @@ func Authentication_unsupported_signature_version(s *S3Conf) error {
 		authHdr = strings.Replace(authHdr, "AWS4-HMAC-SHA256", "AWS2-HMAC-SHA1", 1)
 		req.Header.Set("Authorization", authHdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -147,11 +137,7 @@ func Authentication_malformed_credentials(s *S3Conf) error {
 		hdr := regExp.ReplaceAllString(authHdr, "Credential-access/32234/us-east-1/s3/aws4_request,")
 		req.Header.Set("Authorization", hdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -179,11 +165,7 @@ func Authentication_malformed_credentials_invalid_parts(s *S3Conf) error {
 		hdr := regExp.ReplaceAllString(authHdr, "Credential=access/32234/us-east-1/s3,")
 		req.Header.Set("Authorization", hdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -211,11 +193,7 @@ func Authentication_credentials_terminated_string(s *S3Conf) error {
 		hdr := regExp.ReplaceAllString(authHdr, "Credential=access/32234/us-east-1/s3/aws_request,")
 		req.Header.Set("Authorization", hdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -238,11 +216,8 @@ func Authentication_credentials_incorrect_service(s *S3Conf) error {
 		service:  "ec2",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -271,16 +246,13 @@ func Authentication_credentials_incorrect_region(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 		apiErr := s3err.APIError{
 			Code:           "SignatureDoesNotMatch",
 			Description:    fmt.Sprintf("Credential should be scoped to a valid Region, not %v", cfg.awsRegion),
 			HTTPStatusCode: http.StatusForbidden,
 		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -308,11 +280,7 @@ func Authentication_credentials_invalid_date(s *S3Conf) error {
 		hdr := regExp.ReplaceAllString(authHdr, "Credential=access/3223423234/us-east-1/s3/aws4_request,")
 		req.Header.Set("Authorization", hdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -335,11 +303,8 @@ func Authentication_credentials_future_date(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now().Add(time.Duration(5) * 24 * time.Hour),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -376,11 +341,8 @@ func Authentication_credentials_past_date(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now().Add(time.Duration(-5) * 24 * time.Hour),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -422,11 +384,7 @@ func Authentication_credentials_non_existing_access_key(s *S3Conf) error {
 		hdr := regExp.ReplaceAllString(authHdr, "Credential=a_rarely_existing_access_key_id_a7s86df78as6df89790a8sd7f")
 		req.Header.Set("Authorization", hdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -454,11 +412,7 @@ func Authentication_invalid_signed_headers(s *S3Conf) error {
 		hdr := regExp.ReplaceAllString(authHdr, "SignedHeaders-host;x-amz-content-sha256;x-amz-date,")
 		req.Header.Set("Authorization", hdr)
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -481,12 +435,9 @@ func Authentication_missing_date_header(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 		req.Header.Set("X-Amz-Date", "")
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -509,12 +460,9 @@ func Authentication_invalid_date_header(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 		req.Header.Set("X-Amz-Date", "03032006")
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -537,12 +485,9 @@ func Authentication_date_mismatch(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 		req.Header.Set("X-Amz-Date", "20220830T095525Z")
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -565,12 +510,9 @@ func Authentication_incorrect_payload_hash(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 		req.Header.Set("X-Amz-Content-Sha256", "7sa6df576dsa5f675sad67f")
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -593,13 +535,10 @@ func Authentication_incorrect_md5(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
 		req.Header.Set("Content-Md5", "sadfasdf87sad6f87==")
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -624,11 +563,8 @@ func Authentication_signature_error_incorrect_secret_key(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
 
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -651,10 +587,6 @@ func PresignedAuth_missing_algo_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -669,7 +601,7 @@ func PresignedAuth_missing_algo_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -692,10 +624,6 @@ func PresignedAuth_unsupported_algorithm(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		uri := strings.Replace(v4req.URL, "AWS4-HMAC-SHA256", "AWS4-SHA256", 1)
 
 		req, err := http.NewRequest(v4req.Method, uri, nil)
@@ -703,7 +631,7 @@ func PresignedAuth_unsupported_algorithm(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -726,10 +654,6 @@ func PresignedAuth_missing_credentials_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -744,7 +668,7 @@ func PresignedAuth_missing_credentials_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -767,10 +691,6 @@ func PresignedAuth_malformed_creds_invalid_parts(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -785,7 +705,7 @@ func PresignedAuth_malformed_creds_invalid_parts(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -808,10 +728,6 @@ func PresignedAuth_creds_invalid_terminator(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		uri, err := changeAuthCred(v4req.URL, "aws5_request", credTerminator)
 		if err != nil {
 			return err
@@ -822,7 +738,7 @@ func PresignedAuth_creds_invalid_terminator(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -845,10 +761,6 @@ func PresignedAuth_creds_incorrect_service(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		uri, err := changeAuthCred(v4req.URL, "sns", credService)
 		if err != nil {
 			return err
@@ -859,7 +771,7 @@ func PresignedAuth_creds_incorrect_service(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -890,16 +802,12 @@ func PresignedAuth_creds_incorrect_region(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		req, err := http.NewRequest(v4req.Method, v4req.URL, nil)
 		if err != nil {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -926,10 +834,6 @@ func PresignedAuth_creds_invalid_date(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		uri, err := changeAuthCred(v4req.URL, "32234Z34", credDate)
 		if err != nil {
 			return err
@@ -940,7 +844,7 @@ func PresignedAuth_creds_invalid_date(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -963,10 +867,6 @@ func PresignedAuth_non_existing_access_key_id(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		uri, err := changeAuthCred(v4req.URL, "a_rarely_existing_access_key_id890asd6f807as6ydf870say", credAccess)
 		if err != nil {
 			return err
@@ -977,7 +877,7 @@ func PresignedAuth_non_existing_access_key_id(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1000,10 +900,6 @@ func PresignedAuth_missing_date_query(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -1018,7 +914,7 @@ func PresignedAuth_missing_date_query(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1041,10 +937,6 @@ func PresignedAuth_dates_mismatch(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		uri, err := changeAuthCred(v4req.URL, "20060102", credDate)
 		if err != nil {
 			return err
@@ -1055,7 +947,7 @@ func PresignedAuth_dates_mismatch(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1078,10 +970,6 @@ func PresignedAuth_missing_signed_headers_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -1096,7 +984,7 @@ func PresignedAuth_missing_signed_headers_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1119,10 +1007,6 @@ func PresignedAuth_missing_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -1137,7 +1021,7 @@ func PresignedAuth_missing_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1160,10 +1044,6 @@ func PresignedAuth_invalid_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -1178,7 +1058,7 @@ func PresignedAuth_invalid_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1201,10 +1081,6 @@ func PresignedAuth_negative_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -1219,7 +1095,7 @@ func PresignedAuth_negative_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1242,10 +1118,6 @@ func PresignedAuth_exceeding_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		urlParsed, err := url.Parse(v4req.URL)
 		if err != nil {
 			return err
@@ -1260,7 +1132,7 @@ func PresignedAuth_exceeding_expiration_query_param(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1281,10 +1153,6 @@ func PresignedAuth_expired_request(s *S3Conf) error {
 		cancel()
 		if err != nil {
 			return err
-		}
-
-		httpClient := http.Client{
-			Timeout: shortTimeout,
 		}
 
 		urlParsed, err := url.Parse(v4req.URL)
@@ -1308,7 +1176,7 @@ func PresignedAuth_expired_request(s *S3Conf) error {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1333,16 +1201,12 @@ func PresignedAuth_incorrect_secret_key(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		req, err := http.NewRequest(v4req.Method, v4req.URL, nil)
 		if err != nil {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1370,16 +1234,12 @@ func PresignedAuth_PutObject_success(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		req, err := http.NewRequest(http.MethodPut, v4req.URL, nil)
 		if err != nil {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1416,10 +1276,6 @@ func PresignedAuth_Put_GetObject_with_data(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		req, err := http.NewRequest(v4req.Method, v4req.URL, body)
 		if err != nil {
 			return err
@@ -1427,7 +1283,7 @@ func PresignedAuth_Put_GetObject_with_data(s *S3Conf) error {
 
 		req.Header = v4req.SignedHeader
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1448,7 +1304,7 @@ func PresignedAuth_Put_GetObject_with_data(s *S3Conf) error {
 			return err
 		}
 
-		resp, err = httpClient.Do(req)
+		resp, err = s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1492,10 +1348,6 @@ func PresignedAuth_Put_GetObject_with_UTF8_chars(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		req, err := http.NewRequest(v4req.Method, v4req.URL, nil)
 		if err != nil {
 			return err
@@ -1503,7 +1355,7 @@ func PresignedAuth_Put_GetObject_with_UTF8_chars(s *S3Conf) error {
 
 		req.Header = v4req.SignedHeader
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1524,7 +1376,7 @@ func PresignedAuth_Put_GetObject_with_UTF8_chars(s *S3Conf) error {
 			return err
 		}
 
-		resp, err = httpClient.Do(req)
+		resp, err = s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -1565,16 +1417,12 @@ func PresignedAuth_UploadPart(s *S3Conf) error {
 			return err
 		}
 
-		httpClient := http.Client{
-			Timeout: shortTimeout,
-		}
-
 		req, err := http.NewRequest(v4req.Method, v4req.URL, nil)
 		if err != nil {
 			return err
 		}
 
-		resp, err := httpClient.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -2395,11 +2243,7 @@ func DeleteBucket_success_status_code(s *S3Conf) error {
 		return fmt.Errorf("%v: %w", testName, err)
 	}
 
-	client := http.Client{
-		Timeout: shortTimeout,
-	}
-
-	resp, err := client.Do(req)
+	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		failF("%v: %v", testName, err)
 		return fmt.Errorf("%v: %w", testName, err)
@@ -2714,11 +2558,7 @@ func PutBucketTagging_success_status(s *S3Conf) error {
 			return fmt.Errorf("err signing the request: %w", err)
 		}
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return fmt.Errorf("err sending request: %w", err)
 		}
@@ -2834,11 +2674,7 @@ func DeleteBucketTagging_success_status(s *S3Conf) error {
 			return err
 		}
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -4018,11 +3854,7 @@ func GetObject_by_range_resp_status(s *S3Conf) error {
 			return err
 		}
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -4961,11 +4793,7 @@ func DeleteObject_success_status_code(s *S3Conf) error {
 			return err
 		}
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -5689,11 +5517,7 @@ func DeleteObjectTagging_success_status(s *S3Conf) error {
 			return err
 		}
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -7248,11 +7072,7 @@ func AbortMultipartUpload_success_status_code(s *S3Conf) error {
 			return err
 		}
 
-		client := http.Client{
-			Timeout: shortTimeout,
-		}
-
-		resp, err := client.Do(req)
+		resp, err := s.httpClient.Do(req)
 		if err != nil {
 			return err
 		}
@@ -11125,7 +10945,7 @@ func IAM_user_access_denied(s *S3Conf) error {
 		return fmt.Errorf("%v: %w", testName, err)
 	}
 
-	out, err := execCommand("admin", "-a", usr.access, "-s", usr.secret, "-er", s.endpoint, "delete-user", "-a", "random_access")
+	out, err := execCommand(s.getAdminCommand("-a", usr.access, "-s", usr.secret, "-er", s.endpoint, "delete-user", "-a", "random_access")...)
 	if err == nil {
 		failF("%v: expected cmd error", testName)
 		return fmt.Errorf("%v: expected cmd error", testName)
@@ -11156,7 +10976,7 @@ func IAM_userplus_access_denied(s *S3Conf) error {
 		return fmt.Errorf("%v: %w", testName, err)
 	}
 
-	out, err := execCommand("admin", "-a", usr.access, "-s", usr.secret, "-er", s.endpoint, "delete-user", "-a", "random_access")
+	out, err := execCommand(s.getAdminCommand("-a", usr.access, "-s", usr.secret, "-er", s.endpoint, "delete-user", "-a", "random_access")...)
 	if err == nil {
 		failF("%v: expected cmd error", testName)
 		return fmt.Errorf("%v: expected cmd error", testName)

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -766,7 +766,7 @@ func createUsers(s *S3Conf, users []user) error {
 		if err != nil {
 			return err
 		}
-		out, err := execCommand("admin", "-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "create-user", "-a", usr.access, "-s", usr.secret, "-r", usr.role)
+		out, err := execCommand(s.getAdminCommand("-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "create-user", "-a", usr.access, "-s", usr.secret, "-r", usr.role)...)
 		if err != nil {
 			return err
 		}
@@ -778,7 +778,7 @@ func createUsers(s *S3Conf, users []user) error {
 }
 
 func deleteUser(s *S3Conf, access string) error {
-	out, err := execCommand("admin", "-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "delete-user", "-a", access)
+	out, err := execCommand(s.getAdminCommand("-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "delete-user", "-a", access)...)
 	if err != nil {
 		return err
 	}
@@ -791,7 +791,7 @@ func deleteUser(s *S3Conf, access string) error {
 
 func changeBucketsOwner(s *S3Conf, buckets []string, owner string) error {
 	for _, bucket := range buckets {
-		out, err := execCommand("admin", "-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "change-bucket-owner", "-b", bucket, "-o", owner)
+		out, err := execCommand(s.getAdminCommand("-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "change-bucket-owner", "-b", bucket, "-o", owner)...)
 		if err != nil {
 			return err
 		}
@@ -804,7 +804,7 @@ func changeBucketsOwner(s *S3Conf, buckets []string, owner string) error {
 }
 
 func listBuckets(s *S3Conf) error {
-	out, err := execCommand("admin", "-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "list-buckets")
+	out, err := execCommand(s.getAdminCommand("-a", s.awsID, "-s", s.awsSecret, "-er", s.endpoint, "list-buckets")...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Adds the `--allow-insecure` flag to the test command to run integration tests in insecure mode by skipping TLS certificate verification for the HTTP client.  

Adds two steps in the SDK tests pipeline to run the SDK tests against the HTTPS gateway in both versioning-enabled and versioning-disabled modes.  

Upgrades all Go dependencies to the latest version.