### PR TITLE
fix: Hanldes the case when Statement is missing in PutBucketPolicy js…

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -468,6 +468,7 @@ func TestGetBucketAcl(s *S3Conf) {
 func TestPutBucketPolicy(s *S3Conf) {
 	PutBucketPolicy_non_existing_bucket(s)
 	PutBucketPolicy_invalid_json(s)
+	PutBucketPolicy_statement_not_provided(s)
 	PutBucketPolicy_empty_statement(s)
 	PutBucketPolicy_invalid_effect(s)
 	PutBucketPolicy_empty_actions_string(s)
@@ -1059,6 +1060,7 @@ func GetIntTests() IntTests {
 		"GetBucketAcl_success":                                                    GetBucketAcl_success,
 		"PutBucketPolicy_non_existing_bucket":                                     PutBucketPolicy_non_existing_bucket,
 		"PutBucketPolicy_invalid_json":                                            PutBucketPolicy_invalid_json,
+		"PutBucketPolicy_statement_not_provided":                                  PutBucketPolicy_statement_not_provided,
 		"PutBucketPolicy_empty_statement":                                         PutBucketPolicy_empty_statement,
 		"PutBucketPolicy_invalid_effect":                                          PutBucketPolicy_invalid_effect,
 		"PutBucketPolicy_empty_actions_string":                                    PutBucketPolicy_empty_actions_string,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -11463,6 +11463,24 @@ func PutBucketPolicy_invalid_json(s *S3Conf) error {
 	})
 }
 
+func PutBucketPolicy_statement_not_provided(s *S3Conf) error {
+	testName := "PutBucketPolicy_statement_not_provided"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		doc := `{}`
+
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{
+			Bucket: &bucket,
+			Policy: &doc,
+		})
+		cancel()
+		if err := checkApiErr(err, getMalformedPolicyError("Missing required field Statement")); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
 func PutBucketPolicy_empty_statement(s *S3Conf) error {
 	testName := "PutBucketPolicy_empty_statement"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
If `Statement` field is missing in the json document in `PutBucketPolicy` body, the gateway returns `Missing required field Statement` error description alongside with `MalformedPolicy` error code.