### PR TITLE
fix: fixes the InvalidBucketAclWithObjectOwnership error code.

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -646,8 +646,8 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrInvalidBucketAclWithObjectOwnership: {
-		Code:           "ErrInvalidBucketAclWithObjectOwnership",
-		Description:    "Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting.",
+		Code:           "InvalidBucketAclWithObjectOwnership",
+		Description:    "Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrBothCannedAndHeaderGrants: {


### PR DESCRIPTION
Fixes #1387

The `Code` for `ErrInvalidBucketAclWithObjectOwnership` error should be `InvalidBucketAclWithObjectOwnership` instead of `ErrInvalidBucketAclWithObjectOwnership`. The PR fixes the typo in the error code.