### PR TITLE
fix: Prioritize explicit deny in bucket policy statements

### DIFF
--- a/auth/bucket_policy.go
+++ b/auth/bucket_policy.go
@@ -48,18 +48,19 @@ func (bp *BucketPolicy) Validate(bucket string, iam IAMService) error {
 }
 
 func (bp *BucketPolicy) isAllowed(principal string, action Action, resource string) bool {
+	var isAllowed bool
 	for _, statement := range bp.Statement {
 		if statement.findMatch(principal, action, resource) {
 			switch statement.Effect {
 			case BucketPolicyAccessTypeAllow:
-				return true
+				isAllowed = true
 			case BucketPolicyAccessTypeDeny:
 				return false
 			}
 		}
 	}
 
-	return false
+	return isAllowed
 }
 
 type BucketPolicyItem struct {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -471,6 +471,7 @@ func TestPutBucketPolicy(s *S3Conf) {
 	PutBucketPolicy_incorrect_bucket_name(s)
 	PutBucketPolicy_object_action_on_bucket_resource(s)
 	PutBucketPolicy_bucket_action_on_object_resource(s)
+	PutBucketPolicy_explicit_deny(s)
 	PutBucketPolicy_success(s)
 }
 
@@ -1042,6 +1043,7 @@ func GetIntTests() IntTests {
 		"PutBucketPolicy_duplicate_resource":                                      PutBucketPolicy_duplicate_resource,
 		"PutBucketPolicy_incorrect_bucket_name":                                   PutBucketPolicy_incorrect_bucket_name,
 		"PutBucketPolicy_object_action_on_bucket_resource":                        PutBucketPolicy_object_action_on_bucket_resource,
+		"PutBucketPolicy_explicit_deny":                                           PutBucketPolicy_explicit_deny,
 		"PutBucketPolicy_bucket_action_on_object_resource":                        PutBucketPolicy_bucket_action_on_object_resource,
 		"PutBucketPolicy_success":                                                 PutBucketPolicy_success,
 		"GetBucketPolicy_non_existing_bucket":                                     GetBucketPolicy_non_existing_bucket,


### PR DESCRIPTION
Fixes #1092 

In multi-statement bucket policies, explicit `Deny` rules should take precedence over `Allow` rules.

This change updates the implementation to iterate through all policy statements. If a `Deny` statement is found, it immediately returns `AccessDenied`. If no `Deny` statement is found but an `Allow` statement is present, access is granted.