### PR TITLE
fix: Changes the backend.Walk implementation to return non-truncated result if both delimiter and max-keys are provided

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -220,6 +220,7 @@ func TestListObjects(s *S3Conf) {
 	ListObjects_list_all_objs(s)
 	ListObjects_nested_dir_file_objs(s)
 	ListObjects_check_owner(s)
+	ListObjects_non_truncated_common_prefixes(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		ListObjects_with_checksum(s)
@@ -905,6 +906,7 @@ func GetIntTests() IntTests {
 		"ListObjects_list_all_objs":                                               ListObjects_list_all_objs,
 		"ListObjects_nested_dir_file_objs":                                        ListObjects_nested_dir_file_objs,
 		"ListObjects_check_owner":                                                 ListObjects_check_owner,
+		"ListObjects_non_truncated_common_prefixes":                               ListObjects_non_truncated_common_prefixes,
 		"ListObjects_with_checksum":                                               ListObjects_with_checksum,
 		"ListObjectsV2_start_after":                                               ListObjectsV2_start_after,
 		"ListObjectsV2_both_start_after_and_continuation_token":                   ListObjectsV2_both_start_after_and_continuation_token,


### PR DESCRIPTION
Fixes #816

`ListObjects(V2)` used to return truncated response, if delimiter is provided and the result is limited by max-keys and the number of common prefixes is the same as `max-keys`. e.g
PUT -> `foo/bar`
PUT -> `foo/quxx`
LIST: `max-keys=1;delim=/` -> foo/

`ListObjects(V2)` should return `foo/` as common prefix and `truncated` should be `false`.

The PR makes this fix to return `non-truncated` response for the above described case.