### PR TITLE
feat: add SECURITY.md to define GitHub security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in `versitygw`, we strongly encourage you to report it privately and responsibly.
+
+Please do **not** create public issues or pull requests that contain details about the vulnerability.
+
+Instead, report the issue using GitHub's private **Security Advisories** feature:
+
+- Go to [versitygw's Security Advisories page](https://github.com/versity/versitygw/security/advisories)
+- Click on **"Report a vulnerability"**
+
+We aim to respond within **2 business days** and work with you to quickly resolve the issue.
+
+## Supported Versions
+
+| Version         | Supported |
+| --------------- | --------- |
+| Latest (v1.x.x) | ✅        |
+| Older versions  | ❌        |
+
+## Responsible Disclosure
+
+We appreciate responsible disclosures and are committed to fixing vulnerabilities in a timely manner. Thank you for helping keep `versitygw` secure.


### PR DESCRIPTION
Adds a `SECURITY.md` file under the `.github` directory, following [GitHub's guidelines](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository). This document instructs users on how to report security vulnerabilities, recommending the use of GitHub Security Advisories—a private and secure method for handling security issues in open source projects.

The file will appear in the [Security Policy section](https://github.com/versity/versitygw/security/policy) of the repository.