### PR TITLE
feat: implementes GetBucketPolicyStatus s3 action

### DIFF
--- a/auth/bucket_policy_actions.go
+++ b/auth/bucket_policy_actions.go
@@ -86,6 +86,7 @@ const (
 	GetAccelerateConfigurationAction         Action = "s3:GetAccelerateConfiguration"
 	PutBucketWebsiteAction                   Action = "s3:PutBucketWebsite"
 	GetBucketWebsiteAction                   Action = "s3:GetBucketWebsite"
+	GetBucketPolicyStatusAction              Action = "s3:GetBucketPolicyStatus"
 
 	AllActions Action = "s3:*"
 )
@@ -155,6 +156,7 @@ var supportedActionList = map[Action]struct{}{
 	GetAccelerateConfigurationAction:         {},
 	PutBucketWebsiteAction:                   {},
 	GetBucketWebsiteAction:                   {},
+	GetBucketPolicyStatusAction:              {},
 	AllActions:                               {},
 }
 

--- a/auth/bucket_policy_principals.go
+++ b/auth/bucket_policy_principals.go
@@ -124,7 +124,7 @@ func (p Principals) Contains(userAccess string) bool {
 
 // Bucket policy grants public access, if it contains
 // a wildcard match to all the users
-func (p Principals) IsPublic() bool {
+func (p Principals) isPublic() bool {
 	_, ok := p["*"]
 	return ok
 }

--- a/metrics/actions.go
+++ b/metrics/actions.go
@@ -115,6 +115,7 @@ var (
 	ActionPutBucketWebsite                            = "s3_PutBucketWebsite"
 	ActionGetBucketWebsite                            = "s3_GetBucketWebsite"
 	ActionDeleteBucketWebsite                         = "s3_DeleteBucketWebsite"
+	ActionGetBucketPolicyStatus                       = "s3_GetBucketPolicyStatus"
 
 	// Admin actions
 	ActionAdminCreateUser        = "admin_CreateUser"
@@ -491,6 +492,10 @@ func init() {
 	}
 	ActionMap[ActionDeleteBucketWebsite] = Action{
 		Name:    "DeleteBucketWebsite",
+		Service: "s3",
+	}
+	ActionMap[ActionGetBucketPolicyStatus] = Action{
+		Name:    "GetBucketPolicyStatus",
 		Service: "s3",
 	}
 }

--- a/s3api/router.go
+++ b/s3api/router.go
@@ -738,6 +738,20 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 			middlewares.ParseAcl(be),
 		))
 	bucketRouter.Get("",
+		middlewares.MatchQueryArgs("policyStatus"),
+		controllers.ProcessHandlers(
+			ctrl.GetBucketPolicyStatus,
+			metrics.ActionGetBucketPolicyStatus,
+			services,
+			middlewares.BucketObjectNameValidator(),
+			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionGetBucketPolicyStatus, auth.GetBucketPolicyStatusAction, auth.PermissionRead),
+			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
+			middlewares.VerifyV4Signature(root, iam, region, debug),
+			middlewares.VerifyMD5Body(),
+			middlewares.ApplyBucketCORS(be),
+			middlewares.ParseAcl(be),
+		))
+	bucketRouter.Get("",
 		middlewares.MatchQueryArgs("analytics", "id"),
 		controllers.ProcessHandlers(
 			ctrl.HandleErrorRoute(s3err.GetAPIError(s3err.ErrNotImplemented)),

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -520,6 +520,12 @@ func TestGetBucketPolicy(s *S3Conf) {
 	GetBucketPolicy_success(s)
 }
 
+func TestGetBucketPolicyStatus(s *S3Conf) {
+	GetBucketPolicyStatus_non_existing_bucket(s)
+	GetBucketPolicyStatus_no_such_bucket_policy(s)
+	GetBucketPolicyStatus_success(s)
+}
+
 func TestDeleteBucketPolicy(s *S3Conf) {
 	DeleteBucketPolicy_non_existing_bucket(s)
 	DeleteBucketPolicy_remove_before_setting(s)
@@ -1342,6 +1348,9 @@ func GetIntTests() IntTests {
 		"GetBucketPolicy_non_existing_bucket":                                     GetBucketPolicy_non_existing_bucket,
 		"GetBucketPolicy_not_set":                                                 GetBucketPolicy_not_set,
 		"GetBucketPolicy_success":                                                 GetBucketPolicy_success,
+		"GetBucketPolicyStatus_non_existing_bucket":                               GetBucketPolicyStatus_non_existing_bucket,
+		"GetBucketPolicyStatus_no_such_bucket_policy":                             GetBucketPolicyStatus_no_such_bucket_policy,
+		"GetBucketPolicyStatus_success":                                           GetBucketPolicyStatus_success,
 		"DeleteBucketPolicy_non_existing_bucket":                                  DeleteBucketPolicy_non_existing_bucket,
 		"DeleteBucketPolicy_remove_before_setting":                                DeleteBucketPolicy_remove_before_setting,
 		"DeleteBucketPolicy_success":                                              DeleteBucketPolicy_success,


### PR DESCRIPTION
Closes #1454

Adds the implementation of [S3 GetBucketPolicyStatus action](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketPolicyStatus.html). The implementation goes to front-end. Front-End loads the bucket policy and checks if it grants public access to all users.

A bucket policy document `is public` only when `Principal` contains `*`(all users): only when it grants access to `ALL` users.