### PR TITLE
fix: Changes the GetUserAccount method behavior in single iam mode to…

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -161,7 +161,7 @@ func New(o *Opts) (IAMService, error) {
 	default:
 		// if no iam options selected, default to the single user mode
 		fmt.Println("No IAM service configured, enabling single account mode")
-		return IAMServiceSingle{}, nil
+		return NewIAMServiceSingle(o.RootAccount), nil
 	}
 
 	if err != nil {


### PR DESCRIPTION
Fixes #977

Changes the `GetUserAccount` method implementation in isma single user mode to return the root account, if the root user account is requested and ErrAdminUserNotFound otherwise. In result the `ChangeBucketOwner` admin api behavior is changed for the root user to be able to change the bucket owner to root in iam single user mode.