### PR TITLE
feat: return method not allowed when uploading to read only fs

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -362,6 +362,9 @@ func (p *Posix) CreateBucket(ctx context.Context, input *s3.CreateBucketInput, a
 		return s3err.GetAPIError(s3err.ErrBucketAlreadyExists)
 	}
 	if err != nil {
+		if errors.Is(err, syscall.EROFS) {
+			return s3err.GetAPIError(s3err.ErrMethodNotAllowed)
+		}
 		return fmt.Errorf("mkdir bucket: %w", err)
 	}
 


### PR DESCRIPTION
Instead of an internal server error, we should be returning method not allowed when trying to upload to a read only filesystem or make other modifications that are expected to fail. This will give clearer feedback to the clients that this is not expected to work.

Fixes #1062