### PR TITLE
fix: fixes the range parsing for GetObject. Adds range query support for HeadObject.

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -3207,6 +3207,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 	parsedAcl := ctx.Locals("parsedAcl").(auth.ACL)
 	partNumberQuery := int32(ctx.QueryInt("partNumber", -1))
 	versionId := ctx.Query("versionId")
+	objRange := ctx.Get("Range")
 	key := ctx.Params("key")
 	keyEnd := ctx.Params("*1")
 	if keyEnd != "" {
@@ -3277,6 +3278,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 			PartNumber:   partNumber,
 			VersionId:    &versionId,
 			ChecksumMode: checksumMode,
+			Range:        &objRange,
 		})
 	if err != nil {
 		if res != nil {
@@ -3314,6 +3316,18 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) error {
 			Key:   "x-amz-restore",
 			Value: getstring(res.Restore),
 		},
+	}
+	if getstring(res.AcceptRanges) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "accept-ranges",
+			Value: getstring(res.AcceptRanges),
+		})
+	}
+	if getstring(res.ContentRange) != "" {
+		headers = append(headers, utils.CustomHeader{
+			Key:   "Content-Range",
+			Value: getstring(res.ContentRange),
+		})
 	}
 	if getstring(res.ContentDisposition) != "" {
 		headers = append(headers, utils.CustomHeader{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -523,7 +523,7 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	},
 	ErrInvalidRange: {
 		Code:           "InvalidRange",
-		Description:    "The requested range is not valid for the request. Try another range.",
+		Description:    "The requested range is not satisfiable",
 		HTTPStatusCode: http.StatusRequestedRangeNotSatisfiable,
 	},
 	ErrInvalidURI: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -168,6 +168,7 @@ func TestHeadObject(s *S3Conf) {
 	HeadObject_directory_object_noslash(s)
 	HeadObject_non_existing_dir_object(s)
 	HeadObject_invalid_parent_dir(s)
+	HeadObject_with_range(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		HeadObject_not_enabled_checksum_mode(s)
@@ -193,8 +194,7 @@ func TestGetObjectAttributes(s *S3Conf) {
 func TestGetObject(s *S3Conf) {
 	GetObject_non_existing_key(s)
 	GetObject_directory_object_noslash(s)
-	GetObject_should_succeed_for_invalid_ranges(s)
-	GetObject_content_ranges(s)
+	GetObject_with_range(s)
 	GetObject_invalid_parent(s)
 	GetObject_large_object(s)
 	//TODO: remove the condition after implementing checksums in azure
@@ -203,7 +203,6 @@ func TestGetObject(s *S3Conf) {
 	}
 	GetObject_success(s)
 	GetObject_directory_success(s)
-	GetObject_by_range_success(s)
 	GetObject_by_range_resp_status(s)
 	GetObject_non_existing_dir_object(s)
 }
@@ -877,6 +876,7 @@ func GetIntTests() IntTests {
 		"HeadObject_non_existing_dir_object":                                      HeadObject_non_existing_dir_object,
 		"HeadObject_name_too_long":                                                HeadObject_name_too_long,
 		"HeadObject_invalid_parent_dir":                                           HeadObject_invalid_parent_dir,
+		"HeadObject_with_range":                                                   HeadObject_with_range,
 		"HeadObject_not_enabled_checksum_mode":                                    HeadObject_not_enabled_checksum_mode,
 		"HeadObject_checksums":                                                    HeadObject_checksums,
 		"HeadObject_success":                                                      HeadObject_success,
@@ -890,14 +890,12 @@ func GetIntTests() IntTests {
 		"GetObjectAttributes_checksums":                                           GetObjectAttributes_checksums,
 		"GetObject_non_existing_key":                                              GetObject_non_existing_key,
 		"GetObject_directory_object_noslash":                                      GetObject_directory_object_noslash,
-		"GetObject_should_succeed_for_invalid_ranges":                             GetObject_should_succeed_for_invalid_ranges,
-		"GetObject_content_ranges":                                                GetObject_content_ranges,
+		"GetObject_with_range":                                                    GetObject_with_range,
 		"GetObject_invalid_parent":                                                GetObject_invalid_parent,
 		"GetObject_large_object":                                                  GetObject_large_object,
 		"GetObject_checksums":                                                     GetObject_checksums,
 		"GetObject_success":                                                       GetObject_success,
 		"GetObject_directory_success":                                             GetObject_directory_success,
-		"GetObject_by_range_success":                                              GetObject_by_range_success,
 		"GetObject_by_range_resp_status":                                          GetObject_by_range_resp_status,
 		"GetObject_non_existing_dir_object":                                       GetObject_non_existing_dir_object,
 		"ListObjects_non_existing_bucket":                                         ListObjects_non_existing_bucket,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -502,18 +502,8 @@ func createMp(s3client *s3.Client, bucket, key string, opts ...mpOpt) (*s3.Creat
 	return out, err
 }
 
-func isEqual(a, b []byte) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i, d := range a {
-		if d != b[i] {
-			return false
-		}
-	}
-
-	return true
+func isSameData(a, b []byte) bool {
+	return bytes.Equal(a, b)
 }
 
 func compareMultipartUploads(list1, list2 []types.MultipartUpload) bool {


### PR DESCRIPTION
Fixes #1258
Fixes #1257
Closes #1244

Adds range queries support for `HeadObject`.
Fixes the range parsing logic for `GetObject`, which is used for `HeadObject` as well. Both actions follow the same rules for range parsing.

Fixes the error message returned by `GetObject`.