### PR TITLE
fix: Changes the error type to MalformedXML for PutObjectRetention and PutObjectLegalHold empty or invalid body

### DIFF
--- a/auth/object_lock.go
+++ b/auth/object_lock.go
@@ -95,7 +95,7 @@ func ParseBucketLockConfigurationOutput(input []byte) (*types.ObjectLockConfigur
 func ParseObjectLockRetentionInput(input []byte) ([]byte, error) {
 	var retention s3response.PutObjectRetentionInput
 	if err := xml.Unmarshal(input, &retention); err != nil {
-		return nil, s3err.GetAPIError(s3err.ErrInvalidRequest)
+		return nil, s3err.GetAPIError(s3err.ErrMalformedXML)
 	}
 
 	if retention.RetainUntilDate.Before(time.Now()) {

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -1969,7 +1969,7 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 	if ctx.Request().URI().QueryArgs().Has("legal-hold") {
 		var legalHold types.ObjectLockLegalHold
 		if err := xml.Unmarshal(ctx.Body(), &legalHold); err != nil {
-			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidRequest),
+			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrMalformedXML),
 				&MetaOpts{
 					Logger:      c.logger,
 					MetricsMng:  c.mm,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -13173,7 +13173,7 @@ func PutObjectLegalHold_invalid_body(s *S3Conf) error {
 			Key:    getPtr("my-obj"),
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidRequest)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedXML)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Fixes #1185
Fixes #1191

`PutObjectLegalHold` and `PutObjectRetention` should return `MalformedXML` if the request body is empty or invalid.`