### PR TITLE
fix: Adds PartNumber validation for CompleteMultipartUploads parts. A…

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -78,6 +78,8 @@ const (
 	ErrInvalidPart
 	ErrEmptyParts
 	ErrInvalidPartNumber
+	ErrInvalidPartOrder
+	ErrInvalidCompleteMpPartNumber
 	ErrInternalError
 	ErrInvalidCopyDest
 	ErrInvalidCopySource
@@ -270,6 +272,16 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidPartNumber: {
 		Code:           "InvalidArgument",
 		Description:    "Part number must be an integer between 1 and 10000, inclusive.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidPartOrder: {
+		Code:           "InvalidPartOrder",
+		Description:    "The list of parts was not in ascending order. Parts must be ordered by part number.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCompleteMpPartNumber: {
+		Code:           "InvalidArgument",
+		Description:    "PartNumber must be >= 1",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidCopyDest: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -388,10 +388,12 @@ func TestAbortMultipartUpload(s *S3Conf) {
 
 func TestCompleteMultipartUpload(s *S3Conf) {
 	CompletedMultipartUpload_non_existing_bucket(s)
+	CompleteMultipartUpload_incorrect_part_number(s)
 	CompleteMultipartUpload_invalid_part_number(s)
 	CompleteMultipartUpload_invalid_ETag(s)
 	CompleteMultipartUpload_small_upload_size(s)
 	CompleteMultipartUpload_empty_parts(s)
+	CompleteMultipartUpload_incorrect_parts_order(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		CompleteMultipartUpload_invalid_checksum_type(s)
@@ -971,6 +973,9 @@ func GetIntTests() IntTests {
 		"CompletedMultipartUpload_non_existing_bucket":                            CompletedMultipartUpload_non_existing_bucket,
 		"CompleteMultipartUpload_invalid_part_number":                             CompleteMultipartUpload_invalid_part_number,
 		"CompleteMultipartUpload_invalid_ETag":                                    CompleteMultipartUpload_invalid_ETag,
+		"CompleteMultipartUpload_small_upload_size":                               CompleteMultipartUpload_small_upload_size,
+		"CompleteMultipartUpload_empty_parts":                                     CompleteMultipartUpload_empty_parts,
+		"CompleteMultipartUpload_incorrect_parts_order":                           CompleteMultipartUpload_incorrect_parts_order,
 		"CompleteMultipartUpload_invalid_checksum_type":                           CompleteMultipartUpload_invalid_checksum_type,
 		"CompleteMultipartUpload_invalid_checksum_part":                           CompleteMultipartUpload_invalid_checksum_part,
 		"CompleteMultipartUpload_multiple_checksum_part":                          CompleteMultipartUpload_multiple_checksum_part,


### PR DESCRIPTION
Fixes #1072
Fixes #1063 

`Parts` should be sorted in ascending order for `CompleteMultipartUpload`. The PR adds a check to validate the parts order  in `CompleteMultipartUpload` in both `posix` and `azure` backends.

S3 has `partNumber` validation on `CompleteMultipartUpload`: it should be greater than `1`. The PR adds this check. 
For the upper limits(10000) it simply returns `InvalidPart` error as in the gateway.