### PR TITLE
fix: ignores special checksum headers when parsing x-amz-checksum-x headers

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -305,7 +305,7 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 		mpuObjectSize = &val
 	}
 
-	_, checksums, err := utils.ParseChecksumHeaders(ctx)
+	checksums, err := utils.ParseChecksumHeaders(ctx)
 	if err != nil {
 		return &Response{
 			MetaOpts: &MetaOptions{

--- a/s3api/controllers/object-post_test.go
+++ b/s3api/controllers/object-post_test.go
@@ -449,7 +449,7 @@ func TestS3ApiController_CompleteMultipartUpload(t *testing.T) {
 				locals: defaultLocals,
 				body:   validMpBody,
 				headers: map[string]string{
-					"X-Amz-Sdk-Checksum-Algorithm": "invalid_checksum_algo",
+					"X-Amz-Checksum-Crc32": "invalid_checksum",
 				},
 			},
 			output: testOutput{
@@ -458,7 +458,7 @@ func TestS3ApiController_CompleteMultipartUpload(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidChecksumAlgorithm),
+				err: s3err.GetInvalidChecksumHeaderErr("x-amz-checksum-crc32"),
 			},
 		},
 		{

--- a/s3api/controllers/object-put.go
+++ b/s3api/controllers/object-put.go
@@ -251,7 +251,7 @@ func (c S3ApiController) UploadPart(ctx *fiber.Ctx) (*Response, error) {
 		}, s3err.GetAPIError(s3err.ErrInvalidRequest)
 	}
 
-	algorithm, checksums, err := utils.ParseChecksumHeaders(ctx)
+	algorithm, checksums, err := utils.ParseChecksumHeadersAndSdkAlgo(ctx)
 	if err != nil {
 		debuglogger.Logf("err parsing checksum headers: %v", err)
 		return &Response{
@@ -674,7 +674,7 @@ func (c S3ApiController) PutObject(ctx *fiber.Ctx) (*Response, error) {
 		}, err
 	}
 
-	algorithm, checksums, err := utils.ParseChecksumHeaders(ctx)
+	algorithm, checksums, err := utils.ParseChecksumHeadersAndSdkAlgo(ctx)
 	if err != nil {
 		return &Response{
 			MetaOpts: &MetaOptions{


### PR DESCRIPTION
Fixes #1345

The previous implementation incorrectly parsed the `x-amz-sdk-checksum-algorithm` header for the `CompleteMultipartUpload` operation, even though this header is not expected and should be ignored. It also mistakenly treated the `x-amz-checksum-algorithm` header as an invalid value for `x-amz-checksum-x`.

The updated implementation only parses the `x-amz-sdk-checksum-algorithm` header for `PutObject` and `UploadPart` operations. Additionally, `x-amz-checksum-algorithm` and `x-amz-checksum-type` headers are now correctly ignored when parsing the precalculated checksum headers (`x-amz-checksum-x`).