### PR TITLE
fix: Fixes the InvalidTag error Code and Description

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -309,8 +309,8 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidTag: {
-		Code:           "InvalidArgument",
-		Description:    "The Tag value you have provided is invalid",
+		Code:           "InvalidTag",
+		Description:    "The TagValue you have provided is invalid",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrBucketTaggingLimited: {


### PR DESCRIPTION
For invalid bucket/object tags the error `Code` should be `InvalidTag` and `Message` - `The TagValue you have provided is invalid`.