### PR TITLE
fix: Changes HeadObject returned error type from MethodNotAllowed to …

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -3632,10 +3632,14 @@ func (p *Posix) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.
 
 		// if the specified object version is a delete marker, return MethodNotAllowed
 		if isDelMarker {
-			return &s3.HeadObjectOutput{
-				DeleteMarker: getBoolPtr(true),
-				LastModified: backend.GetTimePtr(fi.ModTime()),
-			}, s3err.GetAPIError(s3err.ErrMethodNotAllowed)
+			if versionId != "" {
+				return &s3.HeadObjectOutput{
+					DeleteMarker: getBoolPtr(true),
+					LastModified: backend.GetTimePtr(fi.ModTime()),
+				}, s3err.GetAPIError(s3err.ErrMethodNotAllowed)
+			} else {
+				return nil, s3err.GetAPIError(s3err.ErrNoSuchKey)
+			}
 		}
 	}
 

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -14461,6 +14461,16 @@ func Versioning_HeadObject_delete_marker(s *S3Conf) error {
 			return err
 		}
 
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.HeadObject(ctx, &s3.HeadObjectInput{
+			Bucket: &bucket,
+			Key:    &obj,
+		})
+		cancel()
+		if err := checkSdkApiErr(err, "NotFound"); err != nil {
+			return err
+		}
+
 		return nil
 	}, withVersioning(types.BucketVersioningStatusEnabled))
 }


### PR DESCRIPTION
Fixes #1029 

`HeadObject` returns `405 MethdoNotAllowed` if a delete marker is attmpted to query with `versionId` specified. On the other hand if a user tries to retreive the latest object version without specifying `versionId`, even if it's a delete marker, the gateway should return `404 NotFound` as `versionId` is not specified and the object is treated as non-existing.