### PR TITLE
fix: Changes the HeadObject and GetObject actions LastModified proper…

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -520,7 +520,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 				},
 				{
 					Key:   "Last-Modified",
-					Value: res.LastModified.Format(timefmt),
+					Value: res.LastModified.UTC().Format(timefmt),
 				},
 			})
 		}
@@ -595,7 +595,7 @@ func (c S3ApiController) GetActions(ctx *fiber.Ctx) error {
 	if res.LastModified != nil {
 		hdrs = append(hdrs, utils.CustomHeader{
 			Key:   "Last-Modified",
-			Value: res.LastModified.Format(timefmt),
+			Value: res.LastModified.UTC().Format(timefmt),
 		})
 	}
 	if res.TagCount != nil {
@@ -3300,7 +3300,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 				},
 				{
 					Key:   "Last-Modified",
-					Value: res.LastModified.Format(timefmt),
+					Value: res.LastModified.UTC().Format(timefmt),
 				},
 			})
 		}
@@ -3384,7 +3384,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 		})
 	}
 	if res.LastModified != nil {
-		lastmod := res.LastModified.Format(timefmt)
+		lastmod := res.LastModified.UTC().Format(timefmt)
 		headers = append(headers, utils.CustomHeader{
 			Key:   "Last-Modified",
 			Value: lastmod,


### PR DESCRIPTION
Fixes #1137

Changes `LastModified` to `UTC` in the `GetObject` and `HeadObject` actions response.