### PR TITLE
feat: Adds the Content-Disposition, Content-Language, Cache-Control and Expires object meta properties support in the gateway.

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -48,7 +48,7 @@ type Backend interface {
 	DeleteBucketOwnershipControls(_ context.Context, bucket string) error
 
 	// multipart operations
-	CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error)
+	CreateMultipartUpload(context.Context, s3response.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error)
 	CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 	AbortMultipartUpload(context.Context, *s3.AbortMultipartUploadInput) error
 	ListMultipartUploads(context.Context, *s3.ListMultipartUploadsInput) (s3response.ListMultipartUploadsResult, error)
@@ -57,7 +57,7 @@ type Backend interface {
 	UploadPartCopy(context.Context, *s3.UploadPartCopyInput) (s3response.CopyPartResult, error)
 
 	// standard object operations
-	PutObject(context.Context, *s3.PutObjectInput) (s3response.PutObjectOutput, error)
+	PutObject(context.Context, s3response.PutObjectInput) (s3response.PutObjectOutput, error)
 	HeadObject(context.Context, *s3.HeadObjectInput) (*s3.HeadObjectOutput, error)
 	GetObject(context.Context, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	GetObjectAcl(context.Context, *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error)
@@ -151,7 +151,7 @@ func (BackendUnsupported) DeleteBucketOwnershipControls(_ context.Context, bucke
 	return s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 
-func (BackendUnsupported) CreateMultipartUpload(context.Context, *s3.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
+func (BackendUnsupported) CreateMultipartUpload(context.Context, s3response.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
 	return s3response.InitiateMultipartUploadResult{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 func (BackendUnsupported) CompleteMultipartUpload(context.Context, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
@@ -173,7 +173,7 @@ func (BackendUnsupported) UploadPartCopy(context.Context, *s3.UploadPartCopyInpu
 	return s3response.CopyPartResult{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 
-func (BackendUnsupported) PutObject(context.Context, *s3.PutObjectInput) (s3response.PutObjectOutput, error) {
+func (BackendUnsupported) PutObject(context.Context, s3response.PutObjectInput) (s3response.PutObjectOutput, error) {
 	return s3response.PutObjectOutput{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 func (BackendUnsupported) HeadObject(context.Context, *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {

--- a/s3api/controllers/backend_moq_test.go
+++ b/s3api/controllers/backend_moq_test.go
@@ -38,7 +38,7 @@ var _ backend.Backend = &BackendMock{}
 //			CreateBucketFunc: func(contextMoqParam context.Context, createBucketInput *s3.CreateBucketInput, defaultACL []byte) error {
 //				panic("mock out the CreateBucket method")
 //			},
-//			CreateMultipartUploadFunc: func(contextMoqParam context.Context, createMultipartUploadInput *s3.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
+//			CreateMultipartUploadFunc: func(contextMoqParam context.Context, createMultipartUploadInput s3response.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
 //				panic("mock out the CreateMultipartUpload method")
 //			},
 //			DeleteBucketFunc: func(contextMoqParam context.Context, bucket string) error {
@@ -140,7 +140,7 @@ var _ backend.Backend = &BackendMock{}
 //			PutBucketVersioningFunc: func(contextMoqParam context.Context, bucket string, status types.BucketVersioningStatus) error {
 //				panic("mock out the PutBucketVersioning method")
 //			},
-//			PutObjectFunc: func(contextMoqParam context.Context, putObjectInput *s3.PutObjectInput) (s3response.PutObjectOutput, error) {
+//			PutObjectFunc: func(contextMoqParam context.Context, putObjectInput s3response.PutObjectInput) (s3response.PutObjectOutput, error) {
 //				panic("mock out the PutObject method")
 //			},
 //			PutObjectAclFunc: func(contextMoqParam context.Context, putObjectAclInput *s3.PutObjectAclInput) error {
@@ -199,7 +199,7 @@ type BackendMock struct {
 	CreateBucketFunc func(contextMoqParam context.Context, createBucketInput *s3.CreateBucketInput, defaultACL []byte) error
 
 	// CreateMultipartUploadFunc mocks the CreateMultipartUpload method.
-	CreateMultipartUploadFunc func(contextMoqParam context.Context, createMultipartUploadInput *s3.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error)
+	CreateMultipartUploadFunc func(contextMoqParam context.Context, createMultipartUploadInput s3response.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error)
 
 	// DeleteBucketFunc mocks the DeleteBucket method.
 	DeleteBucketFunc func(contextMoqParam context.Context, bucket string) error
@@ -301,7 +301,7 @@ type BackendMock struct {
 	PutBucketVersioningFunc func(contextMoqParam context.Context, bucket string, status types.BucketVersioningStatus) error
 
 	// PutObjectFunc mocks the PutObject method.
-	PutObjectFunc func(contextMoqParam context.Context, putObjectInput *s3.PutObjectInput) (s3response.PutObjectOutput, error)
+	PutObjectFunc func(contextMoqParam context.Context, putObjectInput s3response.PutObjectInput) (s3response.PutObjectOutput, error)
 
 	// PutObjectAclFunc mocks the PutObjectAcl method.
 	PutObjectAclFunc func(contextMoqParam context.Context, putObjectAclInput *s3.PutObjectAclInput) error
@@ -382,7 +382,7 @@ type BackendMock struct {
 			// ContextMoqParam is the contextMoqParam argument value.
 			ContextMoqParam context.Context
 			// CreateMultipartUploadInput is the createMultipartUploadInput argument value.
-			CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+			CreateMultipartUploadInput s3response.CreateMultipartUploadInput
 		}
 		// DeleteBucket holds details about calls to the DeleteBucket method.
 		DeleteBucket []struct {
@@ -640,7 +640,7 @@ type BackendMock struct {
 			// ContextMoqParam is the contextMoqParam argument value.
 			ContextMoqParam context.Context
 			// PutObjectInput is the putObjectInput argument value.
-			PutObjectInput *s3.PutObjectInput
+			PutObjectInput s3response.PutObjectInput
 		}
 		// PutObjectAcl holds details about calls to the PutObjectAcl method.
 		PutObjectAcl []struct {
@@ -974,13 +974,13 @@ func (mock *BackendMock) CreateBucketCalls() []struct {
 }
 
 // CreateMultipartUpload calls CreateMultipartUploadFunc.
-func (mock *BackendMock) CreateMultipartUpload(contextMoqParam context.Context, createMultipartUploadInput *s3.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
+func (mock *BackendMock) CreateMultipartUpload(contextMoqParam context.Context, createMultipartUploadInput s3response.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
 	if mock.CreateMultipartUploadFunc == nil {
 		panic("BackendMock.CreateMultipartUploadFunc: method is nil but Backend.CreateMultipartUpload was just called")
 	}
 	callInfo := struct {
 		ContextMoqParam            context.Context
-		CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+		CreateMultipartUploadInput s3response.CreateMultipartUploadInput
 	}{
 		ContextMoqParam:            contextMoqParam,
 		CreateMultipartUploadInput: createMultipartUploadInput,
@@ -997,11 +997,11 @@ func (mock *BackendMock) CreateMultipartUpload(contextMoqParam context.Context, 
 //	len(mockedBackend.CreateMultipartUploadCalls())
 func (mock *BackendMock) CreateMultipartUploadCalls() []struct {
 	ContextMoqParam            context.Context
-	CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+	CreateMultipartUploadInput s3response.CreateMultipartUploadInput
 } {
 	var calls []struct {
 		ContextMoqParam            context.Context
-		CreateMultipartUploadInput *s3.CreateMultipartUploadInput
+		CreateMultipartUploadInput s3response.CreateMultipartUploadInput
 	}
 	mock.lockCreateMultipartUpload.RLock()
 	calls = mock.calls.CreateMultipartUpload
@@ -2238,13 +2238,13 @@ func (mock *BackendMock) PutBucketVersioningCalls() []struct {
 }
 
 // PutObject calls PutObjectFunc.
-func (mock *BackendMock) PutObject(contextMoqParam context.Context, putObjectInput *s3.PutObjectInput) (s3response.PutObjectOutput, error) {
+func (mock *BackendMock) PutObject(contextMoqParam context.Context, putObjectInput s3response.PutObjectInput) (s3response.PutObjectOutput, error) {
 	if mock.PutObjectFunc == nil {
 		panic("BackendMock.PutObjectFunc: method is nil but Backend.PutObject was just called")
 	}
 	callInfo := struct {
 		ContextMoqParam context.Context
-		PutObjectInput  *s3.PutObjectInput
+		PutObjectInput  s3response.PutObjectInput
 	}{
 		ContextMoqParam: contextMoqParam,
 		PutObjectInput:  putObjectInput,
@@ -2261,11 +2261,11 @@ func (mock *BackendMock) PutObject(contextMoqParam context.Context, putObjectInp
 //	len(mockedBackend.PutObjectCalls())
 func (mock *BackendMock) PutObjectCalls() []struct {
 	ContextMoqParam context.Context
-	PutObjectInput  *s3.PutObjectInput
+	PutObjectInput  s3response.PutObjectInput
 } {
 	var calls []struct {
 		ContextMoqParam context.Context
-		PutObjectInput  *s3.PutObjectInput
+		PutObjectInput  s3response.PutObjectInput
 	}
 	mock.lockPutObject.RLock()
 	calls = mock.calls.PutObject

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -556,7 +556,36 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 			Value: acceptRanges,
 		},
 	}
-
+	if getstring(res.ContentDisposition) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "Content-Disposition",
+			Value: getstring(res.ContentDisposition),
+		})
+	}
+	if getstring(res.ContentEncoding) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "Content-Encoding",
+			Value: getstring(res.ContentEncoding),
+		})
+	}
+	if getstring(res.ContentLanguage) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "Content-Language",
+			Value: getstring(res.ContentLanguage),
+		})
+	}
+	if getstring(res.CacheControl) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "Cache-Control",
+			Value: getstring(res.CacheControl),
+		})
+	}
+	if getstring(res.ExpiresString) != "" {
+		hdrs = append(hdrs, utils.CustomHeader{
+			Key:   "Expires",
+			Value: getstring(res.ExpiresString),
+		})
+	}
 	if getstring(res.ContentRange) != "" {
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "Content-Range",
@@ -567,12 +596,6 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "Last-Modified",
 			Value: res.LastModified.Format(timefmt),
-		})
-	}
-	if getstring(res.ContentEncoding) != "" {
-		hdrs = append(hdrs, utils.CustomHeader{
-			Key:   "Content-Encoding",
-			Value: getstring(res.ContentEncoding),
 		})
 	}
 	if res.TagCount != nil {
@@ -1705,6 +1728,9 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 	isRoot := ctx.Locals("isRoot").(bool)
 	contentType := ctx.Get("Content-Type")
 	contentEncoding := ctx.Get("Content-Encoding")
+	contentDisposition := ctx.Get("Content-Disposition")
+	contentLanguage := ctx.Get("Content-Language")
+	cacheControl := ctx.Get("Cache-Control")
 	parsedAcl := ctx.Locals("parsedAcl").(auth.ACL)
 	tagging := ctx.Get("x-amz-tagging")
 
@@ -2500,6 +2526,8 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 			})
 	}
 
+	expires := ctx.Get("Expires")
+
 	var body io.Reader
 	bodyi := ctx.Locals("body-reader")
 	if bodyi != nil {
@@ -2510,12 +2538,16 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 
 	ctx.Locals("logReqBody", false)
 	res, err := c.be.PutObject(ctx.Context(),
-		&s3.PutObjectInput{
+		s3response.PutObjectInput{
 			Bucket:                    &bucket,
 			Key:                       &keyStart,
 			ContentLength:             &contentLength,
 			ContentType:               &contentType,
 			ContentEncoding:           &contentEncoding,
+			ContentDisposition:        &contentDisposition,
+			ContentLanguage:           &contentLanguage,
+			CacheControl:              &cacheControl,
+			Expires:                   &expires,
 			Metadata:                  metadata,
 			Body:                      body,
 			Tagging:                   &tagging,
@@ -3164,6 +3196,36 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 			Value: getstring(res.Restore),
 		},
 	}
+	if getstring(res.ContentDisposition) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "Content-Disposition",
+			Value: getstring(res.ContentDisposition),
+		})
+	}
+	if getstring(res.ContentEncoding) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "Content-Encoding",
+			Value: getstring(res.ContentEncoding),
+		})
+	}
+	if getstring(res.ContentLanguage) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "Content-Language",
+			Value: getstring(res.ContentLanguage),
+		})
+	}
+	if getstring(res.CacheControl) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "Cache-Control",
+			Value: getstring(res.CacheControl),
+		})
+	}
+	if getstring(res.ExpiresString) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "Expires",
+			Value: getstring(res.ExpiresString),
+		})
+	}
 	if res.ObjectLockMode != "" {
 		headers = append(headers, utils.CustomHeader{
 			Key:   "x-amz-object-lock-mode",
@@ -3194,12 +3256,6 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 		headers = append(headers, utils.CustomHeader{
 			Key:   "Last-Modified",
 			Value: lastmod,
-		})
-	}
-	if res.ContentEncoding != nil {
-		headers = append(headers, utils.CustomHeader{
-			Key:   "Content-Encoding",
-			Value: getstring(res.ContentEncoding),
 		})
 	}
 	if res.StorageClass != "" {
@@ -3278,6 +3334,9 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 	isRoot := ctx.Locals("isRoot").(bool)
 	parsedAcl := ctx.Locals("parsedAcl").(auth.ACL)
 	contentType := ctx.Get("Content-Type")
+	contentDisposition := ctx.Get("Content-Disposition")
+	contentLanguage := ctx.Get("Content-Language")
+	cacheControl := ctx.Get("Cache-Control")
 	contentEncoding := ctx.Get("Content-Encoding")
 	tagging := ctx.Get("X-Amz-Tagging")
 
@@ -3604,13 +3663,19 @@ func (c S3ApiController) CreateActions(ctx *fiber.Ctx) error {
 			})
 	}
 
+	expires := ctx.Get("Expires")
+
 	res, err := c.be.CreateMultipartUpload(ctx.Context(),
-		&s3.CreateMultipartUploadInput{
+		s3response.CreateMultipartUploadInput{
 			Bucket:                    &bucket,
 			Key:                       &key,
 			Tagging:                   &tagging,
 			ContentType:               &contentType,
 			ContentEncoding:           &contentEncoding,
+			ContentDisposition:        &contentDisposition,
+			ContentLanguage:           &contentLanguage,
+			CacheControl:              &cacheControl,
+			Expires:                   &expires,
 			ObjectLockRetainUntilDate: &objLockState.RetainUntilDate,
 			ObjectLockMode:            objLockState.ObjectLockMode,
 			ObjectLockLegalHoldStatus: objLockState.LegalHoldStatus,

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -980,7 +980,7 @@ func TestS3ApiController_PutActions(t *testing.T) {
 					CopyObjectResult: &types.CopyObjectResult{},
 				}, nil
 			},
-			PutObjectFunc: func(context.Context, *s3.PutObjectInput) (s3response.PutObjectOutput, error) {
+			PutObjectFunc: func(context.Context, s3response.PutObjectInput) (s3response.PutObjectOutput, error) {
 				return s3response.PutObjectOutput{}, nil
 			},
 			UploadPartFunc: func(context.Context, *s3.UploadPartInput) (*s3.UploadPartOutput, error) {
@@ -1769,7 +1769,7 @@ func TestS3ApiController_CreateActions(t *testing.T) {
 			CompleteMultipartUploadFunc: func(context.Context, *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
 				return &s3.CompleteMultipartUploadOutput{}, nil
 			},
-			CreateMultipartUploadFunc: func(context.Context, *s3.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
+			CreateMultipartUploadFunc: func(context.Context, s3response.CreateMultipartUploadInput) (s3response.InitiateMultipartUploadResult, error) {
 				return s3response.InitiateMultipartUploadResult{}, nil
 			},
 			SelectObjectContentFunc: func(context.Context, *s3.SelectObjectContentInput) func(w *bufio.Writer) {

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -16,6 +16,7 @@ package s3response
 
 import (
 	"encoding/xml"
+	"io"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -445,6 +446,82 @@ type PutObjectRetentionInput struct {
 	XMLName         xml.Name `xml:"Retention"`
 	Mode            types.ObjectLockRetentionMode
 	RetainUntilDate AmzDate
+}
+
+type PutObjectInput struct {
+	ContentLength             *int64
+	ObjectLockRetainUntilDate *time.Time
+
+	Bucket                  *string
+	Key                     *string
+	ContentType             *string
+	ContentEncoding         *string
+	ContentDisposition      *string
+	ContentLanguage         *string
+	CacheControl            *string
+	Expires                 *string
+	Tagging                 *string
+	ChecksumCRC32           *string
+	ChecksumCRC32C          *string
+	ChecksumSHA1            *string
+	ChecksumSHA256          *string
+	ChecksumCRC64NVME       *string
+	ContentMD5              *string
+	ExpectedBucketOwner     *string
+	GrantFullControl        *string
+	GrantRead               *string
+	GrantReadACP            *string
+	GrantWriteACP           *string
+	IfMatch                 *string
+	IfNoneMatch             *string
+	SSECustomerAlgorithm    *string
+	SSECustomerKey          *string
+	SSECustomerKeyMD5       *string
+	SSEKMSEncryptionContext *string
+	SSEKMSKeyId             *string
+	WebsiteRedirectLocation *string
+
+	ObjectLockMode            types.ObjectLockMode
+	ObjectLockLegalHoldStatus types.ObjectLockLegalHoldStatus
+	ChecksumAlgorithm         types.ChecksumAlgorithm
+
+	Metadata map[string]string
+	Body     io.Reader
+}
+
+type CreateMultipartUploadInput struct {
+	Bucket                    *string
+	Key                       *string
+	ExpectedBucketOwner       *string
+	CacheControl              *string
+	ContentDisposition        *string
+	ContentEncoding           *string
+	ContentLanguage           *string
+	ContentType               *string
+	Expires                   *string
+	SSECustomerAlgorithm      *string
+	SSECustomerKey            *string
+	SSECustomerKeyMD5         *string
+	SSEKMSEncryptionContext   *string
+	SSEKMSKeyId               *string
+	GrantFullControl          *string
+	GrantRead                 *string
+	GrantReadACP              *string
+	GrantWriteACP             *string
+	Tagging                   *string
+	WebsiteRedirectLocation   *string
+	BucketKeyEnabled          *bool
+	ObjectLockRetainUntilDate *time.Time
+	Metadata                  map[string]string
+
+	ACL                       types.ObjectCannedACL
+	ChecksumAlgorithm         types.ChecksumAlgorithm
+	ChecksumType              types.ChecksumType
+	ObjectLockLegalHoldStatus types.ObjectLockLegalHoldStatus
+	ObjectLockMode            types.ObjectLockMode
+	RequestPayer              types.RequestPayer
+	ServerSideEncryption      types.ServerSideEncryption
+	StorageClass              types.StorageClass
 }
 
 type AmzDate struct {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -304,7 +304,6 @@ func TestCreateMultipartUpload(s *S3Conf) {
 	CreateMultipartUpload_with_metadata(s)
 	CreateMultipartUpload_with_invalid_tagging(s)
 	CreateMultipartUpload_with_tagging(s)
-	CreateMultipartUpload_with_content_type(s)
 	CreateMultipartUpload_with_object_lock(s)
 	CreateMultipartUpload_with_object_lock_not_enabled(s)
 	CreateMultipartUpload_with_object_lock_invalid_retention(s)
@@ -933,7 +932,6 @@ func GetIntTests() IntTests {
 		"CreateMultipartUpload_with_metadata":                                     CreateMultipartUpload_with_metadata,
 		"CreateMultipartUpload_with_invalid_tagging":                              CreateMultipartUpload_with_invalid_tagging,
 		"CreateMultipartUpload_with_tagging":                                      CreateMultipartUpload_with_tagging,
-		"CreateMultipartUpload_with_content_type":                                 CreateMultipartUpload_with_content_type,
 		"CreateMultipartUpload_with_object_lock":                                  CreateMultipartUpload_with_object_lock,
 		"CreateMultipartUpload_with_object_lock_not_enabled":                      CreateMultipartUpload_with_object_lock_not_enabled,
 		"CreateMultipartUpload_with_object_lock_invalid_retention":                CreateMultipartUpload_with_object_lock_invalid_retention,


### PR DESCRIPTION
Closes #1128

Adds `Content-Disposition`, `Content-Language`, `Cache-Control` and `Expires` object meta properties support in posix and azure backends. Changes the `PutObject` and `CreateMultipartUpload` actions backend input type to custom `s3response` types to be able to store `Expires` as any string.