### PR TITLE
fix: fixes tagging string parsing for PutObject, CopyObject and CreateMultipartUpload

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -89,6 +89,7 @@ const (
 	ErrDuplicateTagKey
 	ErrBucketTaggingLimited
 	ErrObjectTaggingLimited
+	ErrInvalidURLEncodedTagging
 	ErrAuthHeaderEmpty
 	ErrSignatureVersionNotSupported
 	ErrMalformedPOSTRequest
@@ -333,6 +334,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrObjectTaggingLimited: {
 		Code:           "BadRequest",
 		Description:    "Object tags cannot be greater than 10",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidURLEncodedTagging: {
+		Code:           "InvalidArgument",
+		Description:    "The header 'x-amz-tagging' shall be encoded as UTF-8 then URLEncoded URL query parameters without tag name duplicates.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrMalformedXML: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -139,7 +139,7 @@ func TestDeleteBucketTagging(s *S3Conf) {
 func TestPutObject(s *S3Conf) {
 	PutObject_non_existing_bucket(s)
 	PutObject_special_chars(s)
-	PutObject_invalid_long_tags(s)
+	PutObject_tagging(s)
 	PutObject_missing_object_lock_retention_config(s)
 	PutObject_with_object_lock(s)
 	PutObject_invalid_legal_hold(s)
@@ -274,6 +274,7 @@ func TestCopyObject(s *S3Conf) {
 	CopyObject_not_owned_source_bucket(s)
 	CopyObject_copy_to_itself(s)
 	CopyObject_copy_to_itself_invalid_directive(s)
+	CopyObject_should_replace_tagging(s)
 	CopyObject_should_copy_tagging(s)
 	CopyObject_invalid_tagging_directive(s)
 	CopyObject_to_itself_with_new_metadata(s)
@@ -320,7 +321,6 @@ func TestDeleteObjectTagging(s *S3Conf) {
 func TestCreateMultipartUpload(s *S3Conf) {
 	CreateMultipartUpload_non_existing_bucket(s)
 	CreateMultipartUpload_with_metadata(s)
-	CreateMultipartUpload_with_invalid_tagging(s)
 	CreateMultipartUpload_with_tagging(s)
 	CreateMultipartUpload_with_object_lock(s)
 	CreateMultipartUpload_with_object_lock_not_enabled(s)
@@ -866,7 +866,7 @@ func GetIntTests() IntTests {
 		"DeleteBucketTagging_success":                                             DeleteBucketTagging_success,
 		"PutObject_non_existing_bucket":                                           PutObject_non_existing_bucket,
 		"PutObject_special_chars":                                                 PutObject_special_chars,
-		"PutObject_invalid_long_tags":                                             PutObject_invalid_long_tags,
+		"PutObject_tagging":                                                       PutObject_tagging,
 		"PutObject_success":                                                       PutObject_success,
 		"PutObject_racey_success":                                                 PutObject_racey_success,
 		"HeadObject_non_existing_object":                                          HeadObject_non_existing_object,
@@ -943,6 +943,7 @@ func GetIntTests() IntTests {
 		"CopyObject_not_owned_source_bucket":                                      CopyObject_not_owned_source_bucket,
 		"CopyObject_copy_to_itself":                                               CopyObject_copy_to_itself,
 		"CopyObject_copy_to_itself_invalid_directive":                             CopyObject_copy_to_itself_invalid_directive,
+		"CopyObject_should_replace_tagging":                                       CopyObject_should_replace_tagging,
 		"CopyObject_should_copy_tagging":                                          CopyObject_should_copy_tagging,
 		"CopyObject_invalid_tagging_directive":                                    CopyObject_invalid_tagging_directive,
 		"CopyObject_to_itself_with_new_metadata":                                  CopyObject_to_itself_with_new_metadata,
@@ -974,7 +975,6 @@ func GetIntTests() IntTests {
 		"DeleteObjectTagging_success":                                             DeleteObjectTagging_success,
 		"CreateMultipartUpload_non_existing_bucket":                               CreateMultipartUpload_non_existing_bucket,
 		"CreateMultipartUpload_with_metadata":                                     CreateMultipartUpload_with_metadata,
-		"CreateMultipartUpload_with_invalid_tagging":                              CreateMultipartUpload_with_invalid_tagging,
 		"CreateMultipartUpload_with_tagging":                                      CreateMultipartUpload_with_tagging,
 		"CreateMultipartUpload_with_object_lock":                                  CreateMultipartUpload_with_object_lock,
 		"CreateMultipartUpload_with_object_lock_not_enabled":                      CreateMultipartUpload_with_object_lock_not_enabled,


### PR DESCRIPTION
Fixes #1215
Fixes #1216

`PutObject`, `CopyObject` and `CreateMultipartUpload` accept tag string as an http request header which should be url-encoded. The tag string should be a valid url-encoded string and each key/value pair should be valid, otherwise they should fail with `APIError`.

If the provided tag set contains duplicate `keys` the calls should fail with the same `InvalidURLEncodedTagging` error.

Not all url-encoded characters are supported by `S3`. The tagging string should contain only `letters`, `digits` and the following special chars:
- `-`
- `.`
- `/`
- `_`
- `+`
- ` `(space)

And their url-encoded versions: e.g. `%2F`(/), `%2E`(.) ... .

If the provided tagging string contains invalid `key`/`value`, the calls should fail with the following errors respectively: `invalid key` - `(InvalidTag) The TagKey you have provided is invalid`
`invalid value` - `(InvalidTag) The TagValue you have provided is invalid`