### PR TITLE
fix: adds bucket region in ListBuckets result

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -51,6 +51,8 @@ const (
 	minPartNumber     = 1
 	maxPartNumber     = 10000
 	defaultMaxBuckets = int32(10000)
+
+	defaultRegion = "us-east-1"
 )
 
 var (

--- a/s3api/controllers/bucket-list_test.go
+++ b/s3api/controllers/bucket-list_test.go
@@ -58,15 +58,12 @@ func TestS3ApiController_ListBuckets(t *testing.T) {
 			name: "backend returns error",
 			input: testInput{
 				locals: defaultLocals,
-				beRes:  validRes,
 				beErr:  s3err.GetAPIError(s3err.ErrNoSuchBucket),
+				beRes:  s3response.ListAllMyBucketsResult{},
 			},
 			output: testOutput{
-				response: &Response{
-					Data:     validRes,
-					MetaOpts: &MetaOptions{},
-				},
-				err: s3err.GetAPIError(s3err.ErrNoSuchBucket),
+				response: &Response{},
+				err:      s3err.GetAPIError(s3err.ErrNoSuchBucket),
 			},
 		},
 		{
@@ -80,8 +77,7 @@ func TestS3ApiController_ListBuckets(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
-					Data:     validRes,
-					MetaOpts: &MetaOptions{},
+					Data: validRes,
 				},
 			},
 		},

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -317,6 +317,7 @@ type ListAllMyBucketsResult struct {
 
 type ListAllMyBucketsEntry struct {
 	Name         string
+	BucketRegion string
 	CreationDate time.Time
 }
 

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -1701,7 +1701,7 @@ func HeadBucket_success(s *S3Conf) error {
 func ListBuckets_as_user(s *S3Conf) error {
 	testName := "ListBuckets_as_user"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
-		buckets := []types.Bucket{{Name: &bucket}}
+		buckets := []types.Bucket{{Name: &bucket, BucketRegion: &s.awsRegion}}
 		for range 6 {
 			bckt := getBucketName()
 
@@ -1711,7 +1711,8 @@ func ListBuckets_as_user(s *S3Conf) error {
 			}
 
 			buckets = append(buckets, types.Bucket{
-				Name: &bckt,
+				Name:         &bckt,
+				BucketRegion: &s.awsRegion,
 			})
 		}
 
@@ -1762,7 +1763,7 @@ func ListBuckets_as_user(s *S3Conf) error {
 func ListBuckets_as_admin(s *S3Conf) error {
 	testName := "ListBuckets_as_admin"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
-		buckets := []types.Bucket{{Name: &bucket}}
+		buckets := []types.Bucket{{Name: &bucket, BucketRegion: &s.awsRegion}}
 		for range 6 {
 			bckt := getBucketName()
 
@@ -1772,7 +1773,8 @@ func ListBuckets_as_admin(s *S3Conf) error {
 			}
 
 			buckets = append(buckets, types.Bucket{
-				Name: &bckt,
+				Name:         &bckt,
+				BucketRegion: &s.awsRegion,
 			})
 		}
 
@@ -1824,7 +1826,7 @@ func ListBuckets_with_prefix(s *S3Conf) error {
 	testName := "ListBuckets_with_prefix"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
 		prefix := "my-prefix-"
-		allBuckets, prefixedBuckets := []types.Bucket{{Name: &bucket}}, []types.Bucket{}
+		allBuckets, prefixedBuckets := []types.Bucket{{Name: &bucket, BucketRegion: &s.awsRegion}}, []types.Bucket{}
 		for i := range 5 {
 			bckt := getBucketName()
 			if i%2 == 0 {
@@ -1837,12 +1839,14 @@ func ListBuckets_with_prefix(s *S3Conf) error {
 			}
 
 			allBuckets = append(allBuckets, types.Bucket{
-				Name: &bckt,
+				Name:         &bckt,
+				BucketRegion: &s.awsRegion,
 			})
 
 			if i%2 == 0 {
 				prefixedBuckets = append(prefixedBuckets, types.Bucket{
-					Name: &bckt,
+					Name:         &bckt,
+					BucketRegion: &s.awsRegion,
 				})
 			}
 		}
@@ -1911,7 +1915,7 @@ func ListBuckets_invalid_max_buckets(s *S3Conf) error {
 func ListBuckets_truncated(s *S3Conf) error {
 	testName := "ListBuckets_truncated"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
-		buckets := []types.Bucket{{Name: &bucket}}
+		buckets := []types.Bucket{{Name: &bucket, BucketRegion: &s.awsRegion}}
 		for range 5 {
 			bckt := getBucketName()
 
@@ -1921,7 +1925,8 @@ func ListBuckets_truncated(s *S3Conf) error {
 			}
 
 			buckets = append(buckets, types.Bucket{
-				Name: &bckt,
+				Name:         &bckt,
+				BucketRegion: &s.awsRegion,
 			})
 		}
 
@@ -2002,7 +2007,7 @@ func ListBuckets_empty_success(s *S3Conf) error {
 func ListBuckets_success(s *S3Conf) error {
 	testName := "ListBuckets_success"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
-		buckets := []types.Bucket{{Name: &bucket}}
+		buckets := []types.Bucket{{Name: &bucket, BucketRegion: &s.awsRegion}}
 		for range 5 {
 			bckt := getBucketName()
 
@@ -2012,7 +2017,8 @@ func ListBuckets_success(s *S3Conf) error {
 			}
 
 			buckets = append(buckets, types.Bucket{
-				Name: &bckt,
+				Name:         &bckt,
+				BucketRegion: &s.awsRegion,
 			})
 		}
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -728,6 +728,11 @@ func compareBuckets(list1 []types.Bucket, list2 []types.Bucket) bool {
 
 	for i, elem := range list1 {
 		if *elem.Name != *list2[i].Name {
+			fmt.Printf("bucket names are not equal: %s != %s\n", *elem.Name, *list2[i].Name)
+			return false
+		}
+		if *elem.BucketRegion != *list2[i].BucketRegion {
+			fmt.Printf("bucket regions are not equal: %s != %s\n", *elem.BucketRegion, *list2[i].BucketRegion)
 			return false
 		}
 	}


### PR DESCRIPTION
Fixes #1374

Hardcodes the gateway region for each bucket entry in `ListBuckets` result as bucket region.