### PR TITLE
fix: fixes the invalid x-amz-mp-object-size header error in CompleteMultipartUpload.

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -283,14 +283,13 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 	var mpuObjectSize *int64
 	if mpuObjSizeHdr != "" {
 		val, err := strconv.ParseInt(mpuObjSizeHdr, 10, 64)
-		//TODO: Not sure if invalid request should be returned
 		if err != nil {
 			debuglogger.Logf("invalid value for 'x-amz-mp-objects-size' header: %v", err)
 			return &Response{
 				MetaOpts: &MetaOptions{
 					BucketOwner: parsedAcl.Owner,
 				},
-			}, s3err.GetAPIError(s3err.ErrInvalidRequest)
+			}, s3err.GetInvalidMpObjectSizeErr(mpuObjSizeHdr)
 		}
 
 		if val < 0 {
@@ -299,7 +298,7 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 				MetaOpts: &MetaOptions{
 					BucketOwner: parsedAcl.Owner,
 				},
-			}, s3err.GetInvalidMpObjectSizeErr(val)
+			}, s3err.GetNegatvieMpObjectSizeErr(val)
 		}
 
 		mpuObjectSize = &val

--- a/s3api/controllers/object-post_test.go
+++ b/s3api/controllers/object-post_test.go
@@ -420,7 +420,7 @@ func TestS3ApiController_CompleteMultipartUpload(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidRequest),
+				err: s3err.GetInvalidMpObjectSizeErr("invalid_mp_object_size"),
 			},
 		},
 		{
@@ -438,7 +438,7 @@ func TestS3ApiController_CompleteMultipartUpload(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetInvalidMpObjectSizeErr(-4),
+				err: s3err.GetNegatvieMpObjectSizeErr(-4),
 			},
 		},
 		{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -894,10 +894,18 @@ func GetIncorrectMpObjectSizeErr(expected, actual int64) APIError {
 	}
 }
 
-func GetInvalidMpObjectSizeErr(val int64) APIError {
+func GetNegatvieMpObjectSizeErr(val int64) APIError {
 	return APIError{
 		Code:           "InvalidRequest",
 		Description:    fmt.Sprintf("Value for x-amz-mp-object-size header is less than zero: '%v'", val),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+func GetInvalidMpObjectSizeErr(val string) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf("Value for x-amz-mp-object-size header is invalid: '%s'", val),
 		HTTPStatusCode: http.StatusBadRequest,
 	}
 }

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -11260,7 +11260,7 @@ func CompleteMultipartUpload_mpu_object_size(s *S3Conf) error {
 		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 		_, err = s3client.CompleteMultipartUpload(ctx, input)
 		cancel()
-		if err := checkApiErr(err, s3err.GetInvalidMpObjectSizeErr(invMpuSize)); err != nil {
+		if err := checkApiErr(err, s3err.GetNegatvieMpObjectSizeErr(invMpuSize)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Fixes #1398

The `x-amz-mp-object-size` request header can have two erroneous states: an invalid value or a negative integer. AWS returns different error descriptions for each case. This PR fixes the error description for the invalid header value case.

The invalid case can't be integration tested as SDK expects `int64` as the header value.