### PR TITLE
fix: handles tag parsing error cases for PutBucketTagging and PutObjectTagging

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1041,10 +1041,10 @@ func (az *Azure) CreateMultipartUpload(ctx context.Context, input s3response.Cre
 		for _, prt := range tagParts {
 			p := strings.Split(prt, "=")
 			if len(p) != 2 {
-				return s3response.InitiateMultipartUploadResult{}, s3err.GetAPIError(s3err.ErrInvalidTag)
+				return s3response.InitiateMultipartUploadResult{}, s3err.GetAPIError(s3err.ErrInvalidTagValue)
 			}
 			if len(p[0]) > 128 || len(p[1]) > 256 {
-				return s3response.InitiateMultipartUploadResult{}, s3err.GetAPIError(s3err.ErrInvalidTag)
+				return s3response.InitiateMultipartUploadResult{}, s3err.GetAPIError(s3err.ErrInvalidTagValue)
 			}
 			tags[p[0]] = p[1]
 		}
@@ -1827,7 +1827,7 @@ func parseTags(tagstr *string) (map[string]string, error) {
 		for _, prt := range tagParts {
 			p := strings.Split(prt, "=")
 			if len(p) != 2 {
-				return nil, s3err.GetAPIError(s3err.ErrInvalidTag)
+				return nil, s3err.GetAPIError(s3err.ErrInvalidTagValue)
 			}
 			tags[p[0]] = p[1]
 		}

--- a/backend/azure/err.go
+++ b/backend/azure/err.go
@@ -40,7 +40,7 @@ func azErrToS3err(azErr *azcore.ResponseError) s3err.APIError {
 	case "BlobNotFound":
 		return s3err.GetAPIError(s3err.ErrNoSuchKey)
 	case "TagsTooLarge":
-		return s3err.GetAPIError(s3err.ErrInvalidTag)
+		return s3err.GetAPIError(s3err.ErrInvalidTagValue)
 	case "Requested Range Not Satisfiable":
 		return s3err.GetAPIError(s3err.ErrInvalidRange)
 	}

--- a/backend/common.go
+++ b/backend/common.go
@@ -227,10 +227,10 @@ func ParseObjectTags(t string) (map[string]string, error) {
 	for _, prt := range tagParts {
 		p := strings.Split(prt, "=")
 		if len(p) != 2 {
-			return nil, s3err.GetAPIError(s3err.ErrInvalidTag)
+			return nil, s3err.GetAPIError(s3err.ErrInvalidTagValue)
 		}
 		if len(p[0]) > 128 || len(p[1]) > 256 {
-			return nil, s3err.GetAPIError(s3err.ErrInvalidTag)
+			return nil, s3err.GetAPIError(s3err.ErrInvalidTagValue)
 		}
 		tagging[p[0]] = p[1]
 	}

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -84,7 +84,9 @@ const (
 	ErrInvalidCopyDest
 	ErrInvalidCopySource
 	ErrInvalidCopySourceRange
-	ErrInvalidTag
+	ErrInvalidTagKey
+	ErrInvalidTagValue
+	ErrDuplicateTagKey
 	ErrBucketTaggingLimited
 	ErrObjectTaggingLimited
 	ErrAuthHeaderEmpty
@@ -308,9 +310,19 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrInvalidTag: {
+	ErrInvalidTagKey: {
+		Code:           "InvalidTag",
+		Description:    "The TagKey you have provided is invalid",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidTagValue: {
 		Code:           "InvalidTag",
 		Description:    "The TagValue you have provided is invalid",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrDuplicateTagKey: {
+		Code:           "InvalidTag",
+		Description:    "Cannot provide multiple Tags with the same key",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrBucketTaggingLimited: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -118,6 +118,7 @@ func TestDeleteBucketOwnershipControls(s *S3Conf) {
 func TestPutBucketTagging(s *S3Conf) {
 	PutBucketTagging_non_existing_bucket(s)
 	PutBucketTagging_long_tags(s)
+	PutBucketTagging_duplicate_keys(s)
 	PutBucketTagging_tag_count_limit(s)
 	PutBucketTagging_success(s)
 	PutBucketTagging_success_status(s)
@@ -298,6 +299,7 @@ func TestCopyObject(s *S3Conf) {
 func TestPutObjectTagging(s *S3Conf) {
 	PutObjectTagging_non_existing_object(s)
 	PutObjectTagging_long_tags(s)
+	PutObjectTagging_duplicate_keys(s)
 	PutObjectTagging_tag_count_limit(s)
 	PutObjectTagging_success(s)
 }
@@ -852,6 +854,7 @@ func GetIntTests() IntTests {
 		"DeleteBucketOwnershipControls_success":                                   DeleteBucketOwnershipControls_success,
 		"PutBucketTagging_non_existing_bucket":                                    PutBucketTagging_non_existing_bucket,
 		"PutBucketTagging_long_tags":                                              PutBucketTagging_long_tags,
+		"PutBucketTagging_duplicate_keys":                                         PutBucketTagging_duplicate_keys,
 		"PutBucketTagging_tag_count_limit":                                        PutBucketTagging_tag_count_limit,
 		"PutBucketTagging_success":                                                PutBucketTagging_success,
 		"PutBucketTagging_success_status":                                         PutBucketTagging_success_status,
@@ -959,6 +962,7 @@ func GetIntTests() IntTests {
 		"CopyObject_success":                                                      CopyObject_success,
 		"PutObjectTagging_non_existing_object":                                    PutObjectTagging_non_existing_object,
 		"PutObjectTagging_long_tags":                                              PutObjectTagging_long_tags,
+		"PutObjectTagging_duplicate_keys":                                         PutObjectTagging_duplicate_keys,
 		"PutObjectTagging_tag_count_limit":                                        PutObjectTagging_tag_count_limit,
 		"PutObjectTagging_success":                                                PutObjectTagging_success,
 		"GetObjectTagging_non_existing_object":                                    GetObjectTagging_non_existing_object,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -2500,7 +2500,7 @@ func PutBucketTagging_long_tags(s *S3Conf) error {
 			Bucket:  &bucket,
 			Tagging: &tagging})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagKey)); err != nil {
 			return err
 		}
 
@@ -2511,7 +2511,32 @@ func PutBucketTagging_long_tags(s *S3Conf) error {
 			Bucket:  &bucket,
 			Tagging: &tagging})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagValue)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func PutBucketTagging_duplicate_keys(s *S3Conf) error {
+	testName := "PutBucketTagging_duplicate_keys"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		tagging := types.Tagging{
+			TagSet: []types.Tag{
+				{Key: getPtr("key"), Value: getPtr("value")},
+				{Key: getPtr("key"), Value: getPtr("value-1")},
+				{Key: getPtr("key-1"), Value: getPtr("value-2")},
+				{Key: getPtr("key-2"), Value: getPtr("value-3")},
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+			Bucket:  &bucket,
+			Tagging: &tagging,
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrDuplicateTagKey)); err != nil {
 			return err
 		}
 
@@ -2813,7 +2838,7 @@ func PutObject_invalid_long_tags(s *S3Conf) error {
 			Tagging: &tagging,
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagValue)); err != nil {
 			return err
 		}
 
@@ -2827,7 +2852,7 @@ func PutObject_invalid_long_tags(s *S3Conf) error {
 		})
 		cancel()
 
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagValue)); err != nil {
 			return err
 		}
 
@@ -6991,7 +7016,7 @@ func PutObjectTagging_long_tags(s *S3Conf) error {
 			Key:     &obj,
 			Tagging: &tagging})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagKey)); err != nil {
 			return err
 		}
 
@@ -7003,7 +7028,39 @@ func PutObjectTagging_long_tags(s *S3Conf) error {
 			Key:     &obj,
 			Tagging: &tagging})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagValue)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func PutObjectTagging_duplicate_keys(s *S3Conf) error {
+	testName := "PutObjectTagging_duplicate_keys"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		obj := "my-obj"
+		_, err := putObjects(s3client, []string{obj}, bucket)
+		if err != nil {
+			return err
+		}
+
+		tagging := types.Tagging{
+			TagSet: []types.Tag{
+				{Key: getPtr("key-1"), Value: getPtr("value-1")},
+				{Key: getPtr("key-2"), Value: getPtr("value-2")},
+				{Key: getPtr("same-key"), Value: getPtr("value-3")},
+				{Key: getPtr("same-key"), Value: getPtr("value-4")},
+			},
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+			Bucket:  &bucket,
+			Key:     &obj,
+			Tagging: &tagging,
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrDuplicateTagKey)); err != nil {
 			return err
 		}
 
@@ -7630,7 +7687,7 @@ func CreateMultipartUpload_with_invalid_tagging(s *S3Conf) error {
 			Tagging: getPtr("invalid_tag"),
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTag)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidTagValue)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Fixes #1214
Fixes #1231
Fixes #1232

Implements `utils.ParseTagging` which is a generic implementation of parsing tags for both `PutObjectTagging` and `PutBucketTagging`.

- The actions now return `MalformedXML` if the provided request body is invalid.
- Adds validation to return `InvalidTag` if duplicate keys are present in tagging.
- For invalid tag keys, it creates a new error: `ErrInvalidTagKey`.