### PR TITLE
fix: adds full wildcard and any character match for bucket policy actions

### DIFF
--- a/auth/bucket_policy.go
+++ b/auth/bucket_policy.go
@@ -257,3 +257,34 @@ func VerifyPublicBucketPolicy(policy []byte, bucket, object string, action Actio
 
 	return nil
 }
+
+// matchPattern checks if the input string matches the given pattern with wildcard(`*`) and any character(`?`).
+// - `?` matches exactly one occurrence of any character.
+// - `*` matches arbitrary many (including zero) occurrences of any character.
+func matchPattern(pattern, input string) bool {
+	pIdx, sIdx := 0, 0
+	starIdx, matchIdx := -1, 0
+
+	for sIdx < len(input) {
+		if pIdx < len(pattern) && (pattern[pIdx] == '?' || pattern[pIdx] == input[sIdx]) {
+			sIdx++
+			pIdx++
+		} else if pIdx < len(pattern) && pattern[pIdx] == '*' {
+			starIdx = pIdx
+			matchIdx = sIdx
+			pIdx++
+		} else if starIdx != -1 {
+			pIdx = starIdx + 1
+			matchIdx++
+			sIdx = matchIdx
+		} else {
+			return false
+		}
+	}
+
+	for pIdx < len(pattern) && pattern[pIdx] == '*' {
+		pIdx++
+	}
+
+	return pIdx == len(pattern)
+}

