### PR TITLE
feat: adds not implemented routes for bucket logging actions

### DIFF
--- a/auth/bucket_policy_actions.go
+++ b/auth/bucket_policy_actions.go
@@ -70,6 +70,8 @@ const (
 	GetInventoryConfigurationAction          Action = "s3:GetInventoryConfiguration"
 	PutLifecycleConfigurationAction          Action = "s3:PutLifecycleConfiguration"
 	GetLifecycleConfigurationAction          Action = "s3:GetLifecycleConfiguration"
+	PutBucketLoggingAction                   Action = "s3:PutBucketLogging"
+	GetBucketLoggingAction                   Action = "s3:GetBucketLogging"
 
 	AllActions Action = "s3:*"
 )

--- a/metrics/actions.go
+++ b/metrics/actions.go
@@ -93,6 +93,8 @@ var (
 	ActionPutBucketLifecycleConfiguration             = "s3_PutBucketLifecycleConfiguration"
 	ActionGetBucketLifecycleConfiguration             = "s3_GetBucketLifecycleConfiguration"
 	ActionDeleteBucketLifecycle                       = "s3_DeleteBucketLifecycle"
+	ActionPutBucketLogging                            = "s3_PutBucketLogging"
+	ActionGetBucketLogging                            = "s3_GetBucketLogging"
 
 	// Admin actions
 	ActionAdminCreateUser        = "admin_CreateUser"

--- a/s3api/router.go
+++ b/s3api/router.go
@@ -266,6 +266,20 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 		),
 	)
 	bucketRouter.Put("",
+		middlewares.MatchQueryArgs("logging"),
+		controllers.ProcessHandlers(
+			ctrl.HandleErrorRoute(s3err.GetAPIError(s3err.ErrNotImplemented)),
+			metrics.ActionPutBucketLogging,
+			services,
+			middlewares.BucketObjectNameValidator(),
+			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionPutBucketLogging, auth.PutBucketLoggingAction, auth.PermissionWrite),
+			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
+			middlewares.VerifyV4Signature(root, iam, region, debug),
+			middlewares.VerifyMD5Body(),
+			middlewares.ParseAcl(be),
+		),
+	)
+	bucketRouter.Put("",
 		controllers.ProcessHandlers(
 			ctrl.CreateBucket,
 			metrics.ActionCreateBucket,
@@ -651,6 +665,20 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 			services,
 			middlewares.BucketObjectNameValidator(),
 			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionGetBucketLifecycleConfiguration, auth.GetLifecycleConfigurationAction, auth.PermissionRead),
+			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
+			middlewares.VerifyV4Signature(root, iam, region, debug),
+			middlewares.VerifyMD5Body(),
+			middlewares.ParseAcl(be),
+		),
+	)
+	bucketRouter.Get("",
+		middlewares.MatchQueryArgs("logging"),
+		controllers.ProcessHandlers(
+			ctrl.HandleErrorRoute(s3err.GetAPIError(s3err.ErrNotImplemented)),
+			metrics.ActionGetBucketLogging,
+			services,
+			middlewares.BucketObjectNameValidator(),
+			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionGetBucketLogging, auth.GetBucketLoggingAction, auth.PermissionRead),
 			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
 			middlewares.VerifyV4Signature(root, iam, region, debug),
 			middlewares.VerifyMD5Body(),

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -607,6 +607,9 @@ func TestNotImplementedActions(s *S3Conf) {
 	PutBucketLifecycleConfiguration_not_implemented(s)
 	GetBucketLifecycleConfiguration_not_implemented(s)
 	DeleteBucketLifecycle_not_implemented(s)
+	// bucket logging actions
+	PutBucketLogging_not_implemented(s)
+	GetBucketLogging_not_implemented(s)
 }
 
 func TestWORMProtection(s *S3Conf) {
@@ -1332,6 +1335,8 @@ func GetIntTests() IntTests {
 		"PutBucketLifecycleConfiguration_not_implemented":                         PutBucketLifecycleConfiguration_not_implemented,
 		"GetBucketLifecycleConfiguration_not_implemented":                         GetBucketLifecycleConfiguration_not_implemented,
 		"DeleteBucketLifecycle_not_implemented":                                   DeleteBucketLifecycle_not_implemented,
+		"PutBucketLogging_not_implemented":                                        PutBucketLogging_not_implemented,
+		"GetBucketLogging_not_implemented":                                        GetBucketLogging_not_implemented,
 		"WORMProtection_bucket_object_lock_configuration_compliance_mode":         WORMProtection_bucket_object_lock_configuration_compliance_mode,
 		"WORMProtection_bucket_object_lock_configuration_governance_mode":         WORMProtection_bucket_object_lock_configuration_governance_mode,
 		"WORMProtection_bucket_object_lock_governance_bypass_delete":              WORMProtection_bucket_object_lock_governance_bypass_delete,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -14924,6 +14924,52 @@ func DeleteBucketLifecycle_not_implemented(s *S3Conf) error {
 	})
 }
 
+func PutBucketLogging_not_implemented(s *S3Conf) error {
+	testName := "PutBucketLogging_not_implemented"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketLogging(ctx,
+			&s3.PutBucketLoggingInput{
+				Bucket: &bucket,
+				BucketLoggingStatus: &types.BucketLoggingStatus{
+					LoggingEnabled: &types.LoggingEnabled{
+						TargetBucket: &bucket,
+						TargetGrants: []types.TargetGrant{
+							{
+								Grantee: &types.Grantee{
+									Type: types.TypeCanonicalUser,
+									ID:   getPtr("grt1"),
+								},
+								Permission: types.BucketLogsPermissionRead,
+							},
+						},
+						TargetObjectKeyFormat: &types.TargetObjectKeyFormat{
+							SimplePrefix: &types.SimplePrefix{},
+						},
+						TargetPrefix: getPtr("prefix"),
+					},
+				},
+			})
+		cancel()
+
+		return checkApiErr(err, s3err.GetAPIError(s3err.ErrNotImplemented))
+	})
+}
+
+func GetBucketLogging_not_implemented(s *S3Conf) error {
+	testName := "GetBucketLogging_not_implemented"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.GetBucketLogging(ctx,
+			&s3.GetBucketLoggingInput{
+				Bucket: &bucket,
+			})
+		cancel()
+
+		return checkApiErr(err, s3err.GetAPIError(s3err.ErrNotImplemented))
+	})
+}
+
 func WORMProtection_bucket_object_lock_configuration_compliance_mode(s *S3Conf) error {
 	testName := "WORMProtection_bucket_object_lock_configuration_compliance_mode"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
Closes #1444

Adds `NotImplemented` routes for bucket logging S3 actions:
- `PutBucketLogging`
- `GetBucketLogging`