### PR TITLE
fix: Changes the GetObjectLegalHold result root tag to LegalHold

### DIFF
--- a/auth/object_lock.go
+++ b/auth/object_lock.go
@@ -120,18 +120,18 @@ func ParseObjectLockRetentionOutput(input []byte) (*types.ObjectLockRetention, e
 	return &retention, nil
 }
 
-func ParseObjectLegalHoldOutput(status *bool) *types.ObjectLockLegalHold {
+func ParseObjectLegalHoldOutput(status *bool) *s3response.GetObjectLegalHoldResult {
 	if status == nil {
 		return nil
 	}
 
 	if *status {
-		return &types.ObjectLockLegalHold{
+		return &s3response.GetObjectLegalHoldResult{
 			Status: types.ObjectLockLegalHoldStatusOn,
 		}
 	}
 
-	return &types.ObjectLockLegalHold{
+	return &s3response.GetObjectLegalHoldResult{
 		Status: types.ObjectLockLegalHoldStatusOff,
 	}
 }

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -571,6 +571,11 @@ type CopyObjectInput struct {
 	TaggingDirective          types.TaggingDirective
 }
 
+type GetObjectLegalHoldResult struct {
+	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LegalHold"`
+	Status  types.ObjectLockLegalHoldStatus
+}
+
 type AmzDate struct {
 	time.Time
 }


### PR DESCRIPTION
Fixes #1193

Changes the xml root tag element to `LegalHold` in `GetObjectLegalHold` response.