### PR TITLE
fix: Allows checksum-type to be empty in CompleteMultipartUpload inpu…

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1420,7 +1420,7 @@ func (p *Posix) CompleteMultipartUpload(ctx context.Context, input *s3.CompleteM
 	}
 
 	// ChecksumType should be the same as specified on CreateMultipartUpload
-	if checksums.Type != input.ChecksumType {
+	if input.ChecksumType != "" && checksums.Type != input.ChecksumType {
 		checksumType := checksums.Type
 		if checksumType == "" {
 			checksumType = types.ChecksumType("null")

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -413,6 +413,7 @@ func TestCompleteMultipartUpload(s *S3Conf) {
 		CompleteMultipartUpload_should_verify_the_final_checksum(s)
 		CompleteMultipartUpload_checksum_type_mismatch(s)
 		CompleteMultipartUpload_should_ignore_the_final_checksum(s)
+		CompleteMultipartUpload_should_succeed_without_final_checksum_type(s)
 	}
 	CompleteMultipartUpload_success(s)
 	if !s.azureTests {
@@ -1000,6 +1001,7 @@ func GetIntTests() IntTests {
 		"CompleteMultipartUpload_should_verify_the_final_checksum":                CompleteMultipartUpload_should_verify_the_final_checksum,
 		"CompleteMultipartUpload_checksum_type_mismatch":                          CompleteMultipartUpload_checksum_type_mismatch,
 		"CompleteMultipartUpload_should_ignore_the_final_checksum":                CompleteMultipartUpload_should_ignore_the_final_checksum,
+		"CompleteMultipartUpload_should_succeed_without_final_checksum_type":      CompleteMultipartUpload_should_succeed_without_final_checksum_type,
 		"CompleteMultipartUpload_success":                                         CompleteMultipartUpload_success,
 		"CompleteMultipartUpload_racey_success":                                   CompleteMultipartUpload_racey_success,
 		"PutBucketAcl_non_existing_bucket":                                        PutBucketAcl_non_existing_bucket,


### PR DESCRIPTION
Fixes #1105

Extends the `checksum-type` check in `CompleteMultipartUpload` by allowing it to be empty(not provided) and not returning `InvalidRequest` error.