### PR TITLE
add omit on empty for ContinuationToken

### DIFF
--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -172,7 +172,7 @@ type ListObjectsV2Result struct {
 	Name                  *string
 	Prefix                *string
 	StartAfter            *string
-	ContinuationToken     *string
+	ContinuationToken     *string `xml:"ContinuationToken,omitempty"`
 	NextContinuationToken *string
 	KeyCount              *int32
 	MaxKeys               *int32


### PR DESCRIPTION
mount-s3 has strict XML parsing which doesn't like receiving this tag empty. An empty ContinuationToken causes mount-s3 to error out and stop processing requests.