### PR TITLE
fix: Sets limit to tag set count to 10 for PutObjectTagging and 50 for PutBucketTagging

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -1225,6 +1225,19 @@ func (c S3ApiController) PutBucketActions(ctx *fiber.Ctx) error {
 				})
 		}
 
+		if len(bucketTagging.TagSet.Tags) > 50 {
+			if c.debug {
+				log.Printf("bucket tagging length exceeds 50: %v\n", len(bucketTagging.TagSet.Tags))
+			}
+			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrBucketTaggingLimited),
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionPutBucketTagging,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
 		tags := make(map[string]string, len(bucketTagging.TagSet.Tags))
 
 		for _, tag := range bucketTagging.TagSet.Tags {
@@ -1855,6 +1868,19 @@ func (c S3ApiController) PutActions(ctx *fiber.Ctx) error {
 				log.Printf("error unmarshalling object tagging: %v", err)
 			}
 			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrInvalidRequest),
+				&MetaOpts{
+					Logger:      c.logger,
+					MetricsMng:  c.mm,
+					Action:      metrics.ActionPutObjectTagging,
+					BucketOwner: parsedAcl.Owner,
+				})
+		}
+
+		if len(objTagging.TagSet.Tags) > 10 {
+			if c.debug {
+				log.Printf("bucket tagging length exceeds 10: %v\n", len(objTagging.TagSet.Tags))
+			}
+			return SendResponse(ctx, s3err.GetAPIError(s3err.ErrObjectTaggingLimited),
 				&MetaOpts{
 					Logger:      c.logger,
 					MetricsMng:  c.mm,

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -85,6 +85,8 @@ const (
 	ErrInvalidCopySource
 	ErrInvalidCopySourceRange
 	ErrInvalidTag
+	ErrBucketTaggingLimited
+	ErrObjectTaggingLimited
 	ErrAuthHeaderEmpty
 	ErrSignatureVersionNotSupported
 	ErrMalformedPOSTRequest
@@ -309,6 +311,16 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidTag: {
 		Code:           "InvalidArgument",
 		Description:    "The Tag value you have provided is invalid",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrBucketTaggingLimited: {
+		Code:           "BadRequest",
+		Description:    "Bucket tag count cannot be greater than 50",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrObjectTaggingLimited: {
+		Code:           "BadRequest",
+		Description:    "Object tags cannot be greater than 10",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrMalformedXML: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -118,6 +118,7 @@ func TestDeleteBucketOwnershipControls(s *S3Conf) {
 func TestPutBucketTagging(s *S3Conf) {
 	PutBucketTagging_non_existing_bucket(s)
 	PutBucketTagging_long_tags(s)
+	PutBucketTagging_tag_count_limit(s)
 	PutBucketTagging_success(s)
 	PutBucketTagging_success_status(s)
 }
@@ -297,6 +298,7 @@ func TestCopyObject(s *S3Conf) {
 func TestPutObjectTagging(s *S3Conf) {
 	PutObjectTagging_non_existing_object(s)
 	PutObjectTagging_long_tags(s)
+	PutObjectTagging_tag_count_limit(s)
 	PutObjectTagging_success(s)
 }
 
@@ -850,6 +852,7 @@ func GetIntTests() IntTests {
 		"DeleteBucketOwnershipControls_success":                                   DeleteBucketOwnershipControls_success,
 		"PutBucketTagging_non_existing_bucket":                                    PutBucketTagging_non_existing_bucket,
 		"PutBucketTagging_long_tags":                                              PutBucketTagging_long_tags,
+		"PutBucketTagging_tag_count_limit":                                        PutBucketTagging_tag_count_limit,
 		"PutBucketTagging_success":                                                PutBucketTagging_success,
 		"PutBucketTagging_success_status":                                         PutBucketTagging_success_status,
 		"GetBucketTagging_non_existing_bucket":                                    GetBucketTagging_non_existing_bucket,
@@ -956,6 +959,7 @@ func GetIntTests() IntTests {
 		"CopyObject_success":                                                      CopyObject_success,
 		"PutObjectTagging_non_existing_object":                                    PutObjectTagging_non_existing_object,
 		"PutObjectTagging_long_tags":                                              PutObjectTagging_long_tags,
+		"PutObjectTagging_tag_count_limit":                                        PutObjectTagging_tag_count_limit,
 		"PutObjectTagging_success":                                                PutObjectTagging_success,
 		"GetObjectTagging_non_existing_object":                                    GetObjectTagging_non_existing_object,
 		"GetObjectTagging_unset_tags":                                             GetObjectTagging_unset_tags,


### PR DESCRIPTION
Fixes #1204
Fixes #1205

Tag count in `PutBucketTagging` and `PutObjectTagging` is limited. `PutBucketTagging`: 50
`PutObjectTagging`: 10

Adds the changes to return errors respectively