### PR TITLE
fix: Fixes the signed chunk trailer encoding to return proper api errors for invalid and incorrect checksums.

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -770,6 +770,14 @@ func GetInvalidChecksumHeaderErr(header string) APIError {
 	}
 }
 
+func GetInvalidTrailingChecksumHeaderErr(header string) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf("Value for %v trailing header is invalid.", header),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
 // Returns checksum type mismatch APIError
 func GetChecksumTypeMismatchErr(expected, actual types.ChecksumAlgorithm) APIError {
 	return APIError{
@@ -783,7 +791,7 @@ func GetChecksumTypeMismatchErr(expected, actual types.ChecksumAlgorithm) APIErr
 func GetChecksumBadDigestErr(algo types.ChecksumAlgorithm) APIError {
 	return APIError{
 		Code:           "BadDigest",
-		Description:    fmt.Sprintf("The %v you specified did not match the calculated checksum.", strings.ToLower(string(algo))),
+		Description:    fmt.Sprintf("The %v you specified did not match the calculated checksum.", algo),
 		HTTPStatusCode: http.StatusBadRequest,
 	}
 }

--- a/tests/util/util_object.sh
+++ b/tests/util/util_object.sh
@@ -361,11 +361,7 @@ check_checksum_rest_incorrect() {
     log 2 "error setting up bucket and file"
     return 1
   fi
-  if [ "$DIRECT" == "true" ]; then
-    error_cs_str="$(echo "$1" | tr '[:lower:]' '[:upper:]')"
-  else
-    error_cs_str="$1"
-  fi
+  error_cs_str="$(echo "$1" | tr '[:lower:]' '[:upper:]')"
   error_message="The $error_cs_str you specified did not match the calculated checksum."
   if ! calculate_incorrect_checksum "$1" "$(cat "$TEST_FILE_FOLDER/$test_file")"; then
     log 2 "error calculating incorrect checksum"


### PR DESCRIPTION
Fixes #1165

The signed chunk encoding with trailers should return api error for:

1. Invalid checksum - `(InvalidRequest) Value for x-amz-checksum-x trailing header is invalid.`
2. Incorrect checksum - `(BadDigest) The x you specified did not match the calculated checksum.`

Where `x` could be crc32, crc32c, sha1 ...