--- a/auth/bucket_policy_actions_test.go
+++ b/auth/bucket_policy_actions_test.go
@@ -1,0 +1,175 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAction_IsValid(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  Action
+		wantErr bool
+	}{
+		{"valid exact action", GetObjectAction, false},
+		{"valid all actions", AllActions, false},
+		{"invalid prefix", "invalid:Action", true},
+		{"unsupported action 1", "s3:Unsupported", true},
+		{"unsupported action 2", "s3:HeadObject", true},
+		{"valid wildcard match 1", "s3:Get*", false},
+		{"valid wildcard match 2", "s3:*Object*", false},
+		{"valid wildcard match 3", "s3:*Multipart*", false},
+		{"any char match 1", "s3:Get?bject", false},
+		{"any char match 2", "s3:Get??bject", true},
+		{"any char match 3", "s3:???", true},
+		{"mixed match 1", "s3:Get?*", false},
+		{"mixed match 2", "s3:*Object?????", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.action.IsValid()
+			if tt.wantErr {
+				assert.EqualValues(t, policyErrInvalidAction, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAction_String(t *testing.T) {
+	a := Action("s3:TestAction")
+	assert.Equal(t, "s3:TestAction", a.String())
+}
+
+func TestAction_Match(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  Action
+		pattern Action
+		want    bool
+	}{
+		{"exact match", "s3:GetObject", "s3:GetObject", true},
+		{"wildcard match", "s3:GetObject", "s3:Get*", true},
+		{"wildcard mismatch", "s3:PutObject", "s3:Get*", false},
+		{"any character match", "s3:Get1", "s3:Get?", true},
+		{"any character mismatch", "s3:Get12", "s3:Get?", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.action.Match(tt.pattern)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestAction_IsObjectAction(t *testing.T) {
+	tests := []struct {
+		name   string
+		action Action
+		want   *bool
+	}{
+		{"all actions", AllActions, nil},
+		{"object action exact", GetObjectAction, getBoolPtr(true)},
+		{"object action wildcard", "s3:Get*", getBoolPtr(true)},
+		{"non object action", GetBucketAclAction, getBoolPtr(false)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.action.IsObjectAction()
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.NotNil(t, got)
+				assert.Equal(t, *tt.want, *got)
+			}
+		})
+	}
+}
+
+func TestActions_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"valid slice", `["s3:GetObject","s3:PutObject"]`, false},
+		{"empty slice", `[]`, true},
+		{"invalid action in slice", `["s3:Invalid"]`, true},
+		{"valid string", `"s3:GetObject"`, false},
+		{"empty string", `""`, true},
+		{"invalid string", `"s3:Invalid"`, true},
+		{"invalid json", `{}`, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a Actions
+			err := json.Unmarshal([]byte(tt.input), &a)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestActions_Add(t *testing.T) {
+	tests := []struct {
+		name    string
+		action  string
+		wantErr bool
+	}{
+		{"valid add", "s3:GetObject", false},
+		{"invalid add", "s3:InvalidAction", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := make(Actions)
+			err := a.Add(tt.action)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				_, ok := a[Action(tt.action)]
+				assert.True(t, ok)
+			}
+		})
+	}
+}
+
+func TestActions_FindMatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		actions Actions
+		check   Action
+		want    bool
+	}{
+		{"all actions present", Actions{AllActions: {}}, GetObjectAction, true},
+		{"exact match", Actions{GetObjectAction: {}}, GetObjectAction, true},
+		{"wildcard match", Actions{"s3:Get*": {}}, GetObjectAction, true},
+		{"no match", Actions{"s3:Put*": {}}, GetObjectAction, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.actions.FindMatch(tt.check)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/auth/bucket_policy_effect_test.go
+++ b/auth/bucket_policy_effect_test.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBucketPolicyAccessType_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   BucketPolicyAccessType
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "valid allow",
+			input:   BucketPolicyAccessTypeAllow,
+			wantErr: false,
+		},
+		{
+			name:    "valid deny",
+			input:   BucketPolicyAccessTypeDeny,
+			wantErr: false,
+		},
+		{
+			name:    "invalid type",
+			input:   BucketPolicyAccessType("InvalidValue"),
+			wantErr: true,
+			errMsg:  "Invalid effect: InvalidValue",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.input.Validate()
+			if tt.wantErr {
+				assert.EqualError(t, err, tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/auth/bucket_policy_principals_test.go
+++ b/auth/bucket_policy_principals_test.go
@@ -1,0 +1,106 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPrincipals_Add(t *testing.T) {
+	p := make(Principals)
+	p.Add("user1")
+	_, ok := p["user1"]
+	assert.True(t, ok)
+}
+
+func TestPrincipals_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Principals
+		wantErr bool
+	}{
+		{"valid slice", `["user1","user2"]`, Principals{"user1": {}, "user2": {}}, false},
+		{"empty slice", `[]`, nil, true},
+		{"valid string", `"user1"`, Principals{"user1": {}}, false},
+		{"empty string", `""`, nil, true},
+		{"valid AWS object", `{"AWS":"user1"}`, Principals{"user1": {}}, false},
+		{"empty AWS object", `{"AWS":""}`, nil, true},
+		{"valid AWS array", `{"AWS":["user1","user2"]}`, Principals{"user1": {}, "user2": {}}, false},
+		{"empty AWS array", `{"AWS":[]}`, nil, true},
+		{"invalid json", `{invalid}`, nil, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var p Principals
+			err := json.Unmarshal([]byte(tt.input), &p)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, p)
+			}
+		})
+	}
+}
+
+func TestPrincipals_ToSlice(t *testing.T) {
+	p := Principals{"user1": {}, "user2": {}, "*": {}}
+	got := p.ToSlice()
+	assert.Contains(t, got, "user1")
+	assert.Contains(t, got, "user2")
+	assert.NotContains(t, got, "*")
+}
+
+func TestPrincipals_Validate(t *testing.T) {
+	iamSingle := NewIAMServiceSingle(Account{
+		Access: "user1",
+	})
+	tests := []struct {
+		name       string
+		principals Principals
+		mockIAM    IAMService
+		err        error
+	}{
+		{"only wildcard", Principals{"*": {}}, iamSingle, nil},
+		{"wildcard and user", Principals{"*": {}, "user1": {}}, iamSingle, policyErrInvalidPrincipal},
+		{"accounts exist returns err", Principals{"user2": {}, "user3": {}}, iamSingle, policyErrInvalidPrincipal},
+		{"accounts exist non-empty", Principals{"user1": {}}, iamSingle, nil},
+		{"accounts valid", Principals{"user1": {}}, iamSingle, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.principals.Validate(tt.mockIAM)
+			assert.EqualValues(t, tt.err, err)
+		})
+	}
+}
+
+func TestPrincipals_Contains(t *testing.T) {
+	p := Principals{"user1": {}}
+	assert.True(t, p.Contains("user1"))
+	assert.False(t, p.Contains("user2"))
+
+	p = Principals{"*": {}}
+	assert.True(t, p.Contains("anyuser"))
+}
+
+func TestPrincipals_isPublic(t *testing.T) {
+	assert.True(t, Principals{"*": {}}.isPublic())
+	assert.False(t, Principals{"user1": {}}.isPublic())
+}

--- a/auth/bucket_policy_resources.go
+++ b/auth/bucket_policy_resources.go
@@ -110,35 +110,9 @@ func (r Resources) FindMatch(resource string) bool {
 	return false
 }
 
