### PR TITLE
feat: automates the host-style tests in the pipeline

### DIFF
--- a/.github/workflows/host-style-tests.yml
+++ b/.github/workflows/host-style-tests.yml
@@ -1,0 +1,13 @@
+name: host style tests
+permissions: {}
+on: pull_request
+
+jobs:
+  build-and-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: run host-style tests
+        run: make test-host-style

--- a/Makefile
+++ b/Makefile
@@ -96,3 +96,9 @@ up-azurite:
 .PHONY: up-app
 up-app:
 	$(DOCKERCOMPOSE) up
+
+# Run the host-style tests in docker containers
+.PHONY: test-host-style
+test-host-style:
+	docker compose -f tests/host-style-tests/docker-compose.yml up --build --abort-on-container-exit --exit-code-from test
+

--- a/tests/host-style-tests/Dockerfile
+++ b/tests/host-style-tests/Dockerfile
@@ -1,0 +1,27 @@
+FROM golang:latest
+
+WORKDIR /app
+
+COPY go.mod ./
+RUN go mod download
+
+COPY ./ ./
+
+WORKDIR /app/cmd/versitygw
+ENV CGO_ENABLED=0
+RUN go build -o versitygw
+
+FROM alpine:latest
+
+# These arguments can be overriden when building the image
+ARG IAM_DIR=/tmp/vgw
+ARG SETUP_DIR=/tmp/vgw
+
+RUN mkdir -p $IAM_DIR
+RUN mkdir -p $SETUP_DIR
+
+COPY --from=0 /app/cmd/versitygw/versitygw /app/versitygw
+
+WORKDIR /app
+
+ENTRYPOINT [ "/app/versitygw" ]

--- a/tests/host-style-tests/dnsmasq.conf
+++ b/tests/host-style-tests/dnsmasq.conf
@@ -1,0 +1,2 @@
+address=/.dev/172.20.0.10
+no-resolv

--- a/tests/host-style-tests/docker-compose.yml
+++ b/tests/host-style-tests/docker-compose.yml
@@ -1,0 +1,62 @@
+services:
+  dnsmasq:
+    image: strm/dnsmasq
+    container_name: dns-resolver
+    restart: on-failure
+    volumes:
+      - './dnsmasq.conf:/etc/dnsmasq.conf'
+    ports:
+      - "53/udp"
+    cap_add:
+      - NET_ADMIN
+    healthcheck:
+      test: 'if [ -z "$(netstat -nltu |grep \:53)" ]; then exit 1;else exit 0;fi'
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    networks:
+      devnet:
+        ipv4_address: 172.20.0.53
+
+  server:
+    build:
+      context: ../..
+      dockerfile: tests/host-style-tests/Dockerfile
+    depends_on:
+      dnsmasq:
+        condition: service_healthy
+    command: ["-a", "user", "-s", "pass", "--virtual-domain", "dev:7070", "--health", "/health", "--iam-dir", "/tmp/vgw", "posix", "/tmp/vgw"]
+    dns:
+      - 172.20.0.53
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:7070/health"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+    networks:
+      devnet:
+        ipv4_address: 172.20.0.10
+    ports:
+      - "7070:7070"  # Optional: if you want to reach it from host
+
+  test:
+    build:
+      context: ../..
+      dockerfile: tests/host-style-tests/Dockerfile
+    depends_on:
+      server:
+        condition: service_healthy
+      dnsmasq:
+        condition: service_healthy
+    command: ["test", "-a", "user", "-s", "pass", "--host-style", "-e", "http://dev:7070", "full-flow"]
+    dns:
+      - 172.20.0.53
+    networks:
+      devnet:
+
+networks:
+  devnet:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16


### PR DESCRIPTION
Adds a GitHub Actions workflow to run the `host-style` tests inside Docker containers. The tests are executed in a Docker environment using `Docker Compose` with three containers: one for running the tests, one for setting up the server, and one using the `dnsmasq` image for `DNS` server configuration.