### PR TITLE
fix: Adds quotes for object Etags

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -563,7 +563,7 @@ Pager:
 				break Pager
 			}
 			objects = append(objects, s3response.Object{
-				ETag:         (*string)(v.Properties.ETag),
+				ETag:         backend.GetPtrFromString(fmt.Sprintf("%q", *v.Properties.ETag)),
 				Key:          v.Name,
 				LastModified: v.Properties.LastModified,
 				Size:         v.Properties.ContentLength,
@@ -645,7 +645,7 @@ Pager:
 				break Pager
 			}
 			objects = append(objects, s3response.Object{
-				ETag:         (*string)(v.Properties.ETag),
+				ETag:         backend.GetPtrFromString(fmt.Sprintf("%q", *v.Properties.ETag)),
 				Key:          v.Name,
 				LastModified: v.Properties.LastModified,
 				Size:         v.Properties.ContentLength,

--- a/backend/common.go
+++ b/backend/common.go
@@ -152,8 +152,8 @@ func GetMultipartMD5(parts []types.CompletedPart) string {
 	for _, part := range parts {
 		partsEtagBytes = append(partsEtagBytes, getEtagBytes(*part.ETag)...)
 	}
-	s3MD5 := fmt.Sprintf("%s-%d", md5String(partsEtagBytes), len(parts))
-	return s3MD5
+
+	return fmt.Sprintf("\"%s-%d\"", md5String(partsEtagBytes), len(parts))
 }
 
 func getEtagBytes(etag string) []byte {

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2814,7 +2814,7 @@ func (p *Posix) PutObject(ctx context.Context, po *s3.PutObjectInput) (s3respons
 	}
 
 	dataSum := hash.Sum(nil)
-	etag := hex.EncodeToString(dataSum[:])
+	etag := fmt.Sprintf("\"%v\"", hex.EncodeToString(dataSum[:]))
 
 	// if the versioning is enabled, generate a new versionID for the object
 	var versionID string

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -368,10 +368,9 @@ func putObjects(client *s3.Client, objs []string, bucket string) ([]types.Object
 			return nil, err
 		}
 		k := key
-		etag := strings.Trim(*res.ETag, `"`)
 		contents = append(contents, types.Object{
 			Key:          &k,
-			ETag:         &etag,
+			ETag:         res.ETag,
 			StorageClass: types.ObjectStorageClassStandard,
 			Size:         &size,
 		})


### PR DESCRIPTION
Fixes #1018 

Adds quotes when storing object Etags.