### PR TITLE
fix: fixes the HeadObject version access control with policies.

### DIFF
--- a/s3api/controllers/object-get.go
+++ b/s3api/controllers/object-get.go
@@ -388,7 +388,7 @@ func (c S3ApiController) GetObject(ctx *fiber.Ctx) (*Response, error) {
 	utils.ContextKeySkipResBodyLog.Set(ctx, true)
 
 	action := auth.GetObjectAction
-	if versionId != "" {
+	if ctx.Request().URI().QueryArgs().Has("versionId") {
 		action = auth.GetObjectVersionAction
 	}
 

--- a/s3api/controllers/object-head.go
+++ b/s3api/controllers/object-head.go
@@ -41,6 +41,11 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) (*Response, error) {
 	objRange := ctx.Get("Range")
 	key := strings.TrimPrefix(ctx.Path(), fmt.Sprintf("/%s/", bucket))
 
+	action := auth.GetObjectAction
+	if ctx.Request().URI().QueryArgs().Has("versionId") {
+		action = auth.GetObjectVersionAction
+	}
+
 	err := auth.VerifyAccess(ctx.Context(), c.be,
 		auth.AccessOptions{
 			Readonly:       c.readonly,
@@ -50,7 +55,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) (*Response, error) {
 			Acc:            acct,
 			Bucket:         bucket,
 			Object:         key,
-			Action:         auth.GetObjectAction,
+			Action:         action,
 			IsBucketPublic: isPublicBucket,
 		})
 	if err != nil {

--- a/s3api/controllers/object-head_test.go
+++ b/s3api/controllers/object-head_test.go
@@ -57,6 +57,7 @@ func TestS3ApiController_HeadObject(t *testing.T) {
 				locals: defaultLocals,
 				queries: map[string]string{
 					"partNumber": "-4",
+					"versionId":  "id",
 				},
 			},
 			output: testOutput{

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -869,6 +869,8 @@ func TestVersioning(s *S3Conf) {
 	Versioning_WORM_obj_version_locked_with_compliance_retention(s)
 	// Concurrent requests
 	//Versioninig_concurrent_upload_object(s)
+	Versioning_AccessControl_GetObjectVersion(s)
+	Versioning_AccessControl_HeadObjectVersion(s)
 }
 
 func TestVersioningDisabled(s *S3Conf) {
@@ -1366,6 +1368,8 @@ func GetIntTests() IntTests {
 		"Versioning_WORM_obj_version_locked_with_legal_hold":                      Versioning_WORM_obj_version_locked_with_legal_hold,
 		"Versioning_WORM_obj_version_locked_with_governance_retention":            Versioning_WORM_obj_version_locked_with_governance_retention,
 		"Versioning_WORM_obj_version_locked_with_compliance_retention":            Versioning_WORM_obj_version_locked_with_compliance_retention,
+		"Versioning_AccessControl_GetObjectVersion":                               Versioning_AccessControl_GetObjectVersion,
+		"Versioning_AccessControl_HeadObjectVersion":                              Versioning_AccessControl_HeadObjectVersion,
 		"Versioning_concurrent_upload_object":                                     Versioning_concurrent_upload_object,
 		"RouterPutPartNumberWithoutUploadId":                                      RouterPutPartNumberWithoutUploadId,
 		"RouterPostRoot":                                                          RouterPostRoot,

--- a/tests/integration/s3conf.go
+++ b/tests/integration/s3conf.go
@@ -145,6 +145,14 @@ func (c *S3Conf) GetAnonymousClient() *s3.Client {
 	})
 }
 
+func (cfg *S3Conf) getUserClient(usr user) *s3.Client {
+	config := *cfg
+	config.awsID = usr.access
+	config.awsSecret = usr.secret
+
+	return config.GetClient()
+}
+
 func (c *S3Conf) Config() aws.Config {
 	creds := c.getCreds()
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -53,6 +53,35 @@ var (
 	adminErrorPrefix = "XAdmin"
 )
 
+type user struct {
+	access string
+	secret string
+	role   string
+}
+
+var (
+	testuser1 user = user{
+		access: "grt1",
+		secret: "grt1secret",
+		role:   "user",
+	}
+	testuser2 user = user{
+		access: "grt2",
+		secret: "grt2secret",
+		role:   "user",
+	}
+	testuserplus user = user{
+		access: "grtplus",
+		secret: "grt1plussecret",
+		role:   "userplus",
+	}
+	testadmin user = user{
+		access: "admin",
+		secret: "adminsecret",
+		role:   "admin",
+	}
+)
+
 func getBucketName() string {
 	bcktCount++
 	return fmt.Sprintf("test-bucket-%v", bcktCount)
@@ -899,12 +928,6 @@ func uploadParts(client *s3.Client, size, partCount int64, bucket, key, uploadId
 	return parts, csum, err
 }
 
-type user struct {
-	access string
-	secret string
-	role   string
-}
-
 func createUsers(s *S3Conf, users []user) error {
 	for _, usr := range users {
 		err := deleteUser(s, usr.access)
@@ -1063,14 +1086,6 @@ func getMalformedPolicyError(msg string) s3err.APIError {
 		Description:    msg,
 		HTTPStatusCode: http.StatusBadRequest,
 	}
-}
-
-func getUserS3Client(usr user, cfg *S3Conf) *s3.Client {
-	config := *cfg
-	config.awsID = usr.access
-	config.awsSecret = usr.secret
-
-	return config.GetClient()
 }
 
 // if true enables, otherwise disables


### PR DESCRIPTION
Fixes #1385

When accessing a specific object version, the user must have the `s3:GetObjectVersion` permission in the bucket policy. The `s3:GetObject` permission alone is not sufficient for a regular user to query object versions using `HeadObject`.

This PR fixes the issue and adds integration tests for both `HeadObject` and `GetObject`. It also includes cleanup in the integration tests by refactoring the creation of user S3 clients, and moves some test user data to the package level to avoid repetition across tests.