### PR TITLE
feat: add option to disable use of O_TMPFILE

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -524,19 +524,19 @@ func initFlags() []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "ipa-user",
-			Usage:       "Username used to connect to FreeIPA. Needs permissions to read user vault contents",
+			Usage:       "Username used to connect to FreeIPA (requires permissions to read user vault contents)",
 			EnvVars:     []string{"VGW_IPA_USER"},
 			Destination: &ipaUser,
 		},
 		&cli.StringFlag{
 			Name:        "ipa-password",
-			Usage:       "Password of the user used to connect to FreeIPA.",
+			Usage:       "Password of the user used to connect to FreeIPA",
 			EnvVars:     []string{"VGW_IPA_PASSWORD"},
 			Destination: &ipaPassword,
 		},
 		&cli.BoolFlag{
 			Name:        "ipa-insecure",
-			Usage:       "Verify TLS certificate of FreeIPA server. Default is 'true'.",
+			Usage:       "Disable verify TLS certificate of FreeIPA server",
 			EnvVars:     []string{"VGW_IPA_INSECURE"},
 			Destination: &ipaInsecure,
 		},

--- a/cmd/versitygw/posix.go
+++ b/cmd/versitygw/posix.go
@@ -31,6 +31,7 @@ var (
 	dirPerms           uint
 	sidecar            string
 	nometa             bool
+	forceNoTmpFile     bool
 )
 
 func posixCommand() *cli.Command {
@@ -93,6 +94,12 @@ will be translated into the file /mnt/fs/gwroot/mybucket/a/b/c/myobject`,
 				EnvVars:     []string{"VGW_META_NONE"},
 				Destination: &nometa,
 			},
+			&cli.BoolFlag{
+				Name:        "disableotmp",
+				Usage:       "disable O_TMPFILE support for new objects",
+				EnvVars:     []string{"VGW_DISABLE_OTMP"},
+				Destination: &forceNoTmpFile,
+			},
 		},
 	}
 }
@@ -113,11 +120,12 @@ func runPosix(ctx *cli.Context) error {
 	}
 
 	opts := posix.PosixOpts{
-		ChownUID:      chownuid,
-		ChownGID:      chowngid,
-		BucketLinks:   bucketlinks,
-		VersioningDir: versioningDir,
-		NewDirPerm:    fs.FileMode(dirPerms),
+		ChownUID:       chownuid,
+		ChownGID:       chowngid,
+		BucketLinks:    bucketlinks,
+		VersioningDir:  versioningDir,
+		NewDirPerm:     fs.FileMode(dirPerms),
+		ForceNoTmpFile: forceNoTmpFile,
 	}
 
 	var ms meta.MetadataStorer

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -99,6 +99,10 @@ ROOT_SECRET_ACCESS_KEY=
 # endpoint is unauthenticated, and returns a 200 status for GET.
 #VGW_HEALTH=
 
+# Enable VGW_READ_ONLY to only allow read operations to the S3 server. No write
+# operations will be allowed.
+#VGW_READ_ONLY=false
+
 ###############
 # Access Logs #
 ###############
@@ -240,6 +244,24 @@ ROOT_SECRET_ACCESS_KEY=
 #VGW_IAM_LDAP_USER_ID_ATR=
 #VGW_IAM_LDAP_GROUP_ID_ATR=
 
+# The FreeIPA options will enable the FreeIPA IAM service with accounts stored
+# in an external FreeIPA service. Currently the FreeIPA IAM service only
+# supports account retrieval. Creating and modifying accounts must be done
+# outside of the versitygw service.
+# FreeIPA server url e.g. https://ipa.example.test
+#VGW_IPA_HOST=
+# A name of the user vault containing their secret
+#VGW_IPA_VAULT_NAME=
+# Username used to connect to FreeIPA (requires permissions to read user vault
+# contents)
+#VGW_IPA_USER=
+# Password of the user used to connect to FreeIPA
+#VGW_IPA_PASSWORD=
+# Disable verify TLS certificate of FreeIPA server
+#VGW_IPA_INSECURE=false
+# FreeIPA IAM debug output
+#VGW_IPA_DEBUG=false
+
 ###############
 # IAM caching #
 ###############
@@ -316,6 +338,40 @@ ROOT_SECRET_ACCESS_KEY=
 # gateway creates. This applies to buckets created through the gateway as well
 # as any parent directories automatically created with object uploads.
 #VGW_DIR_PERMS=0755
+
+# To enable object versions, the VGW_VERSIONING_DIR option must be set to the
+# directory that will be used to store the object versions. The version
+# directory must NOT be a subdirectory of the VGW_BACKEND_ARG directory.
+#VGW_VERSIONING_DIR=
+
+# The gateway uses xattrs to store metadata for objects by default. For systems
+# that do not support xattrs, the VGW_META_SIDECAR option can be set to a
+# directory that will be used to store the metadata for objects. This is
+# currently experimental, and may have issues for some edge cases.
+#VGW_META_SIDECAR=
+
+# The VGW_META_NONE option will disable the metadata functionality for the
+# gateway. This will cause the gateway to not store any metadata for objects
+# or buckets. This include bucket ACLs and Policy. This may be useful for
+# read only access to pre-existing data where the gateway should not modify
+# the data. It is recommened to enable VGW_READ_ONLY (Global Options) along
+# with this.
+#VGW_META_NONE=false
+
+# The gateway will use O_TMPFILE for writing objects while uploading and
+# link the file to the final object name when the upload is complete if the
+# filesystem supports O_TMPFILE. This creates an atomic object creation
+# that is not visible to other clients or racing uploads until the upload
+# is complete. This will not work if there is a different filesystem mounted
+# below the bucket level than where the bucket resides. The VGW_DISABLE_OTMP
+# option can be set to true to disable this functionality and force the fallback
+# mode when O_TMPFILE is not available. This fallback will create a temporary
+# file in the bucket directory and rename it to the final object name when
+# the upload is complete if the final location is in the same filesystem, or
+# copy the file to the final location if the final location is in a different
+# filesystem. This fallback mode is still atomic, but may be less efficient
+# than O_TMPFILE when the data needs to be copied into the final location.
+#VGW_DISABLE_OTMP=false
 
 ###########
 # scoutfs #


### PR DESCRIPTION
O_TMPFILE can fail if the location we need to link the final file is not within the same filesystem. This can happen if there are different filesystem mounts within a bucket or if using zfs nested datasets within a bucket.

Fixes #1194
Fixes #1035