### PR TITLE
fix: Fixes the bucket policy json document validation errors for inva…

### DIFF
--- a/auth/bucket_policy_actions.go
+++ b/auth/bucket_policy_actions.go
@@ -125,7 +125,7 @@ var supportedObjectActionList = map[Action]struct{}{
 // Validates Action: it should either wildcard match with supported actions list or be in it
 func (a Action) IsValid() error {
 	if !strings.HasPrefix(string(a), "s3:") {
-		return errInvalidAction
+		return policyErrInvalidAction
 	}
 
 	if a == AllActions {
@@ -140,12 +140,12 @@ func (a Action) IsValid() error {
 			}
 		}
 
-		return errInvalidAction
+		return policyErrInvalidAction
 	}
 
 	_, found := supportedActionList[a]
 	if !found {
-		return errInvalidAction
+		return policyErrInvalidAction
 	}
 	return nil
 }
@@ -191,7 +191,7 @@ func (a *Actions) UnmarshalJSON(data []byte) error {
 	var err error
 	if err = json.Unmarshal(data, &ss); err == nil {
 		if len(ss) == 0 {
-			return errInvalidAction
+			return policyErrInvalidAction
 		}
 		*a = make(Actions)
 		for _, s := range ss {
@@ -204,7 +204,7 @@ func (a *Actions) UnmarshalJSON(data []byte) error {
 		var s string
 		if err = json.Unmarshal(data, &s); err == nil {
 			if s == "" {
-				return errInvalidAction
+				return policyErrInvalidAction
 			}
 			*a = make(Actions)
 			err = a.Add(s)

--- a/auth/bucket_policy_principals.go
+++ b/auth/bucket_policy_principals.go
@@ -36,7 +36,7 @@ func (p *Principals) UnmarshalJSON(data []byte) error {
 
 	if err = json.Unmarshal(data, &ss); err == nil {
 		if len(ss) == 0 {
-			return errInvalidPrincipal
+			return policyErrInvalidPrincipal
 		}
 		*p = make(Principals)
 		for _, s := range ss {
@@ -45,7 +45,7 @@ func (p *Principals) UnmarshalJSON(data []byte) error {
 		return nil
 	} else if err = json.Unmarshal(data, &s); err == nil {
 		if s == "" {
-			return errInvalidPrincipal
+			return policyErrInvalidPrincipal
 		}
 		*p = make(Principals)
 		p.Add(s)
@@ -53,7 +53,7 @@ func (p *Principals) UnmarshalJSON(data []byte) error {
 		return nil
 	} else if err = json.Unmarshal(data, &k); err == nil {
 		if k.AWS == "" {
-			return errInvalidPrincipal
+			return policyErrInvalidPrincipal
 		}
 		*p = make(Principals)
 		p.Add(k.AWS)
@@ -65,7 +65,7 @@ func (p *Principals) UnmarshalJSON(data []byte) error {
 		}
 		if err = json.Unmarshal(data, &sk); err == nil {
 			if len(sk.AWS) == 0 {
-				return errInvalidPrincipal
+				return policyErrInvalidPrincipal
 			}
 			*p = make(Principals)
 			for _, s := range sk.AWS {
@@ -97,7 +97,7 @@ func (p Principals) Validate(iam IAMService) error {
 		if len(p) == 1 {
 			return nil
 		}
-		return errInvalidPrincipal
+		return policyErrInvalidPrincipal
 	}
 
 	accs, err := CheckIfAccountsExist(p.ToSlice(), iam)
@@ -105,7 +105,7 @@ func (p Principals) Validate(iam IAMService) error {
 		return err
 	}
 	if len(accs) > 0 {
-		return errInvalidPrincipal
+		return policyErrInvalidPrincipal
 	}
 
 	return nil

--- a/auth/bucket_policy_resources.go
+++ b/auth/bucket_policy_resources.go
@@ -29,7 +29,7 @@ func (r *Resources) UnmarshalJSON(data []byte) error {
 	var err error
 	if err = json.Unmarshal(data, &ss); err == nil {
 		if len(ss) == 0 {
-			return errInvalidResource
+			return policyErrInvalidResource
 		}
 		*r = make(Resources)
 		for _, s := range ss {
@@ -42,7 +42,7 @@ func (r *Resources) UnmarshalJSON(data []byte) error {
 		var s string
 		if err = json.Unmarshal(data, &s); err == nil {
 			if s == "" {
-				return errInvalidResource
+				return policyErrInvalidResource
 			}
 			*r = make(Resources)
 			err = r.Add(s)
@@ -59,7 +59,7 @@ func (r *Resources) UnmarshalJSON(data []byte) error {
 func (r Resources) Add(rc string) error {
 	ok, pattern := isValidResource(rc)
 	if !ok {
-		return errInvalidResource
+		return policyErrInvalidResource
 	}
 
 	r[pattern] = struct{}{}
@@ -93,7 +93,7 @@ func (r Resources) ContainsBucketPattern() bool {
 func (r Resources) Validate(bucket string) error {
 	for resource := range r {
 		if !strings.HasPrefix(resource, bucket) {
-			return errInvalidResource
+			return policyErrInvalidResource
 		}
 	}
 

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -634,8 +634,7 @@ func TestS3ApiController_PutBucketActions(t *testing.T) {
 	</VersioningConfiguration>
 	`
 
-	policyBody := `
-	{
+	policyBody := `{
 		"Statement": [
 			{
 				"Effect": "Allow",

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -466,6 +466,7 @@ func TestGetBucketAcl(s *S3Conf) {
 
 func TestPutBucketPolicy(s *S3Conf) {
 	PutBucketPolicy_non_existing_bucket(s)
+	PutBucketPolicy_invalid_json(s)
 	PutBucketPolicy_empty_statement(s)
 	PutBucketPolicy_invalid_effect(s)
 	PutBucketPolicy_empty_actions_string(s)
@@ -1055,6 +1056,7 @@ func GetIntTests() IntTests {
 		"GetBucketAcl_access_denied":                                              GetBucketAcl_access_denied,
 		"GetBucketAcl_success":                                                    GetBucketAcl_success,
 		"PutBucketPolicy_non_existing_bucket":                                     PutBucketPolicy_non_existing_bucket,
+		"PutBucketPolicy_invalid_json":                                            PutBucketPolicy_invalid_json,
 		"PutBucketPolicy_empty_statement":                                         PutBucketPolicy_empty_statement,
 		"PutBucketPolicy_invalid_effect":                                          PutBucketPolicy_invalid_effect,
 		"PutBucketPolicy_empty_actions_string":                                    PutBucketPolicy_empty_actions_string,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -973,8 +973,7 @@ func changeAuthCred(uri, newVal string, index int) (string, error) {
 }
 
 func genPolicyDoc(effect, principal, action, resource string) string {
-	jsonTemplate := `
-	{
+	jsonTemplate := `{
 		"Statement": [
 			{
 				"Effect":  "%s",


### PR DESCRIPTION
Fixes #965

Changes the returned error description to `Policies must be valid JSON and the first byte must be '{'` for invalid bucket policy json documents, which doesn't start with `{`. The gateway returns `This policy contains invalid Json` error description, if the document starts with `{`, but still isn't valid json.

Implements the `policyErr` string type which implements the `error` interface, to handle the policy json document validation errors, by avoiding staticchecker warnings.