### PR TITLE
fix: fixes the nil body reader panic.

### DIFF
--- a/s3api/middlewares/body-reader.go
+++ b/s3api/middlewares/body-reader.go
@@ -15,6 +15,7 @@
 package middlewares
 
 import (
+	"bytes"
 	"io"
 
 	"github.com/gofiber/fiber/v2"
@@ -25,6 +26,11 @@ func wrapBodyReader(ctx *fiber.Ctx, wr func(io.Reader) io.Reader) {
 	r, ok := utils.ContextKeyBodyReader.Get(ctx).(io.Reader)
 	if !ok {
 		r = ctx.Request().BodyStream()
+		// Override the body reader with an empty reader to prevent panics
+		// in case of unexpected or malformed HTTP requests.
+		if r == nil {
+			r = bytes.NewBuffer([]byte{})
+		}
 	}
 
 	r = wr(r)


### PR DESCRIPTION
Fixes #1418

If neither the `Transfer-Encoding` nor the `Content-Length` headers are provided in chunked uploads, **fasthttp** assumes there is no request body and sets the request body reader to `nil`. This leads to a panic in the auth reader when it attempts to read the body.

The fix ensures that if the request body reader is `nil`, it is overridden with an `empty reader` to prevent panics.