### PR TITLE
fix: fixes the early context cancelation issue in GetObject_with_range integration test.

### DIFF
--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -4320,12 +4320,12 @@ func GetObject_with_range(s *S3Conf) error {
 
 		testGetObjectRange := func(rng, contentRange string, cLength int64, expData []byte, expErr error) error {
 			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+			defer cancel()
 			out, err := s3client.GetObject(ctx, &s3.GetObjectInput{
 				Bucket: &bucket,
 				Key:    &obj,
 				Range:  &rng,
 			})
-			cancel()
 			if err == nil && expErr != nil {
 				return fmt.Errorf("expected err %w, instead got nil", expErr)
 			}


### PR DESCRIPTION
`context` gets cancelled early before reading the full body in the `GetObject_with_range` integration test. This change defers the context cancelation to make sure the full body is ready and the context isn't canceled in the middle of the request body read.