### PR TITLE
fix: s3 proxy return default bucket acl when tags not implemented

### DIFF
--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -1132,6 +1132,9 @@ func (s *S3Proxy) GetBucketAcl(ctx context.Context, input *s3.GetBucketAclInput)
 			if strings.Contains(ae.ErrorCode(), "NoSuchTagSet") {
 				return []byte{}, nil
 			}
+			if strings.Contains(ae.ErrorCode(), "NotImplemented") {
+				return []byte{}, nil
+			}
 		}
 		return nil, handleError(err)
 	}


### PR DESCRIPTION
We currently store bucket ACLs as tags in the backend S3 service. Some backend services do not implment tags though. In this case, we need to return the default bucket ACL for some continued functionality.

There is still more work to return more correct errors for setting ACLs when this is not implemented.