### PR TITLE
fix: fixes the context cancelation issue in Versioning_GetObject_success integration test.

### DIFF
--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -16414,7 +16414,7 @@ func Versioning_GetObject_success(s *S3Conf) error {
 			Key:       &obj,
 			VersionId: r.res.VersionId,
 		})
-		cancel()
+		defer cancel()
 		if err != nil {
 			return err
 		}
@@ -16438,7 +16438,7 @@ func Versioning_GetObject_success(s *S3Conf) error {
 		if err != nil {
 			return err
 		}
-		defer out.Body.Close()
+		out.Body.Close()
 
 		outCsum := sha256.Sum256(bdy)
 		if outCsum != r.csum {
@@ -16451,7 +16451,7 @@ func Versioning_GetObject_success(s *S3Conf) error {
 			Bucket: &bucket,
 			Key:    &obj,
 		})
-		cancel()
+		defer cancel()
 		if err != nil {
 			return err
 		}
@@ -16475,7 +16475,7 @@ func Versioning_GetObject_success(s *S3Conf) error {
 		if err != nil {
 			return err
 		}
-		defer out.Body.Close()
+		out.Body.Close()
 
 		outCsum = sha256.Sum256(bdy)
 		if outCsum != r.csum {


### PR DESCRIPTION
Fixes #1271

In the `Versioning_GetObject_success` integration test the contexts are canceled before reading the full request body after `GetObject`. 
Changes the behaviour to defer the context cancelation, to be sure it's canceled after the full request body is read.