### PR TITLE
x-amz-mp-object-size header for CompleteMultipartUpload

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1478,6 +1478,10 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 		}
 	}
 
+	if input.MpuObjectSize != nil && totalsize != *input.MpuObjectSize {
+		return nil, s3err.GetIncorrectMpObjectSizeErr(totalsize, *input.MpuObjectSize)
+	}
+
 	var hashRdr *utils.HashReader
 	var compositeChecksumRdr *utils.CompositeChecksumReader
 	switch checksums.Type {

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -3439,6 +3439,36 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 				})
 		}
 
+		var mpuObjectSize *int64
+		mpuObjSizeHdr := ctx.Get("X-Amz-Mp-Object-Size")
+		if mpuObjSizeHdr != "" {
+			val, err := strconv.ParseInt(mpuObjSizeHdr, 10, 64)
+			//TODO: Not sure if invalid request should be returned
+			if err != nil {
+				return SendXMLResponse(ctx, nil,
+					s3err.GetAPIError(s3err.ErrInvalidRequest),
+					&MetaOpts{
+						Logger:      c.logger,
+						MetricsMng:  c.mm,
+						Action:      metrics.ActionCompleteMultipartUpload,
+						BucketOwner: parsedAcl.Owner,
+					})
+			}
+
+			if val < 0 {
+				return SendXMLResponse(ctx, nil,
+					s3err.GetInvalidMpObjectSizeErr(val),
+					&MetaOpts{
+						Logger:      c.logger,
+						MetricsMng:  c.mm,
+						Action:      metrics.ActionCompleteMultipartUpload,
+						BucketOwner: parsedAcl.Owner,
+					})
+			}
+
+			mpuObjectSize = &val
+		}
+
 		err = auth.VerifyAccess(ctx.Context(), c.be,
 			auth.AccessOptions{
 				Readonly:      c.readonly,
@@ -3497,6 +3527,7 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 				MultipartUpload: &types.CompletedMultipartUpload{
 					Parts: data.Parts,
 				},
+				MpuObjectSize:     mpuObjectSize,
 				ChecksumCRC32:     backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32]),
 				ChecksumCRC32C:    backend.GetPtrFromString(checksums[types.ChecksumAlgorithmCrc32c]),
 				ChecksumSHA1:      backend.GetPtrFromString(checksums[types.ChecksumAlgorithmSha1]),

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -763,3 +763,19 @@ func GetChecksumTypeMismatchOnMpErr(t types.ChecksumType) APIError {
 		HTTPStatusCode: http.StatusBadRequest,
 	}
 }
+
+func GetIncorrectMpObjectSizeErr(expected, actual int64) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf("The provided 'x-amz-mp-object-size' header value %v does not match what was computed: %v", expected, actual),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+func GetInvalidMpObjectSizeErr(val int64) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf("Value for x-amz-mp-object-size header is less than zero: '%v'", val),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -394,6 +394,7 @@ func TestCompleteMultipartUpload(s *S3Conf) {
 	CompleteMultipartUpload_small_upload_size(s)
 	CompleteMultipartUpload_empty_parts(s)
 	CompleteMultipartUpload_incorrect_parts_order(s)
+	CompleteMultipartUpload_mpu_object_size(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		CompleteMultipartUpload_invalid_checksum_type(s)
@@ -976,6 +977,7 @@ func GetIntTests() IntTests {
 		"CompleteMultipartUpload_small_upload_size":                               CompleteMultipartUpload_small_upload_size,
 		"CompleteMultipartUpload_empty_parts":                                     CompleteMultipartUpload_empty_parts,
 		"CompleteMultipartUpload_incorrect_parts_order":                           CompleteMultipartUpload_incorrect_parts_order,
+		"CompleteMultipartUpload_mpu_object_size":                                 CompleteMultipartUpload_mpu_object_size,
 		"CompleteMultipartUpload_invalid_checksum_type":                           CompleteMultipartUpload_invalid_checksum_type,
 		"CompleteMultipartUpload_invalid_checksum_part":                           CompleteMultipartUpload_invalid_checksum_part,
 		"CompleteMultipartUpload_multiple_checksum_part":                          CompleteMultipartUpload_multiple_checksum_part,


### PR DESCRIPTION
Closes #1061

`x-amz-mp-object-size` request header indicates the expected total object size of the multipart upload request. If there’s a mismatch between the specified object size value and the actual object size value, it results in an` HTTP 400 InvalidRequest` error.

Adds this header support in `posix` and `azure` backends.

