### PR TITLE
fix: update marker/continuation token to be the azure next marker

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -236,7 +236,10 @@ func TestListObjects(s *S3Conf) {
 
 func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_start_after(s)
-	ListObjectsV2_both_start_after_and_continuation_token(s)
+	// posix continuation token not compatible with azure
+	if !s.azureTests {
+		ListObjectsV2_both_start_after_and_continuation_token(s)
+	}
 	ListObjectsV2_start_after_not_in_list(s)
 	ListObjectsV2_start_after_empty_result(s)
 	ListObjectsV2_both_delimiter_and_prefix(s)
@@ -246,6 +249,7 @@ func TestListObjectsV2(s *S3Conf) {
 	ListObjectsV2_exceeding_max_keys(s)
 	ListObjectsV2_list_all_objs(s)
 	ListObjectsV2_with_owner(s)
+	ListObjectsV2_non_truncated_common_prefixes(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		ListObjectsV2_with_checksum(s)
@@ -1146,6 +1150,7 @@ func GetIntTests() IntTests {
 		"ListObjects_nested_dir_file_objs":                                        ListObjects_nested_dir_file_objs,
 		"ListObjects_check_owner":                                                 ListObjects_check_owner,
 		"ListObjects_non_truncated_common_prefixes":                               ListObjects_non_truncated_common_prefixes,
+		"ListObjectsV2_non_truncated_common_prefixes":                             ListObjectsV2_non_truncated_common_prefixes,
 		"ListObjects_with_checksum":                                               ListObjects_with_checksum,
 		"ListObjectsV2_start_after":                                               ListObjectsV2_start_after,
 		"ListObjectsV2_both_start_after_and_continuation_token":                   ListObjectsV2_both_start_after_and_continuation_token,


### PR DESCRIPTION
This changes the marker/continuation token from the object name to the marker from the azure list objects pager. This is needed because passing the object name as the token to the azure next call causes the Azure API to throw 400 Bad Request with InvalidQueryParameterValue. So we have to use the azure marker for compatibility with the azure API pager.

Fixes #1457