### PR TITLE
fix: fixes the invalid part number marker error description in ListParts

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -277,7 +277,7 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	},
 	ErrInvalidPartNumberMarker: {
 		Code:           "InvalidArgument",
-		Description:    "Argument partNumberMarker must be an integer.",
+		Description:    "Argument part-number-marker must be an integer between 0 and 2147483647",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidObjectAttributes: {


### PR DESCRIPTION
Fixes #1383

Fixes the invalid part number marker error description in ListParts. The description should be: `Argument part-number-marker must be an integer between 0 and 2147483647`.