### PR TITLE
fix: Makes the crc64nvme checksum as default for PutObject, even if no checksum is provided

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2668,6 +2668,10 @@ func (p *Posix) PutObject(ctx context.Context, po s3response.PutObjectInput) (s3
 	if po.Key == nil {
 		return s3response.PutObjectOutput{}, s3err.GetAPIError(s3err.ErrNoSuchKey)
 	}
+	// Override the checksum algorithm with default: CRC64NVME
+	if po.ChecksumAlgorithm == "" {
+		po.ChecksumAlgorithm = types.ChecksumAlgorithmCrc64nvme
+	}
 	_, err := os.Stat(*po.Bucket)
 	if errors.Is(err, fs.ErrNotExist) {
 		return s3response.PutObjectOutput{}, s3err.GetAPIError(s3err.ErrNoSuchBucket)

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -148,6 +148,7 @@ func TestPutObject(s *S3Conf) {
 		PutObject_multiple_checksum_headers(s)
 		PutObject_invalid_checksum_header(s)
 		PutObject_incorrect_checksums(s)
+		PutObject_default_checksum(s)
 		PutObject_checksums_success(s)
 	}
 	PutObject_success(s)
@@ -811,6 +812,7 @@ func GetIntTests() IntTests {
 		"PutObject_multiple_checksum_headers":                                     PutObject_multiple_checksum_headers,
 		"PutObject_invalid_checksum_header":                                       PutObject_invalid_checksum_header,
 		"PutObject_incorrect_checksums":                                           PutObject_incorrect_checksums,
+		"PutObject_default_checksum":                                              PutObject_default_checksum,
 		"PutObject_checksums_success":                                             PutObject_checksums_success,
 		"PresignedAuth_Put_GetObject_with_data":                                   PresignedAuth_Put_GetObject_with_data,
 		"PresignedAuth_Put_GetObject_with_UTF8_chars":                             PresignedAuth_Put_GetObject_with_UTF8_chars,


### PR DESCRIPTION
Fixes #1182

S3 calculates the `CRC64NVME` checksum of an object on object upload(`PutObject`), when no checksum algorithm or precalculated checksum header is provided. 

Makes the `CRC64NVME` checksum as default for `PutObject`, when no checksum is provided.