### PR TITLE
fix: scoutfs etag check for multipart uploads

### DIFF
--- a/backend/scoutfs/scoutfs.go
+++ b/backend/scoutfs/scoutfs.go
@@ -287,7 +287,7 @@ func (s *ScoutFS) CompleteMultipartUpload(ctx context.Context, input *s3.Complet
 		if err != nil {
 			etag = ""
 		}
-		if parts[i].ETag == nil || etag != *parts[i].ETag {
+		if parts[i].ETag == nil || !areEtagsSame(etag, *parts[i].ETag) {
 			return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
 
@@ -1024,4 +1024,8 @@ func isNoAttr(err error) bool {
 		return true
 	}
 	return false
+}
+
+func areEtagsSame(e1, e2 string) bool {
+	return strings.Trim(e1, `"`) == strings.Trim(e2, `"`)
 }


### PR DESCRIPTION
The Etag can be quoted or not, so the check to verify the part Etag must remove the quotes before checking for equality. This check is the same now as posix.