### PR TITLE
feat: Implements object meta properties for CopyObject in azure and p…

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -62,7 +62,7 @@ type Backend interface {
 	GetObject(context.Context, *s3.GetObjectInput) (*s3.GetObjectOutput, error)
 	GetObjectAcl(context.Context, *s3.GetObjectAclInput) (*s3.GetObjectAclOutput, error)
 	GetObjectAttributes(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error)
-	CopyObject(context.Context, *s3.CopyObjectInput) (*s3.CopyObjectOutput, error)
+	CopyObject(context.Context, s3response.CopyObjectInput) (*s3.CopyObjectOutput, error)
 	ListObjects(context.Context, *s3.ListObjectsInput) (s3response.ListObjectsResult, error)
 	ListObjectsV2(context.Context, *s3.ListObjectsV2Input) (s3response.ListObjectsV2Result, error)
 	DeleteObject(context.Context, *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
@@ -188,7 +188,7 @@ func (BackendUnsupported) GetObjectAcl(context.Context, *s3.GetObjectAclInput) (
 func (BackendUnsupported) GetObjectAttributes(context.Context, *s3.GetObjectAttributesInput) (s3response.GetObjectAttributesResponse, error) {
 	return s3response.GetObjectAttributesResponse{}, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
-func (BackendUnsupported) CopyObject(context.Context, *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
+func (BackendUnsupported) CopyObject(context.Context, s3response.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 func (BackendUnsupported) ListObjects(context.Context, *s3.ListObjectsInput) (s3response.ListObjectsResult, error) {

--- a/backend/common.go
+++ b/backend/common.go
@@ -211,6 +211,30 @@ func ParseCopySource(copySourceHeader string) (string, string, string, error) {
 	return srcBucket, srcObject, versionId, nil
 }
 
+// ParseObjectTags parses the url encoded input string into
+// map[string]string key-value tag set
+func ParseObjectTags(t string) (map[string]string, error) {
+	tagging := make(map[string]string)
+
+	if t == "" {
+		return tagging, nil
+	}
+
+	tagParts := strings.Split(t, "&")
+	for _, prt := range tagParts {
+		p := strings.Split(prt, "=")
+		if len(p) != 2 {
+			return nil, s3err.GetAPIError(s3err.ErrInvalidTag)
+		}
+		if len(p[0]) > 128 || len(p[1]) > 256 {
+			return nil, s3err.GetAPIError(s3err.ErrInvalidTag)
+		}
+		tagging[p[0]] = p[1]
+	}
+
+	return tagging, nil
+}
+
 func GetMultipartMD5(parts []types.CompletedPart) string {
 	var partsEtagBytes []byte
 	for _, part := range parts {

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -988,7 +988,7 @@ func (s *S3Proxy) GetObjectAttributes(ctx context.Context, input *s3.GetObjectAt
 	}, handleError(err)
 }
 
-func (s *S3Proxy) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
+func (s *S3Proxy) CopyObject(ctx context.Context, input s3response.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	if input.CacheControl != nil && *input.CacheControl == "" {
 		input.CacheControl = nil
 	}
@@ -1031,7 +1031,7 @@ func (s *S3Proxy) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s
 	if input.ExpectedSourceBucketOwner != nil && *input.ExpectedSourceBucketOwner == "" {
 		input.ExpectedSourceBucketOwner = nil
 	}
-	if input.Expires != nil && *input.Expires == defTime {
+	if input.Expires != nil && *input.Expires == "" {
 		input.Expires = nil
 	}
 	if input.GrantFullControl != nil && *input.GrantFullControl == "" {
@@ -1071,7 +1071,58 @@ func (s *S3Proxy) CopyObject(ctx context.Context, input *s3.CopyObjectInput) (*s
 		input.WebsiteRedirectLocation = nil
 	}
 
-	out, err := s.client.CopyObject(ctx, input)
+	var expires *time.Time
+	if input.Expires != nil {
+		exp, err := time.Parse(time.RFC1123, *input.Expires)
+		if err == nil {
+			expires = &exp
+		}
+	}
+
+	out, err := s.client.CopyObject(ctx,
+		&s3.CopyObjectInput{
+			Metadata:                       input.Metadata,
+			Bucket:                         input.Bucket,
+			CopySource:                     input.CopySource,
+			Key:                            input.Key,
+			CacheControl:                   input.CacheControl,
+			ContentDisposition:             input.ContentDisposition,
+			ContentEncoding:                input.ContentEncoding,
+			ContentLanguage:                input.ContentLanguage,
+			ContentType:                    input.ContentType,
+			CopySourceIfMatch:              input.CopySourceIfMatch,
+			CopySourceIfNoneMatch:          input.CopySourceIfNoneMatch,
+			CopySourceSSECustomerAlgorithm: input.CopySourceSSECustomerAlgorithm,
+			CopySourceSSECustomerKey:       input.CopySourceSSECustomerKey,
+			CopySourceSSECustomerKeyMD5:    input.CopySourceSSECustomerKeyMD5,
+			ExpectedBucketOwner:            input.ExpectedBucketOwner,
+			ExpectedSourceBucketOwner:      input.ExpectedSourceBucketOwner,
+			Expires:                        expires,
+			GrantFullControl:               input.GrantFullControl,
+			GrantRead:                      input.GrantRead,
+			GrantReadACP:                   input.GrantReadACP,
+			GrantWriteACP:                  input.GrantWriteACP,
+			SSECustomerAlgorithm:           input.SSECustomerAlgorithm,
+			SSECustomerKey:                 input.SSECustomerKey,
+			SSECustomerKeyMD5:              input.SSECustomerKeyMD5,
+			SSEKMSEncryptionContext:        input.SSEKMSEncryptionContext,
+			SSEKMSKeyId:                    input.SSEKMSKeyId,
+			Tagging:                        input.Tagging,
+			WebsiteRedirectLocation:        input.WebsiteRedirectLocation,
+			CopySourceIfModifiedSince:      input.CopySourceIfModifiedSince,
+			CopySourceIfUnmodifiedSince:    input.CopySourceIfUnmodifiedSince,
+			ObjectLockRetainUntilDate:      input.ObjectLockRetainUntilDate,
+			BucketKeyEnabled:               input.BucketKeyEnabled,
+			ACL:                            input.ACL,
+			ChecksumAlgorithm:              input.ChecksumAlgorithm,
+			MetadataDirective:              input.MetadataDirective,
+			ObjectLockLegalHoldStatus:      input.ObjectLockLegalHoldStatus,
+			ObjectLockMode:                 input.ObjectLockMode,
+			RequestPayer:                   input.RequestPayer,
+			ServerSideEncryption:           input.ServerSideEncryption,
+			StorageClass:                   input.StorageClass,
+			TaggingDirective:               input.TaggingDirective,
+		})
 	return out, handleError(err)
 }
 

--- a/s3api/controllers/backend_moq_test.go
+++ b/s3api/controllers/backend_moq_test.go
@@ -32,7 +32,7 @@ var _ backend.Backend = &BackendMock{}
 //			CompleteMultipartUploadFunc: func(contextMoqParam context.Context, completeMultipartUploadInput *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error) {
 //				panic("mock out the CompleteMultipartUpload method")
 //			},
-//			CopyObjectFunc: func(contextMoqParam context.Context, copyObjectInput *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
+//			CopyObjectFunc: func(contextMoqParam context.Context, copyObjectInput s3response.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 //				panic("mock out the CopyObject method")
 //			},
 //			CreateBucketFunc: func(contextMoqParam context.Context, createBucketInput *s3.CreateBucketInput, defaultACL []byte) error {
@@ -193,7 +193,7 @@ type BackendMock struct {
 	CompleteMultipartUploadFunc func(contextMoqParam context.Context, completeMultipartUploadInput *s3.CompleteMultipartUploadInput) (*s3.CompleteMultipartUploadOutput, error)
 
 	// CopyObjectFunc mocks the CopyObject method.
-	CopyObjectFunc func(contextMoqParam context.Context, copyObjectInput *s3.CopyObjectInput) (*s3.CopyObjectOutput, error)
+	CopyObjectFunc func(contextMoqParam context.Context, copyObjectInput s3response.CopyObjectInput) (*s3.CopyObjectOutput, error)
 
 	// CreateBucketFunc mocks the CreateBucket method.
 	CreateBucketFunc func(contextMoqParam context.Context, createBucketInput *s3.CreateBucketInput, defaultACL []byte) error
@@ -366,7 +366,7 @@ type BackendMock struct {
 			// ContextMoqParam is the contextMoqParam argument value.
 			ContextMoqParam context.Context
 			// CopyObjectInput is the copyObjectInput argument value.
-			CopyObjectInput *s3.CopyObjectInput
+			CopyObjectInput s3response.CopyObjectInput
 		}
 		// CreateBucket holds details about calls to the CreateBucket method.
 		CreateBucket []struct {
@@ -898,13 +898,13 @@ func (mock *BackendMock) CompleteMultipartUploadCalls() []struct {
 }
 
 // CopyObject calls CopyObjectFunc.
-func (mock *BackendMock) CopyObject(contextMoqParam context.Context, copyObjectInput *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
+func (mock *BackendMock) CopyObject(contextMoqParam context.Context, copyObjectInput s3response.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 	if mock.CopyObjectFunc == nil {
 		panic("BackendMock.CopyObjectFunc: method is nil but Backend.CopyObject was just called")
 	}
 	callInfo := struct {
 		ContextMoqParam context.Context
-		CopyObjectInput *s3.CopyObjectInput
+		CopyObjectInput s3response.CopyObjectInput
 	}{
 		ContextMoqParam: contextMoqParam,
 		CopyObjectInput: copyObjectInput,
@@ -921,11 +921,11 @@ func (mock *BackendMock) CopyObject(contextMoqParam context.Context, copyObjectI
 //	len(mockedBackend.CopyObjectCalls())
 func (mock *BackendMock) CopyObjectCalls() []struct {
 	ContextMoqParam context.Context
-	CopyObjectInput *s3.CopyObjectInput
+	CopyObjectInput s3response.CopyObjectInput
 } {
 	var calls []struct {
 		ContextMoqParam context.Context
-		CopyObjectInput *s3.CopyObjectInput
+		CopyObjectInput s3response.CopyObjectInput
 	}
 	mock.lockCopyObject.RLock()
 	calls = mock.calls.CopyObject

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -975,7 +975,7 @@ func TestS3ApiController_PutActions(t *testing.T) {
 			PutObjectAclFunc: func(context.Context, *s3.PutObjectAclInput) error {
 				return nil
 			},
-			CopyObjectFunc: func(context.Context, *s3.CopyObjectInput) (*s3.CopyObjectOutput, error) {
+			CopyObjectFunc: func(context.Context, s3response.CopyObjectInput) (*s3.CopyObjectOutput, error) {
 				return &s3.CopyObjectOutput{
 					CopyObjectResult: &types.CopyObjectResult{},
 				}, nil

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -144,6 +144,7 @@ const (
 	ErrUnexpectedContent
 	ErrMissingSecurityHeader
 	ErrInvalidMetadataDirective
+	ErrInvalidTaggingDirective
 	ErrKeyTooLong
 	ErrInvalidVersionId
 	ErrNoSuchVersion
@@ -595,6 +596,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidMetadataDirective: {
 		Code:           "InvalidArgument",
 		Description:    "Unknown metadata directive.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidTaggingDirective: {
+		Code:           "InvalidArgument",
+		Description:    "Unknown tagging directive.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidVersionId: {

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -524,6 +524,53 @@ type CreateMultipartUploadInput struct {
 	StorageClass              types.StorageClass
 }
 
+type CopyObjectInput struct {
+	Metadata                       map[string]string
+	Bucket                         *string
+	CopySource                     *string
+	Key                            *string
+	CacheControl                   *string
+	ContentDisposition             *string
+	ContentEncoding                *string
+	ContentLanguage                *string
+	ContentType                    *string
+	CopySourceIfMatch              *string
+	CopySourceIfNoneMatch          *string
+	CopySourceSSECustomerAlgorithm *string
+	CopySourceSSECustomerKey       *string
+	CopySourceSSECustomerKeyMD5    *string
+	ExpectedBucketOwner            *string
+	ExpectedSourceBucketOwner      *string
+	Expires                        *string
+	GrantFullControl               *string
+	GrantRead                      *string
+	GrantReadACP                   *string
+	GrantWriteACP                  *string
+	SSECustomerAlgorithm           *string
+	SSECustomerKey                 *string
+	SSECustomerKeyMD5              *string
+	SSEKMSEncryptionContext        *string
+	SSEKMSKeyId                    *string
+	Tagging                        *string
+	WebsiteRedirectLocation        *string
+
+	CopySourceIfModifiedSince   *time.Time
+	CopySourceIfUnmodifiedSince *time.Time
+	ObjectLockRetainUntilDate   *time.Time
+
+	BucketKeyEnabled *bool
+
+	ACL                       types.ObjectCannedACL
+	ChecksumAlgorithm         types.ChecksumAlgorithm
+	MetadataDirective         types.MetadataDirective
+	ObjectLockLegalHoldStatus types.ObjectLockLegalHoldStatus
+	ObjectLockMode            types.ObjectLockMode
+	RequestPayer              types.RequestPayer
+	ServerSideEncryption      types.ServerSideEncryption
+	StorageClass              types.StorageClass
+	TaggingDirective          types.TaggingDirective
+}
+
 type AmzDate struct {
 	time.Time
 }

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -266,9 +266,15 @@ func TestCopyObject(s *S3Conf) {
 	CopyObject_not_owned_source_bucket(s)
 	CopyObject_copy_to_itself(s)
 	CopyObject_copy_to_itself_invalid_directive(s)
+	CopyObject_should_copy_tagging(s)
+	CopyObject_invalid_tagging_directive(s)
 	CopyObject_to_itself_with_new_metadata(s)
 	CopyObject_CopySource_starting_with_slash(s)
 	CopyObject_non_existing_dir_object(s)
+	CopyObject_should_copy_meta_props(s)
+	CopyObject_should_replace_meta_props(s)
+	CopyObject_with_legal_hold(s)
+	CopyObject_with_retention_lock(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		CopyObject_invalid_checksum_algorithm(s)
@@ -909,9 +915,15 @@ func GetIntTests() IntTests {
 		"CopyObject_not_owned_source_bucket":                                      CopyObject_not_owned_source_bucket,
 		"CopyObject_copy_to_itself":                                               CopyObject_copy_to_itself,
 		"CopyObject_copy_to_itself_invalid_directive":                             CopyObject_copy_to_itself_invalid_directive,
+		"CopyObject_should_copy_tagging":                                          CopyObject_should_copy_tagging,
+		"CopyObject_invalid_tagging_directive":                                    CopyObject_invalid_tagging_directive,
 		"CopyObject_to_itself_with_new_metadata":                                  CopyObject_to_itself_with_new_metadata,
 		"CopyObject_CopySource_starting_with_slash":                               CopyObject_CopySource_starting_with_slash,
 		"CopyObject_non_existing_dir_object":                                      CopyObject_non_existing_dir_object,
+		"CopyObject_should_copy_meta_props":                                       CopyObject_should_copy_meta_props,
+		"CopyObject_should_replace_meta_props":                                    CopyObject_should_replace_meta_props,
+		"CopyObject_with_legal_hold":                                              CopyObject_with_legal_hold,
+		"CopyObject_with_retention_lock":                                          CopyObject_with_retention_lock,
 		"CopyObject_invalid_checksum_algorithm":                                   CopyObject_invalid_checksum_algorithm,
 		"CopyObject_create_checksum_on_copy":                                      CopyObject_create_checksum_on_copy,
 		"CopyObject_should_copy_the_existing_checksum":                            CopyObject_should_copy_the_existing_checksum,


### PR DESCRIPTION
Fixes #998
Closes #1125
Closes #1126
Closes #1127

Implements objects meta properties(Content-Disposition, Content-Language, Content-Encoding, Cache-Control, Expires) and tagging besed on the directives(metadata, tagging) in CopyObject in posix and azure backends. The properties/tagging should be coppied from the source object if "COPY" directive is provided and it should be replaced otherwise.

Changes the object copy principle in azure: instead of using the `CopyFromURL` method from azure sdk, it first loads the object then creates one, to be able to compare and store the meta properties.