### PR TITLE
fix: Fixes GetObject and UploadPartCopy actions data range parsing.

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -83,6 +83,7 @@ const (
 	ErrInternalError
 	ErrInvalidCopyDest
 	ErrInvalidCopySource
+	ErrInvalidCopySourceRange
 	ErrInvalidTag
 	ErrAuthHeaderEmpty
 	ErrSignatureVersionNotSupported
@@ -294,6 +295,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidCopySource: {
 		Code:           "InvalidArgument",
 		Description:    "Copy Source must mention the source bucket and key: sourcebucket/sourcekey.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCopySourceRange: {
+		Code:           "InvalidArgument",
+		Description:    "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidTag: {
@@ -788,6 +794,14 @@ func GetInvalidMpObjectSizeErr(val int64) APIError {
 	return APIError{
 		Code:           "InvalidRequest",
 		Description:    fmt.Sprintf("Value for x-amz-mp-object-size header is less than zero: '%v'", val),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+func CreateExceedingRangeErr(objSize int64) APIError {
+	return APIError{
+		Code:           "InvalidArgument",
+		Description:    fmt.Sprintf("Range specified is not valid for source object of size: %d", objSize),
 		HTTPStatusCode: http.StatusBadRequest,
 	}
 }

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -57,7 +57,9 @@ func TestPresignedAuthentication(s *S3Conf) {
 	PresignedAuth_incorrect_secret_key(s)
 	PresignedAuth_PutObject_success(s)
 	PresignedAuth_Put_GetObject_with_data(s)
-	PresignedAuth_Put_GetObject_with_UTF8_chars(s)
+	if !s.azureTests {
+		PresignedAuth_Put_GetObject_with_UTF8_chars(s)
+	}
 	PresignedAuth_UploadPart(s)
 }
 
@@ -186,7 +188,8 @@ func TestGetObjectAttributes(s *S3Conf) {
 func TestGetObject(s *S3Conf) {
 	GetObject_non_existing_key(s)
 	GetObject_directory_object_noslash(s)
-	GetObject_invalid_ranges(s)
+	GetObject_should_succeed_for_invalid_ranges(s)
+	GetObject_content_ranges(s)
 	GetObject_invalid_parent(s)
 	GetObject_with_meta(s)
 	GetObject_large_object(s)
@@ -343,7 +346,8 @@ func TestUploadPartCopy(s *S3Conf) {
 	UploadPartCopy_non_existing_source_bucket(s)
 	UploadPartCopy_non_existing_source_object_key(s)
 	UploadPartCopy_success(s)
-	UploadPartCopy_by_range_invalid_range(s)
+	UploadPartCopy_by_range_invalid_ranges(s)
+	UploadPartCopy_exceeding_copy_source_range(s)
 	UploadPartCopy_greater_range_than_obj_size(s)
 	UploadPartCopy_by_range_success(s)
 	//TODO: remove the condition after implementing checksums in azure
@@ -858,7 +862,8 @@ func GetIntTests() IntTests {
 		"GetObjectAttributes_checksums":                                           GetObjectAttributes_checksums,
 		"GetObject_non_existing_key":                                              GetObject_non_existing_key,
 		"GetObject_directory_object_noslash":                                      GetObject_directory_object_noslash,
-		"GetObject_invalid_ranges":                                                GetObject_invalid_ranges,
+		"GetObject_should_succeed_for_invalid_ranges":                             GetObject_should_succeed_for_invalid_ranges,
+		"GetObject_content_ranges":                                                GetObject_content_ranges,
 		"GetObject_invalid_parent":                                                GetObject_invalid_parent,
 		"GetObject_with_meta":                                                     GetObject_with_meta,
 		"GetObject_large_object":                                                  GetObject_large_object,
@@ -958,7 +963,8 @@ func GetIntTests() IntTests {
 		"UploadPartCopy_non_existing_source_bucket":                               UploadPartCopy_non_existing_source_bucket,
 		"UploadPartCopy_non_existing_source_object_key":                           UploadPartCopy_non_existing_source_object_key,
 		"UploadPartCopy_success":                                                  UploadPartCopy_success,
-		"UploadPartCopy_by_range_invalid_range":                                   UploadPartCopy_by_range_invalid_range,
+		"UploadPartCopy_by_range_invalid_ranges":                                  UploadPartCopy_by_range_invalid_ranges,
+		"UploadPartCopy_exceeding_copy_source_range":                              UploadPartCopy_exceeding_copy_source_range,
 		"UploadPartCopy_greater_range_than_obj_size":                              UploadPartCopy_greater_range_than_obj_size,
 		"UploadPartCopy_by_range_success":                                         UploadPartCopy_by_range_success,
 		"UploadPartCopy_should_copy_the_checksum":                                 UploadPartCopy_should_copy_the_checksum,


### PR DESCRIPTION
Fixes #1004 
Fixes #1122 
Fixes #1120 

Separates `GetObject` and `UploadPartCopy` range parsing/validation. 

`GetObject` returns a successful response if acceptRange is invalid. 
Adjusts the range upper limit, if it exceeds the actual objects size for `GetObject`.
Corrects the `ContentRange` in the `GetObject` response.

Fixes the `UploadPartCopy` action copy source range parsing/validation.
`UploadPartCopy` returns `InvalidArgument` if the copy source range is not valid.