### PR TITLE
fix: add keeplive option (CLI and env var)

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -54,6 +54,7 @@ var (
 	healthPath                               string
 	virtualDomain                            string
 	debug                                    bool
+	keepAlive                                bool
 	pprof                                    string
 	quiet                                    bool
 	readonly                                 bool
@@ -222,6 +223,12 @@ func initFlags() []cli.Flag {
 			Usage:       "enable pprof debug on specified port",
 			EnvVars:     []string{"VGW_PPROF"},
 			Destination: &pprof,
+		},
+		&cli.BoolFlag{
+			Name:        "keep-alive",
+			Usage:       "enable keep-alive connections (for finnicky clients)",
+			EnvVars:     []string{"VGW_KEEP_ALIVE"},
+			Destination: &keepAlive,
 		},
 		&cli.BoolFlag{
 			Name:        "quiet",
@@ -604,7 +611,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		AppName:               "versitygw",
 		ServerHeader:          "VERSITYGW",
 		StreamRequestBody:     true,
-		DisableKeepalive:      true,
+		DisableKeepalive:      !keepAlive,
 		Network:               fiber.NetworkTCP,
 		DisableStartupMessage: true,
 	})


### PR DESCRIPTION
This fix enables Versity Gateway to serve clients that use the AWS C++ SDK - without enabling keepalive in the fiber configuration, clients that use the AWS C++ SDK like Run:ai's model streamer [will wig out from all of the closed connections and fail to function](https://github.com/run-ai/runai-model-streamer/issues/55) when connecting to a Versity GW back end. 

This fix is intentionally side-effect free in that it retains the current default behavior, with the ability to override it via an env var or CLI arg. I can confirm that vLLM built with Run:ai can successfully stream model weights from a Versity GW with this fix in place and enabling keep-alive for connections.