### PR TITLE
fix: non existing bucket acl parsing

### DIFF
--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -1511,10 +1511,11 @@ func (s *S3Proxy) GetObjectLegalHold(ctx context.Context, bucket, object, versio
 }
 
 func (s *S3Proxy) ChangeBucketOwner(ctx context.Context, bucket string, acl []byte) error {
-	var acll auth.ACL
-	if err := json.Unmarshal(acl, &acll); err != nil {
-		return fmt.Errorf("unmarshal acl: %w", err)
+	acll, err := auth.ParseACL(acl)
+	if err != nil {
+		return err
 	}
+
 	req, err := http.NewRequest(http.MethodPatch, fmt.Sprintf("%v/change-bucket-owner/?bucket=%v&owner=%v", s.endpoint, bucket, acll.Owner), nil)
 	if err != nil {
 		return fmt.Errorf("failed to send the request: %w", err)


### PR DESCRIPTION
There were a couple of cases that would return an error for the non existing bucket acl instead of treating that as the default acl.

This also cleans up the backends that were doing their own acl parsing instead of using the auth.ParseACL() function.

Fixes #1304