### PR TITLE
feat: implements public bucket access.

### DIFF
--- a/auth/access-control.go
+++ b/auth/access-control.go
@@ -1,0 +1,201 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/s3err"
+)
+
+func VerifyObjectCopyAccess(ctx context.Context, be backend.Backend, copySource string, opts AccessOptions) error {
+	if opts.IsRoot {
+		return nil
+	}
+	if opts.Acc.Role == RoleAdmin {
+		return nil
+	}
+
+	// Verify destination bucket access
+	if err := VerifyAccess(ctx, be, opts); err != nil {
+		return err
+	}
+	// Verify source bucket access
+	srcBucket, srcObject, found := strings.Cut(copySource, "/")
+	if !found {
+		return s3err.GetAPIError(s3err.ErrInvalidCopySource)
+	}
+
+	// Get source bucket ACL
+	srcBucketACLBytes, err := be.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: &srcBucket})
+	if err != nil {
+		return err
+	}
+
+	var srcBucketAcl ACL
+	if err := json.Unmarshal(srcBucketACLBytes, &srcBucketAcl); err != nil {
+		return err
+	}
+
+	if err := VerifyAccess(ctx, be, AccessOptions{
+		Acl:           srcBucketAcl,
+		AclPermission: PermissionRead,
+		IsRoot:        opts.IsRoot,
+		Acc:           opts.Acc,
+		Bucket:        srcBucket,
+		Object:        srcObject,
+		Action:        GetObjectAction,
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type AccessOptions struct {
+	Acl            ACL
+	AclPermission  Permission
+	IsRoot         bool
+	Acc            Account
+	Bucket         string
+	Object         string
+	Action         Action
+	Readonly       bool
+	IsBucketPublic bool
+}
+
+func VerifyAccess(ctx context.Context, be backend.Backend, opts AccessOptions) error {
+	// Skip the access check for public buckets
+	if opts.IsBucketPublic {
+		return nil
+	}
+	if opts.Readonly {
+		if opts.AclPermission == PermissionWrite || opts.AclPermission == PermissionWriteAcp {
+			return s3err.GetAPIError(s3err.ErrAccessDenied)
+		}
+	}
+	if opts.IsRoot {
+		return nil
+	}
+	if opts.Acc.Role == RoleAdmin {
+		return nil
+	}
+
+	policy, policyErr := be.GetBucketPolicy(ctx, opts.Bucket)
+	if policyErr != nil {
+		if !errors.Is(policyErr, s3err.GetAPIError(s3err.ErrNoSuchBucketPolicy)) {
+			return policyErr
+		}
+	} else {
+		return VerifyBucketPolicy(policy, opts.Acc.Access, opts.Bucket, opts.Object, opts.Action)
+	}
+
+	if err := verifyACL(opts.Acl, opts.Acc.Access, opts.AclPermission); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Detects if the action is policy related
+// e.g.
+// 'GetBucketPolicy', 'PutBucketPolicy'
+func isPolicyAction(action Action) bool {
+	return action == GetBucketPolicyAction || action == PutBucketPolicyAction
+}
+
+// VerifyPublicAccess checks if the bucket is publically accessible by ACL or Policy
+func VerifyPublicAccess(ctx context.Context, be backend.Backend, action Action, permission Permission, bucket, object string) error {
+	// ACL disabled
+	policy, err := be.GetBucketPolicy(ctx, bucket)
+	if err != nil && !errors.Is(err, s3err.GetAPIError(s3err.ErrNoSuchBucketPolicy)) {
+		return err
+	}
+	if err == nil {
+		err = VerifyPublicBucketPolicy(policy, bucket, object, action)
+		if err == nil {
+			// if ACLs are disabled, and the bucket grants public access,
+			// policy actions should return 'MethodNotAllowed'
+			if isPolicyAction(action) {
+				return s3err.GetAPIError(s3err.ErrMethodNotAllowed)
+			}
+
+			return nil
+		}
+	}
+
+	// if the action is not in the ACL whitelist the access is denied
+	_, ok := publicACLAllowedActions[action]
+	if !ok {
+		return s3err.GetAPIError(s3err.ErrAccessDenied)
+	}
+
+	err = VerifyPublicBucketACL(ctx, be, bucket, action, permission)
+	if err != nil {
+		return s3err.GetAPIError(s3err.ErrAccessDenied)
+	}
+
+	return nil
+}
+
+func MayCreateBucket(acct Account, isRoot bool) error {
+	if isRoot {
+		return nil
+	}
+
+	if acct.Role == RoleUser {
+		return s3err.GetAPIError(s3err.ErrAccessDenied)
+	}
+
+	return nil
+}
+
+func IsAdminOrOwner(acct Account, isRoot bool, acl ACL) error {
+	// Owner check
+	if acct.Access == acl.Owner {
+		return nil
+	}
+
+	// Root user has access over almost everything
+	if isRoot {
+		return nil
+	}
+
+	// Admin user case
+	if acct.Role == RoleAdmin {
+		return nil
+	}
+
+	// Return access denied in all other cases
+	return s3err.GetAPIError(s3err.ErrAccessDenied)
+}
+
+type PublicACLAllowedActions map[Action]struct{}
+
+var publicACLAllowedActions PublicACLAllowedActions = PublicACLAllowedActions{
+	ListBucketAction:                 struct{}{},
+	PutObjectAction:                  struct{}{},
+	ListBucketMultipartUploadsAction: struct{}{},
+	DeleteObjectAction:               struct{}{},
+	ListBucketVersionsAction:         struct{}{},
+	GetObjectAction:                  struct{}{},
+	GetObjectAttributesAction:        struct{}{},
+	GetObjectAclAction:               struct{}{},
+}

--- a/auth/bucket_policy_actions.go
+++ b/auth/bucket_policy_actions.go
@@ -91,6 +91,7 @@ var supportedActionList = map[Action]struct{}{
 	DeleteObjectTaggingAction:              {},
 	ListBucketVersionsAction:               {},
 	ListBucketAction:                       {},
+	GetBucketObjectLockConfigurationAction: {},
 	PutBucketObjectLockConfigurationAction: {},
 	GetObjectLegalHoldAction:               {},
 	PutObjectLegalHoldAction:               {},

--- a/auth/bucket_policy_principals.go
+++ b/auth/bucket_policy_principals.go
@@ -121,3 +121,10 @@ func (p Principals) Contains(userAccess string) bool {
 	_, found := p[userAccess]
 	return found
 }
+
+// Bucket policy grants public access, if it contains
+// a wildcard match to all the users
+func (p Principals) IsPublic() bool {
+	_, ok := p["*"]
+	return ok
+}

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/valyala/fasthttp"
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3err"
 	"github.com/versity/versitygw/s3response"
 )
@@ -99,8 +100,7 @@ func TestS3ApiController_ListBuckets(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access", Role: "admin:"})
-		ctx.Locals("isDebug", false)
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access", Role: "admin:"})
 		return ctx.Next()
 	})
 	app.Get("/", s3ApiController.ListBuckets)
@@ -116,8 +116,7 @@ func TestS3ApiController_ListBuckets(t *testing.T) {
 	}
 
 	appErr.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access", Role: "admin:"})
-		ctx.Locals("isDebug", false)
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access", Role: "admin:"})
 		return ctx.Next()
 	})
 	appErr.Get("/", s3ApiControllerErr.ListBuckets)
@@ -220,10 +219,9 @@ func TestS3ApiController_GetActions(t *testing.T) {
 		},
 	}
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	app.Get("/:bucket/:key/*", s3ApiController.GetActions)
@@ -413,10 +411,9 @@ func TestS3ApiController_ListActions(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 
@@ -438,10 +435,9 @@ func TestS3ApiController_ListActions(t *testing.T) {
 	}
 	appError := fiber.New()
 	appError.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	appError.Get("/:bucket", s3ApiControllerError.ListActions)
@@ -707,10 +703,9 @@ func TestS3ApiController_PutBucketActions(t *testing.T) {
 	}
 	// Mock ctx.Locals
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{Owner: "valid access"})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{Owner: "valid access"})
 		return ctx.Next()
 	})
 	app.Put("/:bucket", s3ApiController.PutBucketActions)
