### PR TITLE
feat: Implements signed chunk encoding with trailer in the gateway.

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -156,6 +156,7 @@ const (
 	ErrInvalidChecksumPart
 	ErrChecksumTypeWithAlgo
 	ErrInvalidChecksumHeader
+	ErrTrailerHeaderNotSupported
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -658,6 +659,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidChecksumHeader: {
 		Code:           "InvalidRequest",
 		Description:    "The algorithm type you specified in x-amz-checksum- header is invalid.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrTrailerHeaderNotSupported: {
+		Code:           "InvalidRequest",
+		Description:    "The value specified in the x-amz-trailer header is not supported",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 


### PR DESCRIPTION
Closes #1159
Fixes #1161

Implements signed chunk encoding with trailers in the gateway. The signed encoding (both with and without trailers) is now handled by the `ChunkReader`. Fixes the `ChunkReader` implementation to validate encoding headers byte by byte.

The chunk encoding with trailers follows the general signed chunk encoding pattern, but the final chunk includes the trailing signature (`x-amz-trailing-signature`) and the checksum header (`x-amz-checksum-x`, where `x` can be `crc32`, `crc32c`, `sha1`, `sha256`, or `crc64nvme`).

Adds validation for the `X-Amz-Trailer` header.