### PR TITLE
fix: makes checksum type and algorithm case insensitive in CreateMultipartUpload

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -217,6 +217,7 @@ func (c S3ApiController) CreateMultipartUpload(ctx *fiber.Ctx) (*Response, error
 	if err == nil {
 		headers = map[string]*string{
 			"x-amz-checksum-algorithm": utils.ConvertToStringPtr(checksumAlgorithm),
+			"x-amz-checksum-type":      utils.ConvertToStringPtr(checksumType),
 		}
 	}
 	return &Response{
@@ -233,7 +234,7 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 	key := strings.TrimPrefix(ctx.Path(), fmt.Sprintf("/%s/", bucket))
 	uploadId := ctx.Query("uploadId")
 	mpuObjSizeHdr := ctx.Get("X-Amz-Mp-Object-Size")
-	checksumType := types.ChecksumType(ctx.Get("x-amz-checksum-type"))
+	checksumType := types.ChecksumType(strings.ToUpper(ctx.Get("x-amz-checksum-type")))
 	// context locals
 	acct := utils.ContextKeyAccount.Get(ctx).(auth.Account)
 	isRoot := utils.ContextKeyIsRoot.Get(ctx).(bool)

--- a/s3api/controllers/object-post_test.go
+++ b/s3api/controllers/object-post_test.go
@@ -293,6 +293,7 @@ func TestS3ApiController_CreateMultipartUpload(t *testing.T) {
 				beRes:  s3response.InitiateMultipartUploadResult{},
 				headers: map[string]string{
 					"x-amz-checksum-algorithm": string(types.ChecksumAlgorithmCrc32),
+					"x-amz-checksum-type":      string(types.ChecksumTypeComposite),
 				},
 			},
 			output: testOutput{
@@ -300,6 +301,7 @@ func TestS3ApiController_CreateMultipartUpload(t *testing.T) {
 					Data: s3response.InitiateMultipartUploadResult{},
 					Headers: map[string]*string{
 						"x-amz-checksum-algorithm": utils.ConvertToStringPtr(types.ChecksumAlgorithmCrc32),
+						"x-amz-checksum-type":      utils.ConvertToStringPtr(types.ChecksumTypeComposite),
 					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",

--- a/s3api/utils/utils.go
+++ b/s3api/utils/utils.go
@@ -569,12 +569,12 @@ func checkChecksumTypeAndAlgo(algo types.ChecksumAlgorithm, t types.ChecksumType
 
 // Parses and validates the x-amz-checksum-algorithm and x-amz-checksum-type headers
 func ParseCreateMpChecksumHeaders(ctx *fiber.Ctx) (types.ChecksumAlgorithm, types.ChecksumType, error) {
-	algo := types.ChecksumAlgorithm(ctx.Get("x-amz-checksum-algorithm"))
+	algo := types.ChecksumAlgorithm(strings.ToUpper(ctx.Get("x-amz-checksum-algorithm")))
 	if err := IsChecksumAlgorithmValid(algo); err != nil {
 		return "", "", err
 	}
 
-	chType := types.ChecksumType(ctx.Get("x-amz-checksum-type"))
+	chType := types.ChecksumType(strings.ToUpper(ctx.Get("x-amz-checksum-type")))
 	if err := IsChecksumTypeValid(chType); err != nil {
 		return "", "", err
 	}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -334,7 +334,7 @@ func TestCreateMultipartUpload(s *S3Conf) {
 		CreateMultipartUpload_invalid_checksum_algorithm(s)
 		CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type(s)
 		CreateMultipartUpload_invalid_checksum_type(s)
-		CreateMultipartUpload_valid_checksum_algorithm(s)
+		CreateMultipartUpload_valid_algo_type(s)
 	}
 	CreateMultipartUpload_success(s)
 }
@@ -723,7 +723,7 @@ func TestScoutfs(s *S3Conf) {
 	CreateMultipartUpload_invalid_checksum_algorithm(s)
 	CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type(s)
 	CreateMultipartUpload_invalid_checksum_type(s)
-	CreateMultipartUpload_valid_checksum_algorithm(s)
+	CreateMultipartUpload_valid_algo_type(s)
 	CreateMultipartUpload_success(s)
 
 	CompletedMultipartUpload_non_existing_bucket(s)
@@ -1104,7 +1104,7 @@ func GetIntTests() IntTests {
 		"CreateMultipartUpload_invalid_checksum_algorithm":                        CreateMultipartUpload_invalid_checksum_algorithm,
 		"CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type":       CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type,
 		"CreateMultipartUpload_invalid_checksum_type":                             CreateMultipartUpload_invalid_checksum_type,
-		"CreateMultipartUpload_valid_checksum_algorithm":                          CreateMultipartUpload_valid_checksum_algorithm,
+		"CreateMultipartUpload_valid_algo_type":                                   CreateMultipartUpload_valid_algo_type,
 		"CreateMultipartUpload_success":                                           CreateMultipartUpload_success,
 		"UploadPart_non_existing_bucket":                                          UploadPart_non_existing_bucket,
 		"UploadPart_invalid_part_number":                                          UploadPart_invalid_part_number,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -39,6 +39,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
@@ -1435,4 +1436,19 @@ type PublicBucketTestCase struct {
 	Action      string
 	Call        func(ctx context.Context) error
 	ExpectedErr error
+}
+
+// randomizeCase randomizes the provided string latters case
+func randomizeCase(s string) string {
+	var b strings.Builder
+
+	for _, ch := range s {
+		if rnd.Intn(2) == 0 {
+			b.WriteRune(unicode.ToLower(ch))
+		} else {
+			b.WriteRune(unicode.ToUpper(ch))
+		}
+	}
+
+	return b.String()
 }


### PR DESCRIPTION
Fixes #1339

`x-amz-checksum-type` and `x-amz-checksum-algorithm` request headers should be case insensitive in `CreateMultipartUpload`.

The changes include parsing the header values to upper case before validating and passing to back-end. `x-amz-checksum-type` response header was added in`CreateMultipartUpload`, which was missing before.