### PR TITLE
fix: s3log crash if startTime not defined

### DIFF
--- a/s3log/file.go
+++ b/s3log/file.go
@@ -74,7 +74,10 @@ func (f *FileLogger) Log(ctx *fiber.Ctx, err error, body []byte, meta LogMeta) {
 	}
 	errorCode := ""
 	httpStatus := 200
-	startTime := ctx.Locals("startTime").(time.Time)
+	startTime, ok := ctx.Locals("startTime").(time.Time)
+	if !ok {
+		startTime = time.Now()
+	}
 	tlsConnState := ctx.Context().TLSConnectionState()
 	if tlsConnState != nil {
 		lf.CipherSuite = tls.CipherSuiteName(tlsConnState.CipherSuite)


### PR DESCRIPTION
Following stack shows a crash trying to convert nil interface to time.Time:

initializing S3 access logs with '/log/access.log' file caught signal hangup
caught signal hangup
panic: interface conversion: interface {} is nil, not time.Time

goroutine 17641 [running]:
github.com/versity/versitygw/s3log.(*FileLogger).Log(0xc0001c03c0, 0xc0014a4308, {0x1828a80, 0xc0002f2000}, {0x0?, 0x0, 0x1f80004?}, {{0x0, 0x0}, 0x0, ...})
        /app/s3log/file.go:77 +0x9ae
github.com/versity/versitygw/s3api/controllers.SendResponse(0xc0014a4308, {0x1828a80, 0xc0002f2000}, 0xc005e1dad8)
        /app/s3api/controllers/base.go:3865 +0xe6
github.com/versity/versitygw/s3api.New.DecodeURL.func2(0xc0014a4308)
        /app/s3api/middlewares/url-decoder.go:31 +0x130
github.com/gofiber/fiber/v2.(*App).next(0xc0003def08, 0xc0014a4308)
        /go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.8/router.go:143 +0x1a7
github.com/gofiber/fiber/v2.(*App).handler(0xc0003def08, 0x4d2673?)
        /go/pkg/mod/github.com/gofiber/fiber/v2@v2.52.8/router.go:170 +0x69
github.com/valyala/fasthttp.(*Server).serveConn(0xc00015ab48, {0x1840bf0, 0xc001586000})
        /go/pkg/mod/github.com/valyala/fasthttp@v1.62.0/server.go:2455 +0x11cf
github.com/valyala/fasthttp.(*workerPool).workerFunc(0xc0001ba3f0, 0xc001a06000)
        /go/pkg/mod/github.com/valyala/fasthttp@v1.62.0/workerpool.go:225 +0x92
github.com/valyala/fasthttp.(*workerPool).getCh.func1()
        /go/pkg/mod/github.com/valyala/fasthttp@v1.62.0/workerpool.go:197 +0x32
created by github.com/valyala/fasthttp.(*workerPool).getCh in goroutine 9
        /go/pkg/mod/github.com/valyala/fasthttp@v1.62.0/workerpool.go:196 +0x194

fix this by checking ctx.Locals("startTime").(time.Time) type assertion, and setting default start time to now if not set.

Fixes #1340