### PR TITLE
Add support for plugin backends

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -98,6 +98,7 @@ func main() {
 		scoutfsCommand(),
 		s3Command(),
 		azureCommand(),
+		pluginCommand(),
 		adminCommand(),
 		testCommand(),
 		utilsCommand(),

--- a/cmd/versitygw/plugin.go
+++ b/cmd/versitygw/plugin.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package main
 
 import (

--- a/cmd/versitygw/plugin.go
+++ b/cmd/versitygw/plugin.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"plugin"
+
+	"github.com/urfave/cli/v2"
+	"github.com/versity/versitygw/plugins"
+)
+
+func pluginCommand() *cli.Command {
+	return &cli.Command{
+		Name:        "plugin",
+		Usage:       "load a backend from a plugin",
+		Description: "Runs a s3 gateway and redirects the requests to the backend defined in the plugin",
+		Action:      runPluginBackend,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:    "config",
+				Usage:   "location of the config file",
+				Aliases: []string{"c"},
+			},
+		},
+	}
+}
+
+func runPluginBackend(ctx *cli.Context) error {
+	if ctx.NArg() == 0 {
+		return fmt.Errorf("no plugin file provided to be loaded")
+	}
+
+	pluginPath := ctx.Args().Get(0)
+	config := ctx.String("config")
+
+	p, err := plugin.Open(pluginPath)
+	if err != nil {
+		return err
+	}
+
+	backendSymbol, err := p.Lookup("Backend")
+	if err != nil {
+		return err
+	}
+	backendPluginPtr, ok := backendSymbol.(*plugins.BackendPlugin)
+	if !ok {
+		return errors.New("plugin is not of type *plugins.BackendPlugin")
+	}
+
+	if backendPluginPtr == nil {
+		return errors.New("variable Backend is nil")
+	}
+
+	be, err := (*backendPluginPtr).New(config)
+	if err != nil {
+		return err
+	}
+
+	return runGateway(ctx.Context, be)
+}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,3 +1,17 @@
+// Copyright 2025 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package plugins
 
 import "github.com/versity/versitygw/backend"

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,0 +1,21 @@
+package plugins
+
+import "github.com/versity/versitygw/backend"
+
+// BackendPlugin defines an interface for creating backend
+// implementation instances.
+// Plugins implementing this interface can be built as shared
+// libraries using Go's plugin system (to build use `go build -buildmode=plugin`).
+// The shared library should export an instance of
+// this interface in a variable named `Backend`.
+type BackendPlugin interface {
+	// New creates and initializes a new backend.Backend instance.
+	// The config parameter specifies the path of the file containing
+	// the configuration for the backend.
+	//
+	// Implementations of this method should perform the necessary steps to
+	// establish a connection to the underlying storage system or service
+	// (e.g., network storage system, distributed storage system, cloud storage)
+	//  and configure it according to the provided configuration.
+	New(config string) (backend.Backend, error)
+}


### PR DESCRIPTION
Introduce support for loading storage backends via go plugins.

Plugins can be created as shared libraries using go's plugin system (to be compiled using the command `go build -buildmode=plugin`). The new command `versitygw plugin <path_plugin>` can be used to run a backend defined in the plugin.
The shared library should export an instance of the interface `PluginBackend` in a variable named `Backend`.

Closes #1207