### PR TITLE
fix: scoutfs multipart cleanup in complete/abort mp

### DIFF
--- a/backend/scoutfs/scoutfs.go
+++ b/backend/scoutfs/scoutfs.go
@@ -352,10 +352,10 @@ func (s *ScoutFS) CompleteMultipartUpload(ctx context.Context, input *s3.Complet
 	}
 
 	// cleanup tmp dirs
-	os.RemoveAll(upiddir)
+	os.RemoveAll(filepath.Join(bucket, upiddir))
 	// use Remove for objdir in case there are still other uploads
 	// for same object name outstanding
-	os.Remove(objdir)
+	os.Remove(filepath.Join(bucket, objdir))
 
 	return &s3.CompleteMultipartUploadOutput{
 		Bucket: &bucket,


### PR DESCRIPTION
This was previously not including the bucket directory for the mutlipart temp file cleanup. This fixes leftovers in the tmp directories after uploading multipart uploads.