-// Match checks if the input string matches the given pattern with wildcards (`*`, `?`).
-// - `?` matches exactly one occurrence of any character.
-// - `*` matches arbitrary many (including zero) occurrences of any character.
+// Match matches the given input resource with the pattern
 func (r Resources) Match(pattern, input string) bool {
-	pIdx, sIdx := 0, 0
-	starIdx, matchIdx := -1, 0
-
-	for sIdx < len(input) {
-		if pIdx < len(pattern) && (pattern[pIdx] == '?' || pattern[pIdx] == input[sIdx]) {
-			sIdx++
-			pIdx++
-		} else if pIdx < len(pattern) && pattern[pIdx] == '*' {
-			starIdx = pIdx
-			matchIdx = sIdx
-			pIdx++
-		} else if starIdx != -1 {
-			pIdx = starIdx + 1
-			matchIdx++
-			sIdx = matchIdx
-		} else {
-			return false
-		}
-	}
-
-	for pIdx < len(pattern) && pattern[pIdx] == '*' {
-		pIdx++
-	}
-
-	return pIdx == len(pattern)
+	return matchPattern(pattern, input)
 }
 
 // Checks the resource to have arn prefix and not starting with /

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -494,10 +494,7 @@ func TestPutBucketPolicy(s *S3Conf) {
 	PutBucketPolicy_statement_not_provided(s)
 	PutBucketPolicy_empty_statement(s)
 	PutBucketPolicy_invalid_effect(s)
-	PutBucketPolicy_empty_actions_string(s)
-	PutBucketPolicy_empty_actions_array(s)
 	PutBucketPolicy_invalid_action(s)
-	PutBucketPolicy_incorrect_action_wildcard_usage(s)
 	PutBucketPolicy_empty_principals_string(s)
 	PutBucketPolicy_empty_principals_array(s)
 	PutBucketPolicy_principals_aws_struct_empty_string(s)
@@ -510,8 +507,7 @@ func TestPutBucketPolicy(s *S3Conf) {
 	PutBucketPolicy_invalid_resource_with_starting_slash(s)
 	PutBucketPolicy_duplicate_resource(s)
 	PutBucketPolicy_incorrect_bucket_name(s)
-	PutBucketPolicy_object_action_on_bucket_resource(s)
-	PutBucketPolicy_bucket_action_on_object_resource(s)
+	PutBucketPolicy_action_resource_mismatch(s)
 	PutBucketPolicy_explicit_deny(s)
 	PutBucketPolicy_multi_wildcard_resource(s)
 	PutBucketPolicy_any_char_match(s)
@@ -1328,10 +1324,7 @@ func GetIntTests() IntTests {
 		"PutBucketPolicy_statement_not_provided":                                  PutBucketPolicy_statement_not_provided,
 		"PutBucketPolicy_empty_statement":                                         PutBucketPolicy_empty_statement,
 		"PutBucketPolicy_invalid_effect":                                          PutBucketPolicy_invalid_effect,
-		"PutBucketPolicy_empty_actions_string":                                    PutBucketPolicy_empty_actions_string,
-		"PutBucketPolicy_empty_actions_array":                                     PutBucketPolicy_empty_actions_array,
 		"PutBucketPolicy_invalid_action":                                          PutBucketPolicy_invalid_action,
-		"PutBucketPolicy_incorrect_action_wildcard_usage":                         PutBucketPolicy_incorrect_action_wildcard_usage,
 		"PutBucketPolicy_empty_principals_string":                                 PutBucketPolicy_empty_principals_string,
 		"PutBucketPolicy_empty_principals_array":                                  PutBucketPolicy_empty_principals_array,
 		"PutBucketPolicy_principals_aws_struct_empty_string":                      PutBucketPolicy_principals_aws_struct_empty_string,
@@ -1344,9 +1337,8 @@ func GetIntTests() IntTests {
 		"PutBucketPolicy_invalid_resource_with_starting_slash":                    PutBucketPolicy_invalid_resource_with_starting_slash,
 		"PutBucketPolicy_duplicate_resource":                                      PutBucketPolicy_duplicate_resource,
 		"PutBucketPolicy_incorrect_bucket_name":                                   PutBucketPolicy_incorrect_bucket_name,
-		"PutBucketPolicy_object_action_on_bucket_resource":                        PutBucketPolicy_object_action_on_bucket_resource,
+		"PutBucketPolicy_action_resource_mismatch":                                PutBucketPolicy_action_resource_mismatch,
 		"PutBucketPolicy_explicit_deny":                                           PutBucketPolicy_explicit_deny,
-		"PutBucketPolicy_bucket_action_on_object_resource":                        PutBucketPolicy_bucket_action_on_object_resource,
 		"PutBucketPolicy_multi_wildcard_resource":                                 PutBucketPolicy_multi_wildcard_resource,
 		"PutBucketPolicy_any_char_match":                                          PutBucketPolicy_any_char_match,
 		"PutBucketPolicy_success":                                                 PutBucketPolicy_success,


### PR DESCRIPTION
Fixes #1488

Adds full wildcard (`*`) and single-character (`?`) support for bucket policy actions, fixes resource detection with wildcards, and includes unit tests for `bucket_policy_actions`, `bucket_policy_effect`, and `bucket_policy_principals`.