### PR TITLE
fix: always log internal server error messages to stderr

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -23,6 +23,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -3924,7 +3925,7 @@ func SendResponse(ctx *fiber.Ctx, err error, l *MetaOpts) error {
 			return ctx.Send(s3err.GetAPIErrorResponse(apierr, "", "", ""))
 		}
 
-		debuglogger.Logf("Internal Error, %v", err)
+		fmt.Fprintf(os.Stderr, "Internal Error, %v\n", err)
 		ctx.Status(http.StatusInternalServerError)
 		return ctx.Send(s3err.GetAPIErrorResponse(
 			s3err.GetAPIError(s3err.ErrInternalError), "", "", ""))
@@ -3978,7 +3979,7 @@ func SendXMLResponse(ctx *fiber.Ctx, resp any, err error, l *MetaOpts) error {
 			return ctx.Send(s3err.GetAPIErrorResponse(serr, "", "", ""))
 		}
 
-		debuglogger.Logf("Internal Error, %v", err)
+		fmt.Fprintf(os.Stderr, "Internal Error, %v\n", err)
 		ctx.Status(http.StatusInternalServerError)
 
 		return ctx.Send(s3err.GetAPIErrorResponse(


### PR DESCRIPTION
The debuglogger logs will only get printed if debug is enabled, but we always want the internal server error logs to be logged by the service since this is usually some actionable error that needs to be addressed with the backend storage system.

This changes internal server error logs to always to sent to stderr.