### PR TITLE
feat: sync recent posix changes to scoutfs

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -88,7 +88,6 @@ func Walk(ctx context.Context, fileSystem fs.FS, prefix, delimiter, marker strin
 		// so we can skip a directory without an early return
 		var skipflag error
 		if d.IsDir() {
-			fmt.Println("path: ", path)
 			// If prefix is defined and the directory does not match prefix,
 			// do not descend into the directory because nothing will
 			// match this prefix. Make sure to append the / at the end of


### PR DESCRIPTION
    This syncs recent updates to posix for scoutfs backend including
    the extra metadata such as Content-Disposition,
    Content-Language, Cache-Control and Expires. This also fixes the
    directory object listings that have a double trailing slash due
    to the change in the backend.Walk().
    
    This also simplifies head-object to call the posix on and then
    post process for glacier changes. This allows keeping in closer
    sync with posix head-object over time.