### PR TITLE
correct a bug when using glauth as LDAP IAM

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -119,6 +119,7 @@ type Opts struct {
 	LDAPRoleAtr            string
 	LDAPUserIdAtr          string
 	LDAPGroupIdAtr         string
+	LDAPDebug              bool
 	VaultEndpointURL       string
 	VaultSecretStoragePath string
 	VaultAuthMethod        string
@@ -158,7 +159,7 @@ func New(o *Opts) (IAMService, error) {
 	case o.LDAPServerURL != "":
 		svc, err = NewLDAPService(o.RootAccount, o.LDAPServerURL, o.LDAPBindDN, o.LDAPPassword,
 			o.LDAPQueryBase, o.LDAPAccessAtr, o.LDAPSecretAtr, o.LDAPRoleAtr, o.LDAPUserIdAtr,
-			o.LDAPGroupIdAtr, o.LDAPObjClasses)
+			o.LDAPGroupIdAtr, o.LDAPObjClasses, o.LDAPDebug)
 		fmt.Printf("initializing LDAP IAM with %q\n", o.LDAPServerURL)
 	case o.S3Endpoint != "":
 		svc, err = NewS3(o.RootAccount, o.S3Access, o.S3Secret, o.S3Region, o.S3Bucket,

--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -63,6 +63,7 @@ var (
 	ldapQueryBase, ldapObjClasses            string
 	ldapAccessAtr, ldapSecAtr, ldapRoleAtr   string
 	ldapUserIdAtr, ldapGroupIdAtr            string
+	ldapDebug                                bool
 	vaultEndpointURL, vaultSecretStoragePath string
 	vaultAuthMethod, vaultMountPath          string
 	vaultRootToken, vaultRoleId              string
@@ -398,6 +399,12 @@ func initFlags() []cli.Flag {
 			EnvVars:     []string{"VGW_IAM_LDAP_GROUP_ID_ATR"},
 			Destination: &ldapGroupIdAtr,
 		},
+		&cli.BoolFlag{
+			Name:        "iam-ldap-debug",
+			Usage:       "ldap server debug output",
+			EnvVars:     []string{"VGW_IAM_LDAP_DEBUG"},
+			Destination: &ldapDebug,
+		},
 		&cli.StringFlag{
 			Name:        "iam-vault-endpoint-url",
 			Usage:       "vault server url",
@@ -668,6 +675,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		LDAPRoleAtr:            ldapRoleAtr,
 		LDAPUserIdAtr:          ldapUserIdAtr,
 		LDAPGroupIdAtr:         ldapGroupIdAtr,
+		LDAPDebug:              ldapDebug,
 		VaultEndpointURL:       vaultEndpointURL,
 		VaultSecretStoragePath: vaultSecretStoragePath,
 		VaultAuthMethod:        vaultAuthMethod,


### PR DESCRIPTION
be able to debug IAM LDAP queries.
be consistent between GetUserAccount() and ListUserAccounts() on how to build the search filters.
objectClasses were missing in GetUserAccount research filter, leading to a bad result for example when a posixgGroup have the same name as a posixUser.
