### PR TITLE
use path style

### DIFF
--- a/backend/s3proxy/client.go
+++ b/backend/s3proxy/client.go
@@ -36,6 +36,7 @@ func (s *S3Proxy) getClientWithCtx(ctx context.Context) (*s3.Client, error) {
 	if s.endpoint != "" {
 		return s3.NewFromConfig(cfg, func(o *s3.Options) {
 			o.BaseEndpoint = &s.endpoint
+			o.UsePathStyle = s.usePathStyle
 		}), nil
 	}
 

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -58,6 +58,7 @@ type S3Proxy struct {
 	metaBucket      string
 	disableChecksum bool
 	sslSkipVerify   bool
+	usePathStyle    bool
 	debug           bool
 }
 
@@ -75,7 +76,7 @@ func NewWithClient(ctx context.Context, client *s3.Client, metaBucket string) (*
 	return s, s.validate(ctx)
 }
 
-func New(ctx context.Context, access, secret, endpoint, region, metaBucket string, disableChecksum, sslSkipVerify, debug bool) (*S3Proxy, error) {
+func New(ctx context.Context, access, secret, endpoint, region, metaBucket string, disableChecksum, sslSkipVerify, usePathStyle, debug bool) (*S3Proxy, error) {
 	s := &S3Proxy{
 		access:          access,
 		secret:          secret,
@@ -84,6 +85,7 @@ func New(ctx context.Context, access, secret, endpoint, region, metaBucket strin
 		metaBucket:      metaBucket,
 		disableChecksum: disableChecksum,
 		sslSkipVerify:   sslSkipVerify,
+		usePathStyle:    usePathStyle,
 		debug:           debug,
 	}
 	client, err := s.getClientWithCtx(ctx)

--- a/cmd/versitygw/s3.go
+++ b/cmd/versitygw/s3.go
@@ -29,6 +29,7 @@ var (
 	s3proxyMetaBucket      string
 	s3proxyDisableChecksum bool
 	s3proxySslSkipVerify   bool
+	s3proxyUsePathStyle    bool
 	s3proxyDebug           bool
 )
 
@@ -93,6 +94,13 @@ to an s3 storage backend service.`,
 				Destination: &s3proxySslSkipVerify,
 			},
 			&cli.BoolFlag{
+				Name:        "use-path-style",
+				Usage:       "use path style addressing for s3 proxy",
+				EnvVars:     []string{"VGW_S3_USE_PATH_STYLE"},
+				Value:       false,
+				Destination: &s3proxyUsePathStyle,
+			},
+			&cli.BoolFlag{
 				Name:        "debug",
 				Usage:       "output extra debug tracing",
 				Value:       false,
@@ -105,7 +113,7 @@ to an s3 storage backend service.`,
 
 func runS3(ctx *cli.Context) error {
 	be, err := s3proxy.New(ctx.Context, s3proxyAccess, s3proxySecret, s3proxyEndpoint, s3proxyRegion,
-		s3proxyMetaBucket, s3proxyDisableChecksum, s3proxySslSkipVerify, s3proxyDebug)
+		s3proxyMetaBucket, s3proxyDisableChecksum, s3proxySslSkipVerify, s3proxyUsePathStyle, s3proxyDebug)
 	if err != nil {
 		return fmt.Errorf("init s3 backend: %w", err)
 	}


### PR DESCRIPTION
I want to proxy to a s3 service that does not support the domain bucket names, therefore exposing the `usePathStyle` options as parameter / env variable