### PR TITLE
fix: Fixes non empty directory objects deletion

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -252,6 +252,7 @@ func TestDeleteObject(s *S3Conf) {
 	DeleteObject_directory_object_noslash(s)
 	DeleteObject_non_existing_dir_object(s)
 	DeleteObject_directory_object(s)
+	DeleteObject_non_empty_dir_obj(s)
 	DeleteObject_success(s)
 	DeleteObject_success_status_code(s)
 }
@@ -913,6 +914,7 @@ func GetIntTests() IntTests {
 		"ListObjectVersions_VD_success":                                           ListObjectVersions_VD_success,
 		"DeleteObject_non_existing_object":                                        DeleteObject_non_existing_object,
 		"DeleteObject_directory_object_noslash":                                   DeleteObject_directory_object_noslash,
+		"DeleteObject_non_empty_dir_obj":                                          DeleteObject_non_empty_dir_obj,
 		"DeleteObject_name_too_long":                                              DeleteObject_name_too_long,
 		"CopyObject_overwrite_same_dir_object":                                    CopyObject_overwrite_same_dir_object,
 		"CopyObject_overwrite_same_file_object":                                   CopyObject_overwrite_same_file_object,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -5468,6 +5468,46 @@ func DeleteObject_directory_object_noslash(s *S3Conf) error {
 	})
 }
 
+func DeleteObject_non_empty_dir_obj(s *S3Conf) error {
+	testName := "DeleteObject_non_empty_dir_obj"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		objToDel := "foo/"
+		nestedObj := objToDel + "bar"
+		_, err := putObjects(s3client, []string{nestedObj, objToDel}, bucket)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: &bucket,
+			Key:    &objToDel,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		res, err := s3client.ListObjects(ctx, &s3.ListObjectsInput{
+			Bucket: &bucket,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		if len(res.Contents) != 1 {
+			return fmt.Errorf("expected the object list length to be 1, instead got %v", len(res.Contents))
+		}
+		if *res.Contents[0].Key != nestedObj {
+			return fmt.Errorf("expected the object key to be %v, instead got %v", nestedObj, *res.Contents[0].Key)
+		}
+
+		return nil
+	})
+}
+
 func DeleteObject_directory_not_empty(s *S3Conf) error {
 	testName := "DeleteObject_directory_not_empty"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
Fixes #1181

`DeleteObjects` should remove non-empty directory objects, which has been uploaded as a separate object. e.g
Upload -> `foo/bar`
Upload -> `foo/`

Delete -> `foo/`

The last action call should succeed.

The PR introduces changes which removes `ETag` from the directory object attempting to `delete`, which has been uploaded as a separate object.