### PR TITLE
fix: Increases the context cancelation deadline in integration tests.

### DIFF
--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -39,7 +39,7 @@ import (
 )
 
 var (
-	shortTimeout  = 10 * time.Second
+	shortTimeout  = 30 * time.Second
 	longTimeout   = 60 * time.Second
 	iso8601Format = "20060102T150405Z"
 	timefmt       = "Mon, 02 Jan 2006 15:04:05 GMT"


### PR DESCRIPTION
Increases the context cancelation deadline to `30` seconds to avoid timeouts in relatively large tests.