### PR TITLE
fix: removes ETag quotes for in GetObjectAttributes response for azur…

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -520,7 +520,7 @@ func (az *Azure) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAtt
 	}
 
 	return s3response.GetObjectAttributesResponse{
-		ETag:         data.ETag,
+		ETag:         backend.TrimEtag(data.ETag),
 		ObjectSize:   data.ContentLength,
 		StorageClass: data.StorageClass,
 		LastModified: data.LastModified,

--- a/backend/common.go
+++ b/backend/common.go
@@ -71,6 +71,14 @@ func GetTimePtr(t time.Time) *time.Time {
 	return &t
 }
 
+func TrimEtag(etag *string) *string {
+	if etag == nil {
+		return nil
+	}
+
+	return GetPtrFromString(strings.Trim(*etag, "\""))
+}
+
 var (
 	errInvalidRange = s3err.GetAPIError(s3err.ErrInvalidRange)
 )

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -3751,7 +3751,7 @@ func (p *Posix) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAttr
 	}
 
 	return s3response.GetObjectAttributesResponse{
-		ETag:         data.ETag,
+		ETag:         backend.TrimEtag(data.ETag),
 		ObjectSize:   data.ContentLength,
 		StorageClass: data.StorageClass,
 		LastModified: data.LastModified,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -3795,8 +3795,8 @@ func GetObjectAttributes_existing_object(s *S3Conf) error {
 		if resp.ETag == nil || out.ETag == nil {
 			return fmt.Errorf("nil ETag output")
 		}
-		if *resp.ETag != *out.ETag {
-			return fmt.Errorf("expected ETag to be %v, instead got %v", *resp.ETag, *out.ETag)
+		if strings.Trim(*resp.ETag, "\"") != *out.ETag {
+			return fmt.Errorf("expected ETag to be %v, instead got %v", strings.Trim(*resp.ETag, "\""), *out.ETag)
 		}
 		if out.ObjectSize == nil {
 			return fmt.Errorf("nil object size output")
@@ -14999,8 +14999,8 @@ func Versioning_GetObjectAttributes_object_version(s *S3Conf) error {
 			return err
 		}
 
-		if getString(res.ETag) != *version.ETag {
-			return fmt.Errorf("expected the uploaded object ETag to be %v, instead got %v", *version.ETag, getString(res.ETag))
+		if getString(res.ETag) != strings.Trim(*version.ETag, "\"") {
+			return fmt.Errorf("expected the uploaded object ETag to be %v, instead got %v", strings.Trim(*version.ETag, "\""), getString(res.ETag))
 		}
 		if getString(res.VersionId) != *version.VersionId {
 			return fmt.Errorf("expected the uploaded versionId to be %v, instead got %v", *version.VersionId, getString(res.VersionId))
@@ -15012,8 +15012,8 @@ func Versioning_GetObjectAttributes_object_version(s *S3Conf) error {
 			return err
 		}
 
-		if getString(res.ETag) != *version.ETag {
-			return fmt.Errorf("expected the uploaded object ETag to be %v, instead got %v", *version.ETag, getString(res.ETag))
+		if getString(res.ETag) != strings.Trim(*version.ETag, "\"") {
+			return fmt.Errorf("expected the uploaded object ETag to be %v, instead got %v", strings.Trim(*version.ETag, "\""), getString(res.ETag))
 		}
 		if getString(res.VersionId) != *version.VersionId {
 			return fmt.Errorf("expected the uploaded object versionId to be %v, instead got %v", *version.VersionId, getString(res.VersionId))


### PR DESCRIPTION
Fixes #1114 

`ETag` is returned without double qotes("") for `GetObjectAttributes`.
Removes the `ETag` double quotes in it.