### PR TITLE
fix: panic with malformed request in event/log handlers

### DIFF
--- a/s3event/event.go
+++ b/s3event/event.go
@@ -141,7 +141,12 @@ func InitEventSender(cfg *EventConfig) (S3EventSender, error) {
 
 func createEventSchema(ctx *fiber.Ctx, meta EventMeta, configId ConfigurationId) EventSchema {
 	path := strings.Split(ctx.Path(), "/")
-	bucket, object := path[1], strings.Join(path[2:], "/")
+
+	var bucket, object string
+	if len(path) > 1 {
+		bucket, object = path[1], strings.Join(path[2:], "/")
+	}
+
 	acc := ctx.Locals("account").(auth.Account)
 
 	return EventSchema{

--- a/s3log/file.go
+++ b/s3log/file.go
@@ -68,7 +68,10 @@ func (f *FileLogger) Log(ctx *fiber.Ctx, err error, body []byte, meta LogMeta) {
 	access := "-"
 	reqURI := ctx.OriginalURL()
 	path := strings.Split(ctx.Path(), "/")
-	bucket, object := path[1], strings.Join(path[2:], "/")
+	var bucket, object string
+	if len(path) > 1 {
+		bucket, object = path[1], strings.Join(path[2:], "/")
+	}
 	errorCode := ""
 	httpStatus := 200
 	startTime := ctx.Locals("startTime").(time.Time)

--- a/s3log/webhook.go
+++ b/s3log/webhook.go
@@ -65,7 +65,10 @@ func (wl *WebhookLogger) Log(ctx *fiber.Ctx, err error, body []byte, meta LogMet
 	access := "-"
 	reqURI := ctx.OriginalURL()
 	path := strings.Split(ctx.Path(), "/")
-	bucket, object := path[1], strings.Join(path[2:], "/")
+	var bucket, object string
+	if len(path) > 1 {
+		bucket, object = path[1], strings.Join(path[2:], "/")
+	}
 	errorCode := ""
 	httpStatus := 200
 	startTime := ctx.Locals("startTime").(time.Time)


### PR DESCRIPTION
Sending the following malformed request with eevnt notifcations or access logs enabled will cause a panic related to parsing the bucket and object from the invalid request path:

printf "GET GET  HTTP/1.1\r\nHost: $HOST\r\n\r\n" | nc 127.0.0.1 7070

The fix is to add bounds checks on the slice returned from splitting the request path to set the bucket/object.

Fixes #1269