@@ -1003,10 +998,9 @@ func TestS3ApiController_PutActions(t *testing.T) {
 		},
 	}
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	app.Put("/:bucket/:key/*", s3ApiController.PutActions)
@@ -1292,10 +1286,9 @@ func TestS3ApiController_DeleteBucket(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 
@@ -1378,10 +1371,9 @@ func TestS3ApiController_DeleteObjects(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	app.Post("/:bucket", s3ApiController.DeleteObjects)
@@ -1458,10 +1450,9 @@ func TestS3ApiController_DeleteActions(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	app.Delete("/:bucket/:key/*", s3ApiController.DeleteActions)
@@ -1482,10 +1473,9 @@ func TestS3ApiController_DeleteActions(t *testing.T) {
 	}}
 
 	appErr.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	appErr.Delete("/:bucket/:key/*", s3ApiControllerErr.DeleteActions)
@@ -1565,11 +1555,10 @@ func TestS3ApiController_HeadBucket(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
-		ctx.Locals("region", "us-east-1")
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
+		utils.ContextKeyRegion.Set(ctx, "us-east-1")
 		return ctx.Next()
 	})
 
@@ -1583,17 +1572,16 @@ func TestS3ApiController_HeadBucket(t *testing.T) {
 			return acldata, nil
 		},
 		HeadBucketFunc: func(context.Context, *s3.HeadBucketInput) (*s3.HeadBucketOutput, error) {
-			return nil, s3err.GetAPIError(3)
+			return nil, s3err.GetAPIError(s3err.ErrBucketNotEmpty)
 		},
 	},
 	}
 
 	appErr.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
-		ctx.Locals("region", "us-east-1")
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
+		utils.ContextKeyRegion.Set(ctx, "us-east-1")
 		return ctx.Next()
 	})
 
@@ -1670,10 +1658,9 @@ func TestS3ApiController_HeadObject(t *testing.T) {
 	}
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	app.Head("/:bucket/:key/*", s3ApiController.HeadObject)
@@ -1693,10 +1680,9 @@ func TestS3ApiController_HeadObject(t *testing.T) {
 	}
 
 	appErr.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	appErr.Head("/:bucket/:key/*", s3ApiControllerErr.HeadObject)
