### PR TITLE
feat: add versioning dir option to scoutfs backend

### DIFF
--- a/backend/scoutfs/scoutfs.go
+++ b/backend/scoutfs/scoutfs.go
@@ -35,12 +35,21 @@ import (
 	"github.com/versity/versitygw/s3response"
 )
 
+// ScoutfsOpts are the options for the ScoutFS backend
 type ScoutfsOpts struct {
-	ChownUID         bool
-	ChownGID         bool
-	GlacierMode      bool
-	BucketLinks      bool
-	NewDirPerm       fs.FileMode
+	// ChownUID sets the UID of the object to the UID of the user on PUT
+	ChownUID bool
+	// ChownGID sets the GID of the object to the GID of the user on PUT
+	ChownGID bool
+	// BucketLinks enables symlinks to directories to be treated as buckets
+	BucketLinks bool
+	//VersioningDir sets the version directory to enable object versioning
+	VersioningDir string
+	// NewDirPerm specifies the permission to set on newly created directories
+	NewDirPerm fs.FileMode
+	// GlacierMode enables glacier emulation for offline files
+	GlacierMode bool
+	// DisableNoArchive prevents setting noarchive on temporary files
 	DisableNoArchive bool
 }
 

--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -30,10 +30,11 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 	metastore := meta.XattrMeta{}
 
 	p, err := posix.New(rootdir, metastore, posix.PosixOpts{
-		ChownUID:    opts.ChownUID,
-		ChownGID:    opts.ChownGID,
-		BucketLinks: opts.BucketLinks,
-		NewDirPerm:  opts.NewDirPerm,
+		ChownUID:      opts.ChownUID,
+		ChownGID:      opts.ChownGID,
+		BucketLinks:   opts.BucketLinks,
+		NewDirPerm:    opts.NewDirPerm,
+		VersioningDir: opts.VersioningDir,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/versitygw/scoutfs.go
+++ b/cmd/versitygw/scoutfs.go
@@ -72,6 +72,12 @@ move interfaces as well as support for tiered filesystems.`,
 				EnvVars:     []string{"VGW_BUCKET_LINKS"},
 				Destination: &bucketlinks,
 			},
+			&cli.StringFlag{
+				Name:        "versioning-dir",
+				Usage:       "the directory path to enable bucket versioning",
+				EnvVars:     []string{"VGW_VERSIONING_DIR"},
+				Destination: &versioningDir,
+			},
 			&cli.UintFlag{
 				Name:        "dir-perms",
 				Usage:       "default directory permissions for new directories",
@@ -106,6 +112,7 @@ func runScoutfs(ctx *cli.Context) error {
 	opts.BucketLinks = bucketlinks
 	opts.NewDirPerm = fs.FileMode(dirPerms)
 	opts.DisableNoArchive = disableNoArchive
+	opts.VersioningDir = versioningDir
 
 	be, err := scoutfs.New(ctx.Args().Get(0), opts)
 	if err != nil {

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -443,6 +443,14 @@ ROOT_SECRET_ACCESS_KEY=
 # as any parent directories automatically created with object uploads.
 #VGW_DIR_PERMS=0755
 
+# To enable object versions, the VGW_VERSIONING_DIR option must be set to the
+# directory that will be used to store the object versions. The version
+# directory must NOT be a subdirectory of the VGW_BACKEND_ARG directory.
+# There may be implications for archive policy updates to include version
+# directory as well. It is recommended to discuss archive implications of
+# versioning with Versity support before enabling on an archiving filesystem.
+#VGW_VERSIONING_DIR=
+
 # The default behavior of the gateway is to automatically set the noarchive
 # flag on the multipart upload parts while the multipart upload is in progress.
 # This is to prevent the parts from being archived since they are temporary


### PR DESCRIPTION
This adds the same versioning dir option that is found in the posix backend to scoutfs backend. Functionality is the same.