### PR TITLE
feat: Adds Owner data in ListObjects(V2) result

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -1119,6 +1119,8 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 					BucketOwner: parsedAcl.Owner,
 				})
 		}
+
+		fetchOwner := strings.EqualFold(ctx.Query("fetch-owner"), "true")
 		res, err := c.be.ListObjectsV2(ctx.Context(),
 			&s3.ListObjectsV2Input{
 				Bucket:            &bucket,
@@ -1127,6 +1129,7 @@ func (c S3ApiController) ListActions(ctx *fiber.Ctx) error {
 				Delimiter:         &delimiter,
 				MaxKeys:           &maxkeys,
 				StartAfter:        &sAfter,
+				FetchOwner:        &fetchOwner,
 			})
 		return SendXMLResponse(ctx, res, err,
 			&MetaOpts{

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -218,6 +218,7 @@ func TestListObjects(s *S3Conf) {
 	ListObjects_marker_not_from_obj_list(s)
 	ListObjects_list_all_objs(s)
 	ListObjects_nested_dir_file_objs(s)
+	ListObjects_check_owner(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		ListObjects_with_checksum(s)
@@ -235,6 +236,7 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_all_objs_max_keys(s)
 	ListObjectsV2_exceeding_max_keys(s)
 	ListObjectsV2_list_all_objs(s)
+	ListObjectsV2_with_owner(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		ListObjectsV2_with_checksum(s)
@@ -897,6 +899,7 @@ func GetIntTests() IntTests {
 		"ListObjects_marker_not_from_obj_list":                                    ListObjects_marker_not_from_obj_list,
 		"ListObjects_list_all_objs":                                               ListObjects_list_all_objs,
 		"ListObjects_nested_dir_file_objs":                                        ListObjects_nested_dir_file_objs,
+		"ListObjects_check_owner":                                                 ListObjects_check_owner,
 		"ListObjects_with_checksum":                                               ListObjects_with_checksum,
 		"ListObjectsV2_start_after":                                               ListObjectsV2_start_after,
 		"ListObjectsV2_both_start_after_and_continuation_token":                   ListObjectsV2_both_start_after_and_continuation_token,
@@ -907,6 +910,7 @@ func GetIntTests() IntTests {
 		"ListObjectsV2_truncated_common_prefixes":                                 ListObjectsV2_truncated_common_prefixes,
 		"ListObjectsV2_all_objs_max_keys":                                         ListObjectsV2_all_objs_max_keys,
 		"ListObjectsV2_list_all_objs":                                             ListObjectsV2_list_all_objs,
+		"ListObjectsV2_with_owner":                                                ListObjectsV2_with_owner,
 		"ListObjectsV2_with_checksum":                                             ListObjectsV2_with_checksum,
 		"ListObjectVersions_VD_success":                                           ListObjectVersions_VD_success,
 		"DeleteObject_non_existing_object":                                        DeleteObject_non_existing_object,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -725,8 +725,14 @@ func compareObjects(list1, list2 []types.Object) bool {
 		if obj.ChecksumType != "" {
 			if obj.ChecksumType[0] != list2[i].ChecksumType[0] {
 				fmt.Printf("checksum types are not equal: (%q %q) %v != %v\n",
-					*obj.Key, *list2[i].Key, obj.ChecksumType[0], list2[i].ChecksumType[0])
+					*obj.Key, *list2[i].Key, obj.ChecksumType, list2[i].ChecksumType)
 				return false
+			}
+		}
+		if obj.Owner != nil {
+			if *obj.Owner.ID != *list2[i].Owner.ID {
+				fmt.Printf("object owner IDs not equal: (%q %q) %v != %v\n",
+					*obj.Key, *list2[i].Key, *obj.Owner.ID, *list2[i].Owner.ID)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #819

`ListObjects` returns object owner data in each object entity in the result, while `ListObjectsV2` has `fetch-owner` query param, which indicates if the objects owner data should be fetched. Adds these changes in the gateway to add `Owner` data in `ListObjects` and `ListObjectsV2` result. In aws the objects can be owned by different users in the same bucket. In the gateway all the objects are owned by the bucket owner.