### PR TITLE
feat: adds not implemented routes for bucket accelerate configurationactions

### DIFF
--- a/auth/bucket_policy_actions.go
+++ b/auth/bucket_policy_actions.go
@@ -82,6 +82,8 @@ const (
 	GetBucketPublicAccessBlockAction         Action = "s3:GetBucketPublicAccessBlock"
 	PutBucketNotificationAction              Action = "s3:PutBucketNotification"
 	GetBucketNotificationAction              Action = "s3:GetBucketNotification"
+	PutAccelerateConfigurationAction         Action = "s3:PutAccelerateConfiguration"
+	GetAccelerateConfigurationAction         Action = "s3:GetAccelerateConfiguration"
 
 	AllActions Action = "s3:*"
 )
@@ -147,6 +149,8 @@ var supportedActionList = map[Action]struct{}{
 	GetBucketPublicAccessBlockAction:         {},
 	PutBucketNotificationAction:              {},
 	GetBucketNotificationAction:              {},
+	PutAccelerateConfigurationAction:         {},
+	GetAccelerateConfigurationAction:         {},
 	AllActions:                               {},
 }
 

--- a/metrics/actions.go
+++ b/metrics/actions.go
@@ -110,6 +110,8 @@ var (
 	ActionDeletePublicAccessBlock                     = "s3_DeletePublicAccessBlock"
 	ActionPutBucketNotificationConfiguration          = "s3_PutBucketNotificationConfiguration"
 	ActionGetBucketNotificationConfiguration          = "s3_GetBucketNotificationConfiguration"
+	ActionPutBucketAccelerateConfiguration            = "s3_PutBucketAccelerateConfiguration"
+	ActionGetBucketAccelerateConfiguration            = "s3_GetBucketAccelerateConfiguration"
 
 	// Admin actions
 	ActionAdminCreateUser        = "admin_CreateUser"
@@ -466,6 +468,14 @@ func init() {
 	}
 	ActionMap[ActionGetBucketNotificationConfiguration] = Action{
 		Name:    "GetBucketNotificationConfiguration",
+		Service: "s3",
+	}
+	ActionMap[ActionPutBucketAccelerateConfiguration] = Action{
+		Name:    "PutBucketAccelerateConfiguration",
+		Service: "s3",
+	}
+	ActionMap[ActionGetBucketAccelerateConfiguration] = Action{
+		Name:    "GetBucketAccelerateConfiguration",
 		Service: "s3",
 	}
 }

--- a/s3api/router.go
+++ b/s3api/router.go
@@ -357,6 +357,20 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 		),
 	)
 	bucketRouter.Put("",
+		middlewares.MatchQueryArgs("accelerate"),
+		controllers.ProcessHandlers(
+			ctrl.HandleErrorRoute(s3err.GetAPIError(s3err.ErrNotImplemented)),
+			metrics.ActionPutBucketAccelerateConfiguration,
+			services,
+			middlewares.BucketObjectNameValidator(),
+			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionPutBucketAccelerateConfiguration, auth.PutAccelerateConfigurationAction, auth.PermissionWrite),
+			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
+			middlewares.VerifyV4Signature(root, iam, region, debug),
+			middlewares.VerifyMD5Body(),
+			middlewares.ParseAcl(be),
+		),
+	)
+	bucketRouter.Put("",
 		controllers.ProcessHandlers(
 			ctrl.CreateBucket,
 			metrics.ActionCreateBucket,
@@ -899,6 +913,20 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 			services,
 			middlewares.BucketObjectNameValidator(),
 			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionGetBucketNotificationConfiguration, auth.GetBucketNotificationAction, auth.PermissionRead),
+			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
+			middlewares.VerifyV4Signature(root, iam, region, debug),
+			middlewares.VerifyMD5Body(),
+			middlewares.ParseAcl(be),
+		),
+	)
+	bucketRouter.Get("",
+		middlewares.MatchQueryArgs("accelerate"),
+		controllers.ProcessHandlers(
+			ctrl.HandleErrorRoute(s3err.GetAPIError(s3err.ErrNotImplemented)),
+			metrics.ActionGetBucketAccelerateConfiguration,
+			services,
+			middlewares.BucketObjectNameValidator(),
+			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionGetBucketAccelerateConfiguration, auth.GetAccelerateConfigurationAction, auth.PermissionRead),
 			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
 			middlewares.VerifyV4Signature(root, iam, region, debug),
 			middlewares.VerifyMD5Body(),

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -666,6 +666,9 @@ func TestNotImplementedActions(s *S3Conf) {
 	// bucket notification actions
 	PutBucketNotificationConfiguratio_not_implemented(s)
 	GetBucketNotificationConfiguratio_not_implemented(s)
+	// bucket acceleration actions
+	PutBucketAccelerateConfiguration_not_implemented(s)
+	GetBucketAccelerateConfiguration_not_implemented(s)
 }
 
 func TestWORMProtection(s *S3Conf) {
@@ -1433,6 +1436,8 @@ func GetIntTests() IntTests {
 		"DeletePublicAccessBlock_not_implemented":                                 DeletePublicAccessBlock_not_implemented,
 		"PutBucketNotificationConfiguratio_not_implemented":                       PutBucketNotificationConfiguratio_not_implemented,
 		"GetBucketNotificationConfiguratio_not_implemented":                       GetBucketNotificationConfiguratio_not_implemented,
+		"PutBucketAccelerateConfiguration_not_implemented":                        PutBucketAccelerateConfiguration_not_implemented,
+		"GetBucketAccelerateConfiguration_not_implemented":                        GetBucketAccelerateConfiguration_not_implemented,
 		"WORMProtection_bucket_object_lock_configuration_compliance_mode":         WORMProtection_bucket_object_lock_configuration_compliance_mode,
 		"WORMProtection_bucket_object_lock_configuration_governance_mode":         WORMProtection_bucket_object_lock_configuration_governance_mode,
 		"WORMProtection_bucket_object_lock_governance_bypass_delete":              WORMProtection_bucket_object_lock_governance_bypass_delete,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -15965,6 +15965,37 @@ func GetBucketNotificationConfiguratio_not_implemented(s *S3Conf) error {
 	})
 }
 
+func PutBucketAccelerateConfiguration_not_implemented(s *S3Conf) error {
+	testName := "PutBucketAccelerateConfiguration_not_implemented"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketAccelerateConfiguration(ctx,
+			&s3.PutBucketAccelerateConfigurationInput{
+				Bucket: &bucket,
+				AccelerateConfiguration: &types.AccelerateConfiguration{
+					Status: types.BucketAccelerateStatusEnabled,
+				},
+			})
+		cancel()
+
+		return checkApiErr(err, s3err.GetAPIError(s3err.ErrNotImplemented))
+	})
+}
+
+func GetBucketAccelerateConfiguration_not_implemented(s *S3Conf) error {
+	testName := "GetBucketAccelerateConfiguration_not_implemented"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.GetBucketAccelerateConfiguration(ctx,
+			&s3.GetBucketAccelerateConfigurationInput{
+				Bucket: &bucket,
+			})
+		cancel()
+
+		return checkApiErr(err, s3err.GetAPIError(s3err.ErrNotImplemented))
+	})
+}
+
 func WORMProtection_bucket_object_lock_configuration_compliance_mode(s *S3Conf) error {
 	testName := "WORMProtection_bucket_object_lock_configuration_compliance_mode"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
Closes #1452

Adds `NotImplemented` routes for bucket accelerate configuration S3 actions:
- `PutBucketAccelerateConfiguration`
- `GetBucketAccelerateConfiguration`