### PR TITLE
fix: chunk encoding with incorrect chunk signature

### DIFF
--- a/s3api/utils/signed-chunk-reader.go
+++ b/s3api/utils/signed-chunk-reader.go
@@ -79,7 +79,7 @@ func NewSignedChunkReader(r io.Reader, authdata AuthData, region, secret string,
 func (cr *ChunkReader) Read(p []byte) (int, error) {
 	n, err := cr.r.Read(p)
 	if err != nil && err != io.EOF {
-		return n, err
+		return 0, err
 	}
 
 	if cr.chunkDataLeft < int64(n) {


### PR DESCRIPTION
We were getting errors such as:
2025/02/07 19:24:28 Internal Error, write object data: write exceeds content length 87

whenever the chunk encoding did not have the correct chunk signatures. The issue was that the chunk encoding reader was reading from the underlying reader and then passing the full buffer read back to the caller if the underlying reader returned an error. This meant that we were not processing the chunk headers within the buffer due to the higher level error, and would possibly hand back the longer unprocessed chunk encoded stream to the caller that was in turn trying to write to the object file exceeding the content length limit.

Fixes #1056