### PR TITLE
fis: Fixes the trailing slash issue in CopyObject destination and source object paths in posix.

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -641,6 +641,8 @@ func TestPosix(s *S3Conf) {
 	PutObject_name_too_long(s)
 	HeadObject_name_too_long(s)
 	DeleteObject_name_too_long(s)
+	CopyObject_overwrite_same_dir_object(s)
+	CopyObject_overwrite_same_file_object(s)
 	DeleteObject_directory_not_empty(s)
 	// posix specific versioning tests
 	if !s.versioningEnabled {
@@ -912,6 +914,8 @@ func GetIntTests() IntTests {
 		"DeleteObject_non_existing_object":                                        DeleteObject_non_existing_object,
 		"DeleteObject_directory_object_noslash":                                   DeleteObject_directory_object_noslash,
 		"DeleteObject_name_too_long":                                              DeleteObject_name_too_long,
+		"CopyObject_overwrite_same_dir_object":                                    CopyObject_overwrite_same_dir_object,
+		"CopyObject_overwrite_same_file_object":                                   CopyObject_overwrite_same_file_object,
 		"DeleteObject_non_existing_dir_object":                                    DeleteObject_non_existing_dir_object,
 		"DeleteObject_directory_object":                                           DeleteObject_directory_object,
 		"DeleteObject_success":                                                    DeleteObject_success,


### PR DESCRIPTION
Fixes #1021

`foo` and `foo/` object paths were considered as the same in `CopyObject` source and destination object paths in posix. Implements the `joinPathWithTrailer` function, which calls `filepath.Join` and adds trailing `/` if it existed in the original path. This way the implementation puts separation between directory and file objects with the same name.