### PR TITLE
fix: overrides empty checksum type and algorithm with 'null' for ListParts

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2200,6 +2200,12 @@ func (p *Posix) ListParts(ctx context.Context, input *s3.ListPartsInput) (s3resp
 	if err != nil && !errors.Is(err, meta.ErrNoSuchKey) {
 		return lpr, fmt.Errorf("get mp checksum: %w", err)
 	}
+	if checksum.Algorithm == "" {
+		checksum.Algorithm = types.ChecksumAlgorithm("null")
+	}
+	if checksum.Type == "" {
+		checksum.Type = types.ChecksumType("null")
+	}
 
 	parts := make([]s3response.Part, 0, len(ents))
 	for i, e := range ents {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -386,6 +386,7 @@ func TestListParts(s *S3Conf) {
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		ListParts_with_checksums(s)
+		ListParts_null_checksums(s)
 	}
 	ListParts_success(s)
 }
@@ -1111,6 +1112,7 @@ func GetIntTests() IntTests {
 		"ListParts_default_max_parts":                                             ListParts_default_max_parts,
 		"ListParts_truncated":                                                     ListParts_truncated,
 		"ListParts_with_checksums":                                                ListParts_with_checksums,
+		"ListParts_null_checksums":                                                ListParts_null_checksums,
 		"ListParts_success":                                                       ListParts_success,
 		"ListMultipartUploads_non_existing_bucket":                                ListMultipartUploads_non_existing_bucket,
 		"ListMultipartUploads_empty_result":                                       ListMultipartUploads_empty_result,


### PR DESCRIPTION
Fixes #1288

If the checksum algorithm/type is not specified during multipart upload initialization, it is considered `null`, and the `ListParts` result should also set it to `null`.