### PR TITLE
feat: adds copy source validation for x-amz-copy-source header.

### DIFF
--- a/auth/access-control.go
+++ b/auth/access-control.go
@@ -40,7 +40,7 @@ func VerifyObjectCopyAccess(ctx context.Context, be backend.Backend, copySource 
 	// Verify source bucket access
 	srcBucket, srcObject, found := strings.Cut(copySource, "/")
 	if !found {
-		return s3err.GetAPIError(s3err.ErrInvalidCopySource)
+		return s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket)
 	}
 
 	// Get source bucket ACL

--- a/backend/common.go
+++ b/backend/common.go
@@ -230,7 +230,7 @@ func ParseCopySource(copySourceHeader string) (string, string, string, error) {
 
 	srcBucket, srcObject, ok := strings.Cut(copySource, "/")
 	if !ok {
-		return "", "", "", s3err.GetAPIError(s3err.ErrInvalidCopySource)
+		return "", "", "", s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket)
 	}
 
 	return srcBucket, srcObject, versionId, nil

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -3871,7 +3871,7 @@ func (p *Posix) CopyObject(ctx context.Context, input s3response.CopyObjectInput
 		return s3response.CopyObjectOutput{}, s3err.GetAPIError(s3err.ErrInvalidCopyDest)
 	}
 	if input.CopySource == nil {
-		return s3response.CopyObjectOutput{}, s3err.GetAPIError(s3err.ErrInvalidCopySource)
+		return s3response.CopyObjectOutput{}, s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket)
 	}
 	if input.ExpectedBucketOwner == nil {
 		return s3response.CopyObjectOutput{}, s3err.GetAPIError(s3err.ErrInvalidRequest)

--- a/s3api/controllers/object-put_test.go
+++ b/s3api/controllers/object-put_test.go
@@ -585,6 +585,9 @@ func TestS3ApiController_UploadPartCopy(t *testing.T) {
 			name: "verify access fails",
 			input: testInput{
 				locals: accessDeniedLocals,
+				headers: map[string]string{
+					"X-Amz-Copy-Source": "bucket/key",
+				},
 			},
 			output: testOutput{
 				response: &Response{
@@ -612,7 +615,7 @@ func TestS3ApiController_UploadPartCopy(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidCopySource),
+				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceEncoding),
 			},
 		},
 		{
@@ -806,6 +809,9 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 			name: "verify access fails",
 			input: testInput{
 				locals: accessDeniedLocals,
+				headers: map[string]string{
+					"X-Amz-Copy-Source": "bucket/object",
+				},
 			},
 			output: testOutput{
 				response: &Response{
@@ -820,9 +826,6 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 			name: "invalid copy source",
 			input: testInput{
 				locals: defaultLocals,
-				headers: map[string]string{
-					"X-Amz-Copy-Source": "bad%G1",
-				},
 			},
 			output: testOutput{
 				response: &Response{
@@ -830,7 +833,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidCopySource),
+				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket),
 			},
 		},
 		{
@@ -848,7 +851,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidCopySource),
+				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket),
 			},
 		},
 		{
@@ -866,7 +869,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidCopySource),
+				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket),
 			},
 		},
 		{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -87,8 +87,10 @@ const (
 	ErrInvalidCompleteMpPartNumber
 	ErrInternalError
 	ErrInvalidCopyDest
-	ErrInvalidCopySource
 	ErrInvalidCopySourceRange
+	ErrInvalidCopySourceBucket
+	ErrInvalidCopySourceObject
+	ErrInvalidCopySourceEncoding
 	ErrInvalidTagKey
 	ErrInvalidTagValue
 	ErrDuplicateTagKey
@@ -333,14 +335,24 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "This copy request is illegal because it is trying to copy an object to itself without changing the object's metadata, storage class, website redirect location or encryption attributes.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrInvalidCopySource: {
-		Code:           "InvalidArgument",
-		Description:    "Copy Source must mention the source bucket and key: sourcebucket/sourcekey.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
 	ErrInvalidCopySourceRange: {
 		Code:           "InvalidArgument",
 		Description:    "The x-amz-copy-source-range value must be of the form bytes=first-last where first and last are the zero-based offsets of the first and last bytes to copy",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCopySourceBucket: {
+		Code:           "InvalidArgument",
+		Description:    "Invalid copy source bucket name",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCopySourceObject: {
+		Code:           "InvalidArgument",
+		Description:    "Invalid copy source object key",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCopySourceEncoding: {
+		Code:           "InvalidArgument",
+		Description:    "Invalid copy source encoding",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidTagKey: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -278,7 +278,8 @@ func TestCopyObject(s *S3Conf) {
 	CopyObject_should_copy_tagging(s)
 	CopyObject_invalid_tagging_directive(s)
 	CopyObject_to_itself_with_new_metadata(s)
-	CopyObject_CopySource_starting_with_slash(s)
+	CopyObject_copy_source_starting_with_slash(s)
+	CopyObject_invalid_copy_source(s)
 	CopyObject_non_existing_dir_object(s)
 	CopyObject_should_copy_meta_props(s)
 	CopyObject_should_replace_meta_props(s)
@@ -1062,7 +1063,8 @@ func GetIntTests() IntTests {
 		"CopyObject_should_copy_tagging":                                          CopyObject_should_copy_tagging,
 		"CopyObject_invalid_tagging_directive":                                    CopyObject_invalid_tagging_directive,
 		"CopyObject_to_itself_with_new_metadata":                                  CopyObject_to_itself_with_new_metadata,
-		"CopyObject_CopySource_starting_with_slash":                               CopyObject_CopySource_starting_with_slash,
+		"CopyObject_copy_source_starting_with_slash":                              CopyObject_copy_source_starting_with_slash,
+		"CopyObject_invalid_copy_source":                                          CopyObject_invalid_copy_source,
 		"CopyObject_non_existing_dir_object":                                      CopyObject_non_existing_dir_object,
 		"CopyObject_should_copy_meta_props":                                       CopyObject_should_copy_meta_props,
 		"CopyObject_should_replace_meta_props":                                    CopyObject_should_replace_meta_props,


### PR DESCRIPTION
Fixes #1388
Fixes #1389
Fixes #1390
Fixes #1401

Adds the `x-amz-copy-source` header validation for `CopyObject` and `UploadPartCopy` in front-end. The error:
```
	ErrInvalidCopySource: {
		Code:           "InvalidArgument",
		Description:    "Copy Source must mention the source bucket and key: sourcebucket/sourcekey.",
		HTTPStatusCode: http.StatusBadRequest,
	},
```
is now deprecated.

The conditional read/write headers validation in `CopyObject` should come with #821 and #822.