### PR TITLE
fix: Adds crc64nvme checksum cases in the integration tests

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -179,7 +179,6 @@ func TestGetObjectAttributes(s *S3Conf) {
 	GetObjectAttributes_existing_object(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
-
 		GetObjectAttributes_checksums(s)
 	}
 }

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -27,8 +27,10 @@ import (
 	"fmt"
 	"hash"
 	"hash/crc32"
+	"hash/crc64"
 	"io"
 	"math/big"
+	"math/bits"
 	rnd "math/rand"
 	"net/http"
 	"net/url"
@@ -811,6 +813,8 @@ func uploadParts(client *s3.Client, size, partCount int64, bucket, key, uploadId
 		hash = sha1.New()
 	case types.ChecksumAlgorithmSha256:
 		hash = sha256.New()
+	case types.ChecksumAlgorithmCrc64nvme:
+		hash = crc64.New(crc64.MakeTable(bits.Reverse64(0xad93d23594c93659)))
 	default:
 		hash = sha256.New()
 	}


### PR DESCRIPTION
As aws go sdk has added the `crc64nvme` checksum support, the PR adds integration test cases for it.