@@ -1798,10 +1784,9 @@ func TestS3ApiController_CreateActions(t *testing.T) {
 	`
 
 	app.Use(func(ctx *fiber.Ctx) error {
-		ctx.Locals("account", auth.Account{Access: "valid access"})
-		ctx.Locals("isRoot", true)
-		ctx.Locals("isDebug", false)
-		ctx.Locals("parsedAcl", auth.ACL{})
+		utils.ContextKeyAccount.Set(ctx, auth.Account{Access: "valid access"})
+		utils.ContextKeyIsRoot.Set(ctx, true)
+		utils.ContextKeyParsedAcl.Set(ctx, auth.ACL{})
 		return ctx.Next()
 	})
 	app.Post("/:bucket/:key/*", s3ApiController.CreateActions)

--- a/s3api/middlewares/admin.go
+++ b/s3api/middlewares/admin.go
@@ -21,13 +21,14 @@ import (
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/metrics"
 	"github.com/versity/versitygw/s3api/controllers"
+	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3err"
 	"github.com/versity/versitygw/s3log"
 )
 
 func IsAdmin(logger s3log.AuditLogger) fiber.Handler {
 	return func(ctx *fiber.Ctx) error {
-		acct := ctx.Locals("account").(auth.Account)
+		acct := utils.ContextKeyAccount.Get(ctx).(auth.Account)
 		if acct.Role != auth.RoleAdmin {
 			path := ctx.Path()
 			return controllers.SendResponse(ctx, s3err.GetAPIError(s3err.ErrAdminAccessDenied),

--- a/s3api/middlewares/public-bucket.go
+++ b/s3api/middlewares/public-bucket.go
@@ -1,0 +1,298 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"io"
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/auth"
+	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/metrics"
+	"github.com/versity/versitygw/s3api/utils"
+	"github.com/versity/versitygw/s3err"
+	"github.com/versity/versitygw/s3log"
+)
+
+func AuthorizePublicBucketAccess(be backend.Backend, l s3log.AuditLogger, mm *metrics.Manager) fiber.Handler {
+	return func(ctx *fiber.Ctx) error {
+		// skip for auhtneicated requests
+		if ctx.Query("X-Amz-Algorithm") != "" || ctx.Get("Authorization") != "" {
+			return ctx.Next()
+		}
+
+		bucket, object := parsePath(ctx.Path())
+
+		action, permission, err := detectS3Action(ctx, object == "")
+		if err != nil {
+			return sendResponse(ctx, err, l, mm)
+		}
+
+		err = auth.VerifyPublicAccess(ctx.Context(), be, action, permission, bucket, object)
+		if err != nil {
+			return sendResponse(ctx, err, l, mm)
+		}
+
+		if utils.IsBigDataAction(ctx) {
+			payloadType := ctx.Get("X-Amz-Content-Sha256")
+			if utils.IsUnsignedStreamingPayload(payloadType) {
+				checksumType, err := utils.ExtractChecksumType(ctx)
+				if err != nil {
+					return sendResponse(ctx, err, l, mm)
+				}
+
+				wrapBodyReader(ctx, func(r io.Reader) io.Reader {
+					var cr io.Reader
+					cr, err = utils.NewUnsignedChunkReader(r, checksumType)
+					return cr
+				})
+				if err != nil {
+					return sendResponse(ctx, err, l, mm)
+				}
+			}
+		}
+
+		utils.ContextKeyPublicBucket.Set(ctx, true)
+
+		return ctx.Next()
+	}
+}
+
+func detectS3Action(ctx *fiber.Ctx, isBucketAction bool) (auth.Action, auth.Permission, error) {
+	path := ctx.Path()
+	// ListBuckets is not publically available
+	if path == "/" {
+		//TODO: Still not clear what kind of error should be returned in this case(ListBuckets)
+		return "", auth.PermissionRead, s3err.GetAPIError(s3err.ErrAccessDenied)
+	}
+
+	queryArgs := ctx.Context().QueryArgs()
+
+	switch ctx.Method() {
+	case fiber.MethodPatch:
+		// Admin apis should always be protected
+		return "", "", s3err.GetAPIError(s3err.ErrAccessDenied)
+	case fiber.MethodHead:
+		// HeadBucket
+		if isBucketAction {
+			return auth.ListBucketAction, auth.PermissionRead, nil
+		}
+
+		// HeadObject
+		return auth.GetObjectAction, auth.PermissionRead, nil
+	case fiber.MethodGet:
+		if isBucketAction {
+			if queryArgs.Has("tagging") {
+				// GetBucketTagging
+				return auth.GetBucketTaggingAction, auth.PermissionRead, nil
+			} else if queryArgs.Has("ownershipControls") {
+				// GetBucketOwnershipControls
+				return auth.GetBucketOwnershipControlsAction, auth.PermissionRead, s3err.GetAPIError(s3err.ErrAnonymousGetBucketOwnership)
+			} else if queryArgs.Has("versioning") {
+				// GetBucketVersioning
+				return auth.GetBucketVersioningAction, auth.PermissionRead, nil
+			} else if queryArgs.Has("policy") {
+				// GetBucketPolicy
+				return auth.GetBucketPolicyAction, auth.PermissionRead, nil
+			} else if queryArgs.Has("cors") {
+				// GetBucketCors
+				return auth.GetBucketCorsAction, auth.PermissionRead, nil
+			} else if queryArgs.Has("versions") {
+				// ListObjectVersions
+				return auth.ListBucketVersionsAction, auth.PermissionRead, nil
+			} else if queryArgs.Has("object-lock") {
+				// GetObjectLockConfiguration
+				return auth.GetBucketObjectLockConfigurationAction, auth.PermissionReadAcp, nil
+			} else if queryArgs.Has("acl") {
+				// GetBucketAcl
+				return auth.GetBucketAclAction, auth.PermissionRead, nil
+			} else if queryArgs.Has("uploads") {
+				// ListMultipartUploads
+				return auth.ListBucketMultipartUploadsAction, auth.PermissionRead, nil
+			} else if queryArgs.GetUintOrZero("list-type") == 2 {
+				// ListObjectsV2
+				return auth.ListBucketAction, auth.PermissionRead, nil
+			}
+			// All the other requests are considerd as ListObjects in the router
+			// no matter what kind of query arguments are provided apart from the ones above
+
+			return auth.ListBucketAction, auth.PermissionRead, nil
+		}
+
+		if queryArgs.Has("tagging") {
+			// GetObjectTagging
+			return auth.GetObjectTaggingAction, auth.PermissionRead, nil
+		} else if queryArgs.Has("retention") {
+			// GetObjectRetention
+			return auth.GetObjectRetentionAction, auth.PermissionRead, nil
+		} else if queryArgs.Has("legal-hold") {
+			// GetObjectLegalHold
+			return auth.GetObjectLegalHoldAction, auth.PermissionReadAcp, nil
+		} else if queryArgs.Has("acl") {
+			// GetObjectAcl
+			return auth.GetObjectAclAction, auth.PermissionRead, nil
+		} else if queryArgs.Has("attributes") {
+			// GetObjectAttributes
+			return auth.GetObjectAttributesAction, auth.PermissionRead, nil
+		} else if queryArgs.Has("uploadId") {
+			// ListParts
+			return auth.ListMultipartUploadPartsAction, auth.PermissionRead, nil
+		}
+
+		// All the other requests are considerd as GetObject in the router
+		// no matter what kind of query arguments are provided apart from the ones above
+		if queryArgs.Has("versionId") {
+			return auth.GetObjectVersionAction, auth.PermissionRead, nil
+		}
+		return auth.GetObjectAction, auth.PermissionRead, nil
+	case fiber.MethodPut:
+		if isBucketAction {
+			if queryArgs.Has("tagging") {
+				// PutBucketTagging
+				return auth.PutBucketTaggingAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("ownershipControls") {
+				// PutBucketOwnershipControls
+				return auth.PutBucketOwnershipControlsAction, auth.PermissionWrite, s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership)
+			}
+			if queryArgs.Has("versioning") {
+				// PutBucketVersioning
+				return auth.PutBucketVersioningAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("object-lock") {
+				// PutObjectLockConfiguration
+				return auth.PutBucketObjectLockConfigurationAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("cors") {
+				// PutBucketCors
+				return auth.PutBucketCorsAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("policy") {
+				// PutBucketPolicy
+				return auth.PutBucketPolicyAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("acl") {
+				// PutBucketAcl
+				return auth.PutBucketAclAction, auth.PermissionWrite, s3err.GetAPIError(s3err.ErrAnonymousRequest)
+			}
+
+			// All the other rquestes are considered as 'CreateBucket' in the router
+			return "", "", s3err.GetAPIError(s3err.ErrAnonymousRequest)
+		}
+
+		if queryArgs.Has("tagging") {
+			// PutObjectTagging
+			return auth.PutObjectTaggingAction, auth.PermissionWrite, nil
+		}
+		if queryArgs.Has("retention") {
+			// PutObjectRetention
+			return auth.PutObjectRetentionAction, auth.PermissionWrite, nil
+		}
+		if queryArgs.Has("legal-hold") {
+			// PutObjectLegalHold
+			return auth.PutObjectLegalHoldAction, auth.PermissionWrite, nil
+		}
+		if queryArgs.Has("acl") {
+			// PutObjectAcl
+			return auth.PutObjectAclAction, auth.PermissionWriteAcp, s3err.GetAPIError(s3err.ErrAnonymousRequest)
+		}
+		if queryArgs.Has("uploadId") && queryArgs.Has("partNumber") {
+			if ctx.Get("X-Amz-Copy-Source") != "" {
+				// UploadPartCopy
+				//TODO: Add public access check for copy-source
+				// Return AccessDenied for now
+				return auth.PutObjectAction, auth.PermissionWrite, s3err.GetAPIError(s3err.ErrAccessDenied)
+			}
+
+			utils.ContextKeyBodyReader.Set(ctx, ctx.Request().BodyStream())
+			// UploadPart
+			return auth.PutObjectAction, auth.PermissionWrite, nil
+		}
+		if ctx.Get("X-Amz-Copy-Source") != "" {
+			return auth.PutObjectAction, auth.PermissionWrite, s3err.GetAPIError(s3err.ErrAnonymousCopyObject)
+		}
+
+		utils.ContextKeyBodyReader.Set(ctx, ctx.Request().BodyStream())
+		// All the other requests are considered as 'PutObject' in the router
+		return auth.PutObjectAction, auth.PermissionWrite, nil
+	case fiber.MethodPost:
+		if isBucketAction {
+			// DeleteObjects
+			// FIXME: should be fixed with https://github.com/versity/versitygw/issues/1327
+			// Return AccessDenied for now
+			return auth.DeleteObjectAction, auth.PermissionWrite, s3err.GetAPIError(s3err.ErrAccessDenied)
+		}
+
+		if queryArgs.Has("restore") {
+			return auth.RestoreObjectAction, auth.PermissionWrite, nil
+		}
+		if queryArgs.Has("select") && ctx.Query("select-type") == "2" {
+			// SelectObjectContent
+			return auth.GetObjectAction, auth.PermissionRead, s3err.GetAPIError(s3err.ErrAnonymousRequest)
+		}
+		if queryArgs.Has("uploadId") {
+			// CompleteMultipartUpload
+			return auth.PutObjectAction, auth.PermissionWrite, nil
+		}
+
+		// All the other requests are considered as 'CreateMultipartUpload' in the router
+		return "", "", s3err.GetAPIError(s3err.ErrAnonymousCreateMp)
+	case fiber.MethodDelete:
+		if isBucketAction {
+			if queryArgs.Has("tagging") {
+				// DeleteBucketTagging
+				return auth.PutBucketTaggingAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("ownershipControls") {
+				// DeleteBucketOwnershipControls
+				return auth.PutBucketOwnershipControlsAction, auth.PermissionWrite, s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership)
+			}
+			if queryArgs.Has("policy") {
+				// DeleteBucketPolicy
+				return auth.PutBucketPolicyAction, auth.PermissionWrite, nil
+			}
+			if queryArgs.Has("cors") {
+				// DeleteBucketCors
+				return auth.PutBucketCorsAction, auth.PermissionWrite, nil
+			}
+
+			// All the other requests are considered as 'DeleteBucket' in the router
+			return auth.DeleteBucketAction, auth.PermissionWrite, nil
+		}
+
+		if queryArgs.Has("tagging") {
+			// DeleteObjectTagging
+			return auth.PutObjectTaggingAction, auth.PermissionWrite, nil
+		}
+		if queryArgs.Has("uploadId") {
+			// AbortMultipartUpload
+			return auth.AbortMultipartUploadAction, auth.PermissionWrite, nil
+		}
+		// All the other requests are considered as 'DeleteObject' in the router
+		return auth.DeleteObjectAction, auth.PermissionWrite, nil
+	default:
+		// In no action is detected, return AccessDenied ?
+		return "", "", s3err.GetAPIError(s3err.ErrAccessDenied)
+	}
+}
+
+// parsePath extracts the bucket and object names from the path
+func parsePath(path string) (string, string) {
+	p := strings.TrimPrefix(path, "/")
+	bucket, object, _ := strings.Cut(p, "/")
+
+	return bucket, object
+}

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -83,10 +83,16 @@ func New(
 		app.Use(middlewares.HostStyleParser(server.virtualDomain))
 	}
 
+	// initilaze the default value setter middleware
+	app.Use(middlewares.SetDefaultValues(root, region))
+
 	// initialize the debug logger in debug mode
 	if server.debug {
 		app.Use(middlewares.DebugLogger())
 	}
+
+	// Public buckets access checker
+	app.Use(middlewares.AuthorizePublicBucketAccess(be, l, mm))
 
 	// Authentication middlewares
 	app.Use(middlewares.VerifyPresignedV4Signature(root, iam, l, mm, region, server.debug))

--- a/s3api/utils/context-keys.go
+++ b/s3api/utils/context-keys.go
@@ -1,0 +1,65 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+// Region, StartTime, IsRoot, Account, AccessKey context locals
+// are set to defualut values in middlewares.SetDefaultValues
+// to avoid the nil interface conversions
+type ContextKey string
+
+const (
+	ContextKeyRegion         ContextKey = "region"
+	ContextKeyStartTime      ContextKey = "start-time"
+	ContextKeyIsRoot         ContextKey = "is-root"
+	ContextKeyRootAccessKey  ContextKey = "root-access-key"
+	ContextKeyAccount        ContextKey = "account"
+	ContextKeyAuthenticated  ContextKey = "authenticated"
+	ContextKeyPublicBucket   ContextKey = "public-bucket"
+	ContextKeyParsedAcl      ContextKey = "parsed-acl"
+	ContextKeySkipResBodyLog ContextKey = "skip-res-body-log"
+	ContextKeyBodyReader     ContextKey = "body-reader"
+)
+
+func (ck ContextKey) Values() []ContextKey {
+	return []ContextKey{
+		ContextKeyRegion,
+		ContextKeyStartTime,
+		ContextKeyIsRoot,
+		ContextKeyRootAccessKey,
+		ContextKeyAccount,
+		ContextKeyAuthenticated,
+		ContextKeyPublicBucket,
+		ContextKeyParsedAcl,
+		ContextKeySkipResBodyLog,
+		ContextKeyBodyReader,
+	}
+}
+
+func (ck ContextKey) Set(ctx *fiber.Ctx, val any) {
+	ctx.Locals(string(ck), val)
+}
+
+func (ck ContextKey) IsSet(ctx *fiber.Ctx) bool {
+	val := ctx.Locals(string(ck))
+	return val != nil
+}
+
+func (ck ContextKey) Get(ctx *fiber.Ctx) any {
+	return ctx.Locals(string(ck))
+}

--- a/s3api/utils/presign-auth-reader.go
+++ b/s3api/utils/presign-auth-reader.go
@@ -180,7 +180,7 @@ func ParsePresignedURIParts(ctx *fiber.Ctx) (AuthData, error) {
 		return a, s3err.GetAPIError(s3err.ErrSignatureDateDoesNotMatch)
 	}
 
-	if ctx.Locals("region") != creds[2] {
+	if ContextKeyRegion.Get(ctx) != creds[2] {
 		return a, s3err.APIError{
 			Code:           "SignatureDoesNotMatch",
 			Description:    fmt.Sprintf("Credential should be scoped to a valid Region, not %v", creds[2]),

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -59,6 +59,11 @@ type ErrorCode int
 const (
 	ErrNone ErrorCode = iota
 	ErrAccessDenied
+	ErrAnonymousRequest
+	ErrAnonymousCreateMp
+	ErrAnonymousCopyObject
+	ErrAnonymousPutBucketOwnership
+	ErrAnonymousGetBucketOwnership
 	ErrMethodNotAllowed
 	ErrBucketNotEmpty
 	ErrVersionedBucketNotEmpty
@@ -184,6 +189,31 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrAccessDenied: {
 		Code:           "AccessDenied",
 		Description:    "Access Denied.",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrAnonymousRequest: {
+		Code:           "AccessDenied",
+		Description:    "Anonymous users cannot invoke this API. Please authenticate.",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrAnonymousCreateMp: {
+		Code:           "AccessDenied",
+		Description:    "Anonymous users cannot initiate multipart uploads. Please authenticate.",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrAnonymousCopyObject: {
+		Code:           "AccessDenied",
+		Description:    "Anonymous users cannot copy objects. Please authenticate.",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrAnonymousPutBucketOwnership: {
+		Code:           "AccessDenied",
+		Description:    "s3:PutBucketOwnershipControls does not support Anonymous requests!",
+		HTTPStatusCode: http.StatusForbidden,
+	},
+	ErrAnonymousGetBucketOwnership: {
+		Code:           "AccessDenied",
+		Description:    "s3:GetBucketOwnershipControls does not support Anonymous requests!",
 		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrMethodNotAllowed: {

--- a/s3event/event.go
+++ b/s3event/event.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/versity/versitygw/auth"
+	"github.com/versity/versitygw/s3api/utils"
 )
 
 type S3EventSender interface {
@@ -147,14 +148,14 @@ func createEventSchema(ctx *fiber.Ctx, meta EventMeta, configId ConfigurationId)
 		bucket, object = path[1], strings.Join(path[2:], "/")
 	}
 
-	acc := ctx.Locals("account").(auth.Account)
+	acc := utils.ContextKeyAccount.Get(ctx).(auth.Account)
 
 	return EventSchema{
 		Records: []EventRecord{
 			{
 				EventVersion: "2.2",
 				EventSource:  "aws:s3",
-				AwsRegion:    ctx.Locals("region").(string),
+				AwsRegion:    utils.ContextKeyRegion.Get(ctx).(string),
 				EventTime:    time.Now().Format(time.RFC3339),
 				EventName:    meta.EventName,
 				UserIdentity: EventUserIdentity{

--- a/s3log/file_admin.go
+++ b/s3log/file_admin.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/versity/versitygw/auth"
+	"github.com/versity/versitygw/s3api/utils"
 )
 
 // FileLogger is a local file audit log
@@ -57,7 +58,10 @@ func (f *AdminFileLogger) Log(ctx *fiber.Ctx, err error, body []byte, meta LogMe
 	access := "-"
 	reqURI := ctx.OriginalURL()
 	errorCode := ""
-	startTime := ctx.Locals("startTime").(time.Time)
+	startTime, ok := utils.ContextKeyStartTime.Get(ctx).(time.Time)
+	if !ok {
+		startTime = time.Now()
+	}
 	tlsConnState := ctx.Context().TLSConnectionState()
 	if tlsConnState != nil {
 		lf.CipherSuite = tls.CipherSuiteName(tlsConnState.CipherSuite)
@@ -68,9 +72,9 @@ func (f *AdminFileLogger) Log(ctx *fiber.Ctx, err error, body []byte, meta LogMe
 		errorCode = err.Error()
 	}
 
-	switch ctx.Locals("account").(type) {
+	switch utils.ContextKeyAccount.Get(ctx).(type) {
 	case auth.Account:
-		access = ctx.Locals("account").(auth.Account).Access
+		access = utils.ContextKeyAccount.Get(ctx).(auth.Account).Access
 	}
 
 	lf.Time = time.Now()

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -15,7 +15,6 @@
 package integration
 
 func TestAuthentication(s *S3Conf) {
-	Authentication_empty_auth_header(s)
 	Authentication_invalid_auth_header(s)
 	Authentication_unsupported_signature_version(s)
 	Authentication_malformed_credentials(s)
@@ -37,7 +36,6 @@ func TestAuthentication(s *S3Conf) {
 }
 
 func TestPresignedAuthentication(s *S3Conf) {
-	PresignedAuth_missing_algo_query_param(s)
 	PresignedAuth_unsupported_algorithm(s)
 	PresignedAuth_missing_credentials_query_param(s)
 	PresignedAuth_malformed_creds_invalid_parts(s)
@@ -636,6 +634,11 @@ func TestFullFlow(s *S3Conf) {
 	TestGetObjectLegalHold(s)
 	TestWORMProtection(s)
 	TestAccessControl(s)
+	// FIXME: The tests should pass for azure as well
+	// but this issue should be fixed with https://github.com/versity/versitygw/issues/1336
+	if !s.azureTests {
+		TestPublicBuckets(s)
+	}
 	if s.versioningEnabled {
 		TestVersioning(s)
 	}
@@ -775,6 +778,13 @@ func TestAccessControl(s *S3Conf) {
 	AccessControl_copy_object_with_starting_slash_for_user(s)
 }
 
+func TestPublicBuckets(s *S3Conf) {
+	PublicBucket_default_privet_bucket(s)
+	PublicBucket_public_bucket_policy(s)
+	PublicBucket_public_object_policy(s)
+	PublicBucket_public_acl(s)
+}
+
 func TestVersioning(s *S3Conf) {
 	// PutBucketVersioning action
 	PutBucketVersioning_non_existing_bucket(s)
@@ -863,7 +873,6 @@ type IntTests map[string]func(s *S3Conf) error
 
 func GetIntTests() IntTests {
 	return IntTests{
-		"Authentication_empty_auth_header":                                        Authentication_empty_auth_header,
 		"Authentication_invalid_auth_header":                                      Authentication_invalid_auth_header,
 		"Authentication_unsupported_signature_version":                            Authentication_unsupported_signature_version,
 		"Authentication_malformed_credentials":                                    Authentication_malformed_credentials,
@@ -882,7 +891,6 @@ func GetIntTests() IntTests {
 		"Authentication_incorrect_payload_hash":                                   Authentication_incorrect_payload_hash,
 		"Authentication_incorrect_md5":                                            Authentication_incorrect_md5,
 		"Authentication_signature_error_incorrect_secret_key":                     Authentication_signature_error_incorrect_secret_key,
-		"PresignedAuth_missing_algo_query_param":                                  PresignedAuth_missing_algo_query_param,
 		"PresignedAuth_unsupported_algorithm":                                     PresignedAuth_unsupported_algorithm,
 		"PresignedAuth_missing_credentials_query_param":                           PresignedAuth_missing_credentials_query_param,
 		"PresignedAuth_malformed_creds_invalid_parts":                             PresignedAuth_malformed_creds_invalid_parts,
@@ -1277,6 +1285,10 @@ func GetIntTests() IntTests {
 		"AccessControl_root_PutBucketAcl":                                         AccessControl_root_PutBucketAcl,
 		"AccessControl_user_PutBucketAcl_with_policy_access":                      AccessControl_user_PutBucketAcl_with_policy_access,
 		"AccessControl_copy_object_with_starting_slash_for_user":                  AccessControl_copy_object_with_starting_slash_for_user,
+		"PublicBucket_default_privet_bucket":                                      PublicBucket_default_privet_bucket,
+		"PublicBucket_public_bucket_policy":                                       PublicBucket_public_bucket_policy,
+		"PublicBucket_public_object_policy":                                       PublicBucket_public_object_policy,
+		"PublicBucket_public_acl":                                                 PublicBucket_public_acl,
 		"PutBucketVersioning_non_existing_bucket":                                 PutBucketVersioning_non_existing_bucket,
 		"PutBucketVersioning_invalid_status":                                      PutBucketVersioning_invalid_status,
 		"PutBucketVersioning_success_enabled":                                     PutBucketVersioning_success_enabled,

--- a/tests/integration/s3conf.go
+++ b/tests/integration/s3conf.go
@@ -130,16 +130,24 @@ func (c *S3Conf) GetClient() *s3.Client {
 	})
 }
 
+func (c *S3Conf) GetAnonymousClient() *s3.Client {
+	cfg := c.Config()
+	cfg.Credentials = aws.AnonymousCredentials{}
+	return s3.NewFromConfig(cfg, func(o *s3.Options) {
+		if c.hostStyle {
+			o.BaseEndpoint = &c.endpoint
+			o.UsePathStyle = false
+		}
+	})
+}
+
 func (c *S3Conf) Config() aws.Config {
 	creds := c.getCreds()
-
-	tr := &http.Transport{}
-	client := &http.Client{Transport: tr}
 
 	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(c.awsRegion),
 		config.WithCredentialsProvider(creds),
-		config.WithHTTPClient(client),
+		config.WithHTTPClient(c.httpClient),
 		config.WithRetryMaxAttempts(1),
 	}
 

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -47,31 +47,6 @@ var (
 	nullVersionId = "null"
 )
 
-func Authentication_empty_auth_header(s *S3Conf) error {
-	testName := "Authentication_empty_auth_header"
-	return authHandler(s, &authConfig{
-		testName: testName,
-		path:     "my-bucket",
-		method:   http.MethodGet,
-		body:     nil,
-		service:  "s3",
-		date:     time.Now(),
-	}, func(req *http.Request) error {
-		req.Header.Set("Authorization", "")
-
-		resp, err := s.httpClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrAuthHeaderEmpty)); err != nil {
-			return err
-		}
-
-		return nil
-	})
-}
-
 func Authentication_invalid_auth_header(s *S3Conf) error {
 	testName := "Authentication_invalid_auth_header"
 	return authHandler(s, &authConfig{
@@ -572,43 +547,6 @@ func Authentication_signature_error_incorrect_secret_key(s *S3Conf) error {
 		}
 		defer resp.Body.Close()
 		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrSignatureDoesNotMatch)); err != nil {
-			return err
-		}
-
-		return nil
-	})
-}
-
-func PresignedAuth_missing_algo_query_param(s *S3Conf) error {
-	testName := "PresignedAuth_missing_algo_query_param"
-	return presignedAuthHandler(s, testName, func(client *s3.PresignClient) error {
-		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
-		v4req, err := client.PresignDeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: getPtr("my-bucket")})
-		cancel()
-		if err != nil {
-			return err
-		}
-
-		urlParsed, err := url.Parse(v4req.URL)
-		if err != nil {
-			return err
-		}
-
-		queries := urlParsed.Query()
-		queries.Del("X-Amz-Algorithm")
-		urlParsed.RawQuery = queries.Encode()
-
-		req, err := http.NewRequest(v4req.Method, urlParsed.String(), nil)
-		if err != nil {
-			return err
-		}
-
-		resp, err := s.httpClient.Do(req)
-		if err != nil {
-			return err
-		}
-
-		if err := checkAuthErr(resp, s3err.GetAPIError(s3err.ErrInvalidQueryParams)); err != nil {
 			return err
 		}
 
@@ -15333,6 +15271,2420 @@ func AccessControl_copy_object_with_starting_slash_for_user(s *S3Conf) error {
 
 		return nil
 	})
+}
+
+// Public bucket tests
+func PublicBucket_default_privet_bucket(s *S3Conf) error {
+	testName := "PublicBucket_default_privet_bucket"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		partNumber := int32(1)
+
+		for _, test := range []PublicBucketTestCase{
+			{
+				Action: "ListBuckets",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListBuckets(ctx, &s3.ListBucketsInput{})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "HeadBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CreateBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: getPtr("new-bucket")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+						Bucket: &bucket,
+						ACL:    types.BucketCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "DeleteBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketVersioning",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+						Bucket: &bucket,
+						VersioningConfiguration: &types.VersioningConfiguration{
+							Status: types.BucketVersioningStatusSuspended,
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketVersioning",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{Bucket: &bucket, Policy: getPtr("{}")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketOwnershipControls(ctx, &s3.PutBucketOwnershipControlsInput{
+						Bucket: &bucket,
+						OwnershipControls: &types.OwnershipControls{
+							Rules: []types.OwnershipControlsRule{
+								{
+									ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "GetBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousGetBucketOwnership),
+			},
+			{
+				Action: "DeleteBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "PutBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
+						Bucket: &bucket,
+						CORSConfiguration: &types.CORSConfiguration{
+							CORSRules: []types.CORSRule{
+								{
+									AllowedMethods: []string{http.MethodPut},
+									AllowedOrigins: []string{"my origin"},
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CreateMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCreateMp),
+			},
+			{
+				Action: "CompleteMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "AbortMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListMultipartUploads",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListMultipartUploads(ctx, &s3.ListMultipartUploadsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListParts",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListParts(ctx, &s3.ListPartsInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "UploadPart",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.UploadPart(ctx, &s3.UploadPartInput{
+						Bucket:     &bucket,
+						Key:        getPtr("object-key"),
+						UploadId:   getPtr("upload-id"),
+						PartNumber: &partNumber,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "UploadPartCopy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
+						Bucket:     &bucket,
+						Key:        getPtr("object-key"),
+						UploadId:   getPtr("upload-id"),
+						PartNumber: &partNumber,
+						CopySource: getPtr("source-bucket/source-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObject(ctx, &s3.PutObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "HeadObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAcl(ctx, &s3.GetObjectAclInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectAttributes",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAttributes(ctx, &s3.GetObjectAttributesInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						ObjectAttributes: []types.ObjectAttributes{
+							types.ObjectAttributesEtag,
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CopyObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CopyObject(ctx, &s3.CopyObjectInput{
+						Bucket:     &bucket,
+						Key:        getPtr("copy-key"),
+						CopySource: getPtr("bucket-name/object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCopyObject),
+			},
+			{
+				Action: "ListObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjects(ctx, &s3.ListObjectsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListObjectsV2",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+						Bucket: &bucket,
+						Delete: &types.Delete{
+							Objects: []types.ObjectIdentifier{
+								{Key: getPtr("object-key")},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectAcl(ctx, &s3.PutObjectAclInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						ACL:    types.ObjectCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "ListObjectVersions",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "RestoreObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.RestoreObject(ctx, &s3.RestoreObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						RestoreRequest: &types.RestoreRequest{
+							Days: aws.Int32(1),
+							GlacierJobParameters: &types.GlacierJobParameters{
+								Tier: types.TierStandard,
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "SelectObjectContent",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.SelectObjectContent(ctx, &s3.SelectObjectContentInput{
+						Bucket:         &bucket,
+						Key:            getPtr("object-key"),
+						ExpressionType: types.ExpressionTypeSql,
+						Expression:     getPtr("SELECT * FROM S3Object"),
+						InputSerialization: &types.InputSerialization{
+							CSV: &types.CSVInput{},
+						},
+						OutputSerialization: &types.OutputSerialization{
+							CSV: &types.CSVOutput{},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "GetBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+						Bucket: &bucket,
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketTagging(ctx, &s3.DeleteBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjectTagging(ctx, &s3.DeleteObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLockConfiguration(ctx, &s3.PutObjectLockConfigurationInput{
+						Bucket: &bucket,
+						ObjectLockConfiguration: &types.ObjectLockConfiguration{
+							ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+							Rule: &types.ObjectLockRule{
+								DefaultRetention: &types.DefaultRetention{
+									Days: aws.Int32(1),
+									Mode: types.ObjectLockRetentionModeCompliance,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectRetention(ctx, &s3.PutObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						Retention: &types.ObjectLockRetention{
+							Mode:            types.ObjectLockRetentionModeCompliance,
+							RetainUntilDate: aws.Time(time.Now().Add(24 * time.Hour)),
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectRetention(ctx, &s3.GetObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLegalHold(ctx, &s3.PutObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						LegalHold: &types.ObjectLockLegalHold{
+							Status: types.ObjectLockLegalHoldStatusOn,
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLegalHold(ctx, &s3.GetObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+		} {
+			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+			err := test.Call(ctx)
+			cancel()
+			if err == nil && test.ExpectedErr != nil {
+				return fmt.Errorf("%v: expected err %v, instead got successful response", test.Action, test.ExpectedErr)
+			}
+			if err != nil {
+				if test.ExpectedErr == nil {
+					return fmt.Errorf("%v: expected no error, instead got %v", test.Action, err)
+				}
+
+				apiErr, ok := test.ExpectedErr.(s3err.APIError)
+				if !ok {
+					return fmt.Errorf("invalid error type provided in the test, expected s3err.APIError")
+				}
+
+				// The head requests doesn't have request body, thus only the status needs to be checked
+				if test.Action == "HeadBucket" || test.Action == "HeadObject" {
+					if err := checkSdkApiErr(err, http.StatusText(apiErr.HTTPStatusCode)); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if err := checkApiErr(err, apiErr); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}, withAnonymousClient())
+}
+
+func PublicBucket_public_bucket_policy(s *S3Conf) error {
+	testName := "PublicBucket_public_bucket_policy"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		rootClient := s.GetClient()
+		// Grant public access to the bucket for bucket operations
+		err := grantPublicBucketPolicy(rootClient, bucket, policyTypeBucket)
+		if err != nil {
+			return err
+		}
+		partNumber := int32(1)
+
+		for _, test := range []PublicBucketTestCase{
+			{
+				Action: "ListBuckets",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListBuckets(ctx, &s3.ListBucketsInput{})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "HeadBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "CreateBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: getPtr("new-bucket")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+						Bucket: &bucket,
+						ACL:    types.BucketCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{Bucket: &bucket, Policy: getPtr("{}")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrMethodNotAllowed),
+			},
+			{
+				Action: "GetBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrMethodNotAllowed),
+			},
+			{
+				Action: "DeleteBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrMethodNotAllowed),
+			},
+			{
+				Action: "PutBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketOwnershipControls(ctx, &s3.PutBucketOwnershipControlsInput{
+						Bucket: &bucket,
+						OwnershipControls: &types.OwnershipControls{
+							Rules: []types.OwnershipControlsRule{
+								{
+									ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "GetBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousGetBucketOwnership),
+			},
+			{
+				Action: "DeleteBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "PutBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
+						Bucket: &bucket,
+						CORSConfiguration: &types.CORSConfiguration{
+							CORSRules: []types.CORSRule{
+								{
+									AllowedMethods: []string{http.MethodPut},
+									AllowedOrigins: []string{"my origin"},
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrNotImplemented),
+			},
+			{
+				Action: "GetBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrNotImplemented),
+			},
+			{
+				Action: "DeleteBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrNotImplemented),
+			},
+			{
+				Action: "CreateMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCreateMp),
+			},
+			{
+				Action: "CompleteMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "AbortMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListMultipartUploads",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListMultipartUploads(ctx, &s3.ListMultipartUploadsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "ListParts",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListParts(ctx, &s3.ListPartsInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "UploadPart",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.UploadPart(ctx, &s3.UploadPartInput{
+						Bucket:     &bucket,
+						Key:        getPtr("object-key"),
+						UploadId:   getPtr("upload-id"),
+						PartNumber: &partNumber,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "UploadPartCopy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
+						Bucket:     &bucket,
+						Key:        getPtr("object-key"),
+						UploadId:   getPtr("upload-id"),
+						PartNumber: &partNumber,
+						CopySource: getPtr("source-bucket/source-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObject(ctx, &s3.PutObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "HeadObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAcl(ctx, &s3.GetObjectAclInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectAttributes",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAttributes(ctx, &s3.GetObjectAttributesInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						ObjectAttributes: []types.ObjectAttributes{
+							types.ObjectAttributesEtag,
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CopyObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CopyObject(ctx, &s3.CopyObjectInput{
+						Bucket:     &bucket,
+						Key:        getPtr("copy-key"),
+						CopySource: getPtr("bucket-name/object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCopyObject),
+			},
+			{
+				Action: "ListObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjects(ctx, &s3.ListObjectsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "ListObjectsV2",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "DeleteObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+						Bucket: &bucket,
+						Delete: &types.Delete{
+							Objects: []types.ObjectIdentifier{
+								{Key: getPtr("object-key")},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectAcl(ctx, &s3.PutObjectAclInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						ACL:    types.ObjectCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "ListObjectVersions",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "RestoreObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.RestoreObject(ctx, &s3.RestoreObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						RestoreRequest: &types.RestoreRequest{
+							Days: aws.Int32(1),
+							GlacierJobParameters: &types.GlacierJobParameters{
+								Tier: types.TierStandard,
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "SelectObjectContent",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.SelectObjectContent(ctx, &s3.SelectObjectContentInput{
+						Bucket:         &bucket,
+						Key:            getPtr("object-key"),
+						ExpressionType: types.ExpressionTypeSql,
+						Expression:     getPtr("SELECT * FROM S3Object"),
+						InputSerialization: &types.InputSerialization{
+							CSV: &types.CSVInput{},
+						},
+						OutputSerialization: &types.OutputSerialization{
+							CSV: &types.CSVOutput{},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+						Bucket: &bucket,
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "DeleteBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketTagging(ctx, &s3.DeleteBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjectTagging(ctx, &s3.DeleteObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLockConfiguration(ctx, &s3.PutObjectLockConfigurationInput{
+						Bucket: &bucket,
+						ObjectLockConfiguration: &types.ObjectLockConfiguration{
+							ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+							Rule: &types.ObjectLockRule{
+								DefaultRetention: &types.DefaultRetention{
+									Days: aws.Int32(1),
+									Mode: types.ObjectLockRetentionModeGovernance,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "PutObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectRetention(ctx, &s3.PutObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						Retention: &types.ObjectLockRetention{
+							Mode:            types.ObjectLockRetentionModeCompliance,
+							RetainUntilDate: aws.Time(time.Now().Add(24 * time.Hour)),
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectRetention(ctx, &s3.GetObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLegalHold(ctx, &s3.PutObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						LegalHold: &types.ObjectLockLegalHold{
+							Status: types.ObjectLockLegalHoldStatusOn,
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLegalHold(ctx, &s3.GetObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+		} {
+			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+			err := test.Call(ctx)
+			cancel()
+			if err == nil && test.ExpectedErr != nil {
+				return fmt.Errorf("%v: expected err %v, instead got successful response", test.Action, test.ExpectedErr)
+			}
+			if err != nil {
+				if test.ExpectedErr == nil {
+					return fmt.Errorf("%v: expected no error, instead got %v", test.Action, err)
+				}
+
+				apiErr, ok := test.ExpectedErr.(s3err.APIError)
+				if !ok {
+					return fmt.Errorf("invalid error type provided in the test, expected s3err.APIError")
+				}
+
+				// The head requests doesn't have request body, thus only the status needs to be checked
+				if test.Action == "HeadBucket" || test.Action == "HeadObject" {
+					if err := checkSdkApiErr(err, http.StatusText(apiErr.HTTPStatusCode)); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if err := checkApiErr(err, apiErr); err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	}, withAnonymousClient(), withLock(), withSkipTearDown())
+}
+
+func PublicBucket_public_object_policy(s *S3Conf) error {
+	testName := "PublicBucket_public_object_policy"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		rootClient := s.GetClient()
+		// Grant public access to the bucket for bucket operations
+		err := grantPublicBucketPolicy(rootClient, bucket, policyTypeObject)
+		if err != nil {
+			return err
+		}
+
+		mpKey := "my-mp"
+
+		mp1, err := createMp(rootClient, bucket, mpKey)
+		if err != nil {
+			return err
+		}
+
+		mp2, err := createMp(rootClient, bucket, mpKey)
+		if err != nil {
+			return err
+		}
+
+		partNumber := int32(1)
+		var partEtag *string
+
+		for _, test := range []PublicBucketTestCase{
+			{
+				Action: "ListBuckets",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListBuckets(ctx, &s3.ListBucketsInput{})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "HeadBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CreateBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: getPtr("new-bucket")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+						Bucket: &bucket,
+						ACL:    types.BucketCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{Bucket: &bucket, Policy: getPtr("{}")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketOwnershipControls(ctx, &s3.PutBucketOwnershipControlsInput{
+						Bucket: &bucket,
+						OwnershipControls: &types.OwnershipControls{
+							Rules: []types.OwnershipControlsRule{
+								{
+									ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "GetBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousGetBucketOwnership),
+			},
+			{
+				Action: "DeleteBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "PutBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
+						Bucket: &bucket,
+						CORSConfiguration: &types.CORSConfiguration{
+							CORSRules: []types.CORSRule{
+								{
+									AllowedMethods: []string{http.MethodPut},
+									AllowedOrigins: []string{"my origin"},
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CreateMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCreateMp),
+			},
+			{
+				Action: "AbortMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+						Bucket:   &bucket,
+						Key:      &mpKey,
+						UploadId: mp1.UploadId,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "ListMultipartUploads",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListMultipartUploads(ctx, &s3.ListMultipartUploadsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListParts",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListParts(ctx, &s3.ListPartsInput{
+						Bucket:   &bucket,
+						Key:      &mpKey,
+						UploadId: mp2.UploadId,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "UploadPart",
+				Call: func(ctx context.Context) error {
+					partBuffer := make([]byte, 5*1024*1024)
+					rand.Read(partBuffer)
+					res, err := s3client.UploadPart(ctx, &s3.UploadPartInput{
+						Bucket:     &bucket,
+						Key:        &mpKey,
+						UploadId:   mp2.UploadId,
+						PartNumber: &partNumber,
+						Body:       bytes.NewReader(partBuffer),
+					})
+					if err == nil {
+						partEtag = res.ETag
+					}
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			//FIXME: should be fixed after implementing the source bucket public access check
+			// return AccessDenied for now
+			{
+				Action: "UploadPartCopy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
+						Bucket:     &bucket,
+						Key:        &mpKey,
+						UploadId:   mp2.UploadId,
+						PartNumber: &partNumber,
+						CopySource: getPtr("source-bucket/source-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CompleteMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+						Bucket:   &bucket,
+						Key:      &mpKey,
+						UploadId: mp2.UploadId,
+						MultipartUpload: &types.CompletedMultipartUpload{
+							Parts: []types.CompletedPart{
+								{
+									ETag:       partEtag,
+									PartNumber: &partNumber,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "PutObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObject(ctx, &s3.PutObjectInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "HeadObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &bucket, Key: &mpKey})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: &mpKey})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAcl(ctx, &s3.GetObjectAclInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrNotImplemented),
+			},
+			{
+				Action: "GetObjectAttributes",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAttributes(ctx, &s3.GetObjectAttributesInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+						ObjectAttributes: []types.ObjectAttributes{
+							types.ObjectAttributesEtag,
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "CopyObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CopyObject(ctx, &s3.CopyObjectInput{
+						Bucket:     &bucket,
+						Key:        getPtr("copy-key"),
+						CopySource: getPtr("bucket-name/object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCopyObject),
+			},
+			{
+				Action: "ListObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjects(ctx, &s3.ListObjectsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListObjectsV2",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			// FIXME: should be fixed with https://github.com/versity/versitygw/issues/1327
+			{
+				Action: "DeleteObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+						Bucket: &bucket,
+						Delete: &types.Delete{
+							Objects: []types.ObjectIdentifier{
+								{Key: getPtr("object-key")},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectAcl(ctx, &s3.PutObjectAclInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						ACL:    types.ObjectCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "ListObjectVersions",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "RestoreObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.RestoreObject(ctx, &s3.RestoreObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						RestoreRequest: &types.RestoreRequest{
+							Days: aws.Int32(1),
+							GlacierJobParameters: &types.GlacierJobParameters{
+								Tier: types.TierStandard,
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrNotImplemented),
+			},
+			{
+				Action: "SelectObjectContent",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.SelectObjectContent(ctx, &s3.SelectObjectContentInput{
+						Bucket:         &bucket,
+						Key:            getPtr("object-key"),
+						ExpressionType: types.ExpressionTypeSql,
+						Expression:     getPtr("SELECT * FROM S3Object"),
+						InputSerialization: &types.InputSerialization{
+							CSV: &types.CSVInput{},
+						},
+						OutputSerialization: &types.OutputSerialization{
+							CSV: &types.CSVOutput{},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+						Bucket: &bucket,
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketTagging(ctx, &s3.DeleteBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "DeleteObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjectTagging(ctx, &s3.DeleteObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "PutObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLockConfiguration(ctx, &s3.PutObjectLockConfigurationInput{
+						Bucket: &bucket,
+						ObjectLockConfiguration: &types.ObjectLockConfiguration{
+							ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+							Rule: &types.ObjectLockRule{
+								DefaultRetention: &types.DefaultRetention{
+									Days: aws.Int32(1),
+									Mode: types.ObjectLockRetentionModeGovernance,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectRetention(ctx, &s3.PutObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+						Retention: &types.ObjectLockRetention{
+							Mode:            types.ObjectLockRetentionModeGovernance,
+							RetainUntilDate: aws.Time(time.Now().Add(24 * time.Hour)),
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectRetention(ctx, &s3.GetObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "PutObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLegalHold(ctx, &s3.PutObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+						LegalHold: &types.ObjectLockLegalHold{
+							Status: types.ObjectLockLegalHoldStatusOff,
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLegalHold(ctx, &s3.GetObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    &mpKey,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "DeleteObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+						Bucket:                    &bucket,
+						Key:                       &mpKey,
+						BypassGovernanceRetention: getBoolPtr(true),
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "DeleteBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+		} {
+			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+			err := test.Call(ctx)
+			cancel()
+			if err == nil && test.ExpectedErr != nil {
+				return fmt.Errorf("%v: expected err %v, instead got successful response", test.Action, test.ExpectedErr)
+			}
+			if err != nil {
+				if test.ExpectedErr == nil {
+					return fmt.Errorf("%v: expected no error, instead got %v", test.Action, err)
+				}
+
+				apiErr, ok := test.ExpectedErr.(s3err.APIError)
+				if !ok {
+					return fmt.Errorf("invalid error type provided in the test, expected s3err.APIError")
+				}
+
+				// The head requests doesn't have request body, thus only the status needs to be checked
+				if test.Action == "HeadBucket" || test.Action == "HeadObject" {
+					if err := checkSdkApiErr(err, http.StatusText(apiErr.HTTPStatusCode)); err != nil {
+						return err
+					}
+					continue
+				}
+
+				if err := checkApiErr(err, apiErr); err != nil {
+					return err
+				}
+			}
+		}
+
+		// disable object lock on the bucket
+		err = changeBucketObjectLockStatus(rootClient, bucket, false)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}, withAnonymousClient(), withLock())
+}
+
+func PublicBucket_public_acl(s *S3Conf) error {
+	testName := "PublicBucket_public_acl"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		partNumber := int32(1)
+		var etag *string
+		obj := "my-obj"
+
+		// grant public access with acl
+		rootClient := s.GetClient()
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := rootClient.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+			Bucket: &bucket,
+			ACL:    types.BucketCannedACLPublicReadWrite,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		mp, err := createMp(rootClient, bucket, obj)
+		if err != nil {
+			return err
+		}
+
+		for _, test := range []PublicBucketTestCase{
+			{
+				Action: "ListBuckets",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListBuckets(ctx, &s3.ListBucketsInput{})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "HeadBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadBucket(ctx, &s3.HeadBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketAcl(ctx, &s3.GetBucketAclInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CreateBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateBucket(ctx, &s3.CreateBucketInput{Bucket: getPtr("new-bucket")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "PutBucketAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+						Bucket: &bucket,
+						ACL:    types.BucketCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "DeleteBucket",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucket(ctx, &s3.DeleteBucketInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			//FIXME: implement tests for versioning enabled gateway
+			// {
+			// 	Action: "PutBucketVersioning",
+			// 	Call: func(ctx context.Context) error {
+			// 		_, err := s3client.PutBucketVersioning(ctx, &s3.PutBucketVersioningInput{
+			// 			Bucket: &bucket,
+			// 			VersioningConfiguration: &types.VersioningConfiguration{
+			// 				Status: types.BucketVersioningStatusSuspended,
+			// 			},
+			// 		})
+			// 		return err
+			// 	},
+			// 	ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			// },
+			// {
+			// 	Action: "GetBucketVersioning",
+			// 	Call: func(ctx context.Context) error {
+			// 		_, err := s3client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{Bucket: &bucket})
+			// 		return err
+			// 	},
+			// 	ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			// },
+			{
+				Action: "PutBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketPolicy(ctx, &s3.PutBucketPolicyInput{Bucket: &bucket, Policy: getPtr("{}")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketPolicy(ctx, &s3.GetBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketPolicy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketPolicy(ctx, &s3.DeleteBucketPolicyInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketOwnershipControls(ctx, &s3.PutBucketOwnershipControlsInput{
+						Bucket: &bucket,
+						OwnershipControls: &types.OwnershipControls{
+							Rules: []types.OwnershipControlsRule{
+								{
+									ObjectOwnership: types.ObjectOwnershipBucketOwnerEnforced,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "GetBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousGetBucketOwnership),
+			},
+			{
+				Action: "DeleteBucketOwnershipControls",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketOwnershipControls(ctx, &s3.DeleteBucketOwnershipControlsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousPutBucketOwnership),
+			},
+			{
+				Action: "PutBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketCors(ctx, &s3.PutBucketCorsInput{
+						Bucket: &bucket,
+						CORSConfiguration: &types.CORSConfiguration{
+							CORSRules: []types.CORSRule{
+								{
+									AllowedMethods: []string{http.MethodPut},
+									AllowedOrigins: []string{"my origin"},
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketCors(ctx, &s3.GetBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketCors",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketCors(ctx, &s3.DeleteBucketCorsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CreateMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CreateMultipartUpload(ctx, &s3.CreateMultipartUploadInput{Bucket: &bucket, Key: getPtr("object-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCreateMp),
+			},
+			{
+				Action: "AbortMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.AbortMultipartUpload(ctx, &s3.AbortMultipartUploadInput{
+						Bucket:   &bucket,
+						Key:      &obj,
+						UploadId: mp.UploadId,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "ListMultipartUploads",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListMultipartUploads(ctx, &s3.ListMultipartUploadsInput{Bucket: &bucket})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "ListParts",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListParts(ctx, &s3.ListPartsInput{Bucket: &bucket, Key: getPtr("object-key"), UploadId: getPtr("upload-id")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "UploadPart",
+				Call: func(ctx context.Context) error {
+					partBuffer := make([]byte, 5*1024*1024)
+					rand.Read(partBuffer)
+					res, err := s3client.UploadPart(ctx, &s3.UploadPartInput{
+						Bucket:     &bucket,
+						Key:        &obj,
+						UploadId:   mp.UploadId,
+						PartNumber: &partNumber,
+						Body:       bytes.NewReader(partBuffer),
+					})
+					if err == nil {
+						etag = res.ETag
+					}
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			//FIXME: should be fixed after implementing the source bucket public access check
+			// return AccessDenied for now
+			{
+				Action: "UploadPartCopy",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.UploadPartCopy(ctx, &s3.UploadPartCopyInput{
+						Bucket:     &bucket,
+						Key:        &obj,
+						UploadId:   mp.UploadId,
+						PartNumber: &partNumber,
+						CopySource: getPtr("source-bucket/source-key")})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "CompleteMultipartUpload",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+						Bucket:   &bucket,
+						Key:      &obj,
+						UploadId: mp.UploadId,
+						MultipartUpload: &types.CompletedMultipartUpload{
+							Parts: []types.CompletedPart{
+								{
+									ETag:       etag,
+									PartNumber: &partNumber,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "PutObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObject(ctx, &s3.PutObjectInput{
+						Bucket: &bucket,
+						Key:    &obj,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "HeadObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.HeadObject(ctx, &s3.HeadObjectInput{Bucket: &bucket, Key: &obj})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObject(ctx, &s3.GetObjectInput{Bucket: &bucket, Key: &obj})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "GetObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAcl(ctx, &s3.GetObjectAclInput{
+						Bucket: &bucket,
+						Key:    &obj,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrNotImplemented),
+			},
+			{
+				Action: "GetObjectAttributes",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectAttributes(ctx, &s3.GetObjectAttributesInput{
+						Bucket: &bucket,
+						Key:    &obj,
+						ObjectAttributes: []types.ObjectAttributes{
+							types.ObjectAttributesEtag,
+						},
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "CopyObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.CopyObject(ctx, &s3.CopyObjectInput{
+						Bucket:     &bucket,
+						Key:        getPtr("copy-key"),
+						CopySource: getPtr("bucket-name/object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousCopyObject),
+			},
+			{
+				Action: "ListObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjects(ctx, &s3.ListObjectsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "ListObjectsV2",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "DeleteObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObject(ctx, &s3.DeleteObjectInput{
+						Bucket: &bucket,
+						Key:    &obj,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			// FIXME: should be fixed with https://github.com/versity/versitygw/issues/1327
+			{
+				Action: "DeleteObjects",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+						Bucket: &bucket,
+						Delete: &types.Delete{
+							Objects: []types.ObjectIdentifier{
+								{Key: getPtr("object-key")},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectAcl",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectAcl(ctx, &s3.PutObjectAclInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						ACL:    types.ObjectCannedACLPublicRead,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "ListObjectVersions",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: nil,
+			},
+			{
+				Action: "RestoreObject",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.RestoreObject(ctx, &s3.RestoreObjectInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						RestoreRequest: &types.RestoreRequest{
+							Days: aws.Int32(1),
+							GlacierJobParameters: &types.GlacierJobParameters{
+								Tier: types.TierStandard,
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "SelectObjectContent",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.SelectObjectContent(ctx, &s3.SelectObjectContentInput{
+						Bucket:         &bucket,
+						Key:            getPtr("object-key"),
+						ExpressionType: types.ExpressionTypeSql,
+						Expression:     getPtr("SELECT * FROM S3Object"),
+						InputSerialization: &types.InputSerialization{
+							CSV: &types.CSVInput{},
+						},
+						OutputSerialization: &types.OutputSerialization{
+							CSV: &types.CSVOutput{},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAnonymousRequest),
+			},
+			{
+				Action: "GetBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+						Bucket: &bucket,
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteBucketTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteBucketTagging(ctx, &s3.DeleteBucketTaggingInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectTagging(ctx, &s3.GetObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectTagging(ctx, &s3.PutObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						Tagging: &types.Tagging{
+							TagSet: []types.Tag{{Key: getPtr("key"), Value: getPtr("value")}},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "DeleteObjectTagging",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.DeleteObjectTagging(ctx, &s3.DeleteObjectTaggingInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLockConfiguration(ctx, &s3.PutObjectLockConfigurationInput{
+						Bucket: &bucket,
+						ObjectLockConfiguration: &types.ObjectLockConfiguration{
+							ObjectLockEnabled: types.ObjectLockEnabledEnabled,
+							Rule: &types.ObjectLockRule{
+								DefaultRetention: &types.DefaultRetention{
+									Days: aws.Int32(1),
+									Mode: types.ObjectLockRetentionModeCompliance,
+								},
+							},
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectLockConfiguration",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLockConfiguration(ctx, &s3.GetObjectLockConfigurationInput{
+						Bucket: &bucket,
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectRetention(ctx, &s3.PutObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						Retention: &types.ObjectLockRetention{
+							Mode:            types.ObjectLockRetentionModeCompliance,
+							RetainUntilDate: aws.Time(time.Now().Add(24 * time.Hour)),
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectRetention",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectRetention(ctx, &s3.GetObjectRetentionInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "PutObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.PutObjectLegalHold(ctx, &s3.PutObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+						LegalHold: &types.ObjectLockLegalHold{
+							Status: types.ObjectLockLegalHoldStatusOn,
+						},
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+			{
+				Action: "GetObjectLegalHold",
+				Call: func(ctx context.Context) error {
+					_, err := s3client.GetObjectLegalHold(ctx, &s3.GetObjectLegalHoldInput{
+						Bucket: &bucket,
+						Key:    getPtr("object-key"),
+					})
+					return err
+				},
+				ExpectedErr: s3err.GetAPIError(s3err.ErrAccessDenied),
+			},
+		} {
+			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+			err := test.Call(ctx)
+			cancel()
+			if err == nil && test.ExpectedErr != nil {
+				return fmt.Errorf("%v: expected err %v, instead got successful response", test.Action, test.ExpectedErr)
+			}
+			if err != nil {
+				if test.ExpectedErr == nil {
+					return fmt.Errorf("%v: expected no error, instead got %v", test.Action, err)
+				}
+
+				apiErr, ok := test.ExpectedErr.(s3err.APIError)
+				if !ok {
+					return fmt.Errorf("invalid error type provided in the test, expected s3err.APIError")
+				}
+
+				// The head requests doesn't have request body, thus only the status needs to be checked
+				if test.Action == "HeadBucket" || test.Action == "HeadObject" {
+					if err := checkSdkApiErr(err, http.StatusText(apiErr.HTTPStatusCode)); err != nil {
+						return fmt.Errorf("%v: %w", test.Action, err)
+					}
+					continue
+				}
+
+				if err := checkApiErr(err, apiErr); err != nil {
+					return fmt.Errorf("%v: %w", test.Action, err)
+				}
+			}
+		}
+
+		return nil
+	}, withAnonymousClient(), withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
 }
 
 // IAM related tests


### PR DESCRIPTION
Fixes #1325 

This implementation introduces **public buckets**, which are accessible without signature-based authentication.

Public buckets support a set of actions on buckets and objects, returning various errors based on the S3 action type and permissions (ACL or policy). The implementation aligns with the table provided in [this gist](https://gist.github.com/niksis02/5919d52d6112537a31c14d9abfa89ac0).

There are two ways to grant public access to a bucket:

* **Bucket ACLs**
* **Bucket Policies**

The implementation includes an `AuthorizePublicBucketAccess` middleware, which checks if public access has been granted to the bucket. If so, authentication middlewares are skipped. For unauthenticated requests, appropriate errors are returned based on the specific S3 action.

---

**1. Bucket-Level Operations:**

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": "arn:aws:s3:::test"
    }
  ]
}
```

**2. Object-Level Operations:**

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": "arn:aws:s3:::test/*"
    }
  ]
}
```

**3. Both Bucket and Object-Level Operations:**

```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": "arn:aws:s3:::test"
    },
    {
      "Effect": "Allow",
      "Principal": "*",
      "Action": "s3:*",
      "Resource": "arn:aws:s3:::test/*"
    }
  ]
}
```

---

```sh
aws s3api create-bucket --bucket test --object-ownership BucketOwnerPreferred
aws s3api put-bucket-acl --bucket test --acl public-read
```