### PR TITLE
Potential fix for code scanning alert no. 15: Potentially unsafe quoting

### DIFF
--- a/auth/iam_ipa.go
+++ b/auth/iam_ipa.go
@@ -354,15 +354,18 @@ func (ipa *IpaIAMService) newRequest(method string, args []string, dict map[stri
 		return "", fmt.Errorf("ipa request invalid: %w", err)
 	}
 
-	return fmt.Sprintf(`{
-		"id": %d,
-		"method": %s,
-		"params": [
-			%s,
-			%s
-		]
+	request := map[string]interface{}{
+		"id":     id,
+		"method": json.RawMessage(jmethod),
+		"params": []json.RawMessage{json.RawMessage(jargs), json.RawMessage(jdict)},
 	}
-	`, id, jmethod, jargs, jdict), nil
+
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	return string(requestJSON), nil
 }
 
 // pkcs7Unpad validates and unpads data from the given bytes slice.


### PR DESCRIPTION
Potential fix for [https://github.com/versity/versitygw/security/code-scanning/15](https://github.com/versity/versitygw/security/code-scanning/15)

To fix the problem, we should avoid manually constructing the JSON string with `fmt.Sprintf` and instead use a structured approach to build the JSON object. This ensures that all necessary escaping is handled correctly by the JSON library.

- Replace the manual construction of the JSON string with a map and marshal it to JSON.
- This change will be made in the `newRequest` function in the `auth/iam_ipa.go` file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
