### PR TITLE
fix: Returns ErrSignatureVersionNotSupported for sigV2 signed requests.

### DIFF
--- a/s3api/middlewares/authentication.go
+++ b/s3api/middlewares/authentication.go
@@ -63,10 +63,6 @@ func VerifyV4Signature(root RootUserConfig, iam auth.IAMService, logger s3log.Au
 			return sendResponse(ctx, err, logger, mm)
 		}
 
-		if authData.Algorithm != "AWS4-HMAC-SHA256" {
-			return sendResponse(ctx, s3err.GetAPIError(s3err.ErrSignatureVersionNotSupported), logger, mm)
-		}
-
 		if authData.Region != region {
 			return sendResponse(ctx, s3err.APIError{
 				Code:           "SignatureDoesNotMatch",

--- a/s3api/utils/auth-reader.go
+++ b/s3api/utils/auth-reader.go
@@ -190,6 +190,10 @@ func ParseAuthorization(authorization string) (AuthData, error) {
 
 	algo := authParts[0]
 
+	if algo != "AWS4-HMAC-SHA256" {
+		return a, s3err.GetAPIError(s3err.ErrSignatureVersionNotSupported)
+	}
+
 	kvData := authParts[1]
 	kvPairs := strings.Split(kvData, ",")
 	// we are expecting at least Credential, SignedHeaders, and Signature

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -81,7 +81,7 @@ func Authentication_invalid_auth_header(s *S3Conf) error {
 		service:  "s3",
 		date:     time.Now(),
 	}, func(req *http.Request) error {
-		req.Header.Set("Authorization", "invalid header")
+		req.Header.Set("Authorization", "invalid_header")
 
 		resp, err := s.httpClient.Do(req)
 		if err != nil {


### PR DESCRIPTION
Fixes #1171

As signature v2 is depracated the gateway doesn't support it. AWS S3 supports signature version 2 in some regions. For some regions the request fails with error:
```
InvalidRequest: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.
```

The PR makes this change to return unsupported authorization mechanism for `sigV2` requests.