### PR TITLE
feat: add get bucket location frontend handlers

### DIFF
--- a/auth/bucket_policy_actions.go
+++ b/auth/bucket_policy_actions.go
@@ -87,6 +87,7 @@ const (
 	PutBucketWebsiteAction                   Action = "s3:PutBucketWebsite"
 	GetBucketWebsiteAction                   Action = "s3:GetBucketWebsite"
 	GetBucketPolicyStatusAction              Action = "s3:GetBucketPolicyStatus"
+	GetBucketLocationAction                  Action = "s3:GetBucketLocation"
 
 	AllActions Action = "s3:*"
 )
@@ -157,6 +158,7 @@ var supportedActionList = map[Action]struct{}{
 	PutBucketWebsiteAction:                   {},
 	GetBucketWebsiteAction:                   {},
 	GetBucketPolicyStatusAction:              {},
+	GetBucketLocationAction:                  {},
 	AllActions:                               {},
 }
 

--- a/metrics/actions.go
+++ b/metrics/actions.go
@@ -116,6 +116,7 @@ var (
 	ActionGetBucketWebsite                            = "s3_GetBucketWebsite"
 	ActionDeleteBucketWebsite                         = "s3_DeleteBucketWebsite"
 	ActionGetBucketPolicyStatus                       = "s3_GetBucketPolicyStatus"
+	ActionGetBucketLocation                           = "s3_GetBucketLocation"
 
 	// Admin actions
 	ActionAdminCreateUser        = "admin_CreateUser"
@@ -496,6 +497,10 @@ func init() {
 	}
 	ActionMap[ActionGetBucketPolicyStatus] = Action{
 		Name:    "GetBucketPolicyStatus",
+		Service: "s3",
+	}
+	ActionMap[ActionGetBucketLocation] = Action{
+		Name:    "GetBucketLocation",
 		Service: "s3",
 	}
 }

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -49,6 +49,7 @@ var (
 			Access: "root",
 			Role:   auth.RoleAdmin,
 		},
+		utils.ContextKeyRegion: "us-east-1",
 	}
 
 	accessDeniedLocals map[utils.ContextKey]any = map[utils.ContextKey]any{

--- a/s3api/router.go
+++ b/s3api/router.go
@@ -612,6 +612,21 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 
 	// GET bucket operations
 	bucketRouter.Get("",
+		middlewares.MatchQueryArgs("location"),
+		controllers.ProcessHandlers(
+			ctrl.GetBucketLocation,
+			metrics.ActionGetBucketLocation,
+			services,
+			middlewares.BucketObjectNameValidator(),
+			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionGetBucketLocation, auth.GetBucketLocationAction, auth.PermissionRead),
+			middlewares.VerifyPresignedV4Signature(root, iam, region, debug),
+			middlewares.VerifyV4Signature(root, iam, region, debug),
+			middlewares.VerifyMD5Body(),
+			middlewares.ApplyBucketCORS(be),
+			middlewares.ParseAcl(be),
+		),
+	)
+	bucketRouter.Get("",
 		middlewares.MatchQueryArgs("tagging"),
 		controllers.ProcessHandlers(
 			ctrl.GetBucketTagging,

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -721,3 +721,9 @@ type Checksum struct {
 	SHA256    *string
 	CRC64NVME *string
 }
+
+// LocationConstraint represents the GetBucketLocation response
+type LocationConstraint struct {
+	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LocationConstraint"`
+	Value   string   `xml:",chardata"`
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -135,6 +135,12 @@ func TestDeleteBucketTagging(s *S3Conf) {
 	DeleteBucketTagging_success(s)
 }
 
+func TestGetBucketLocation(s *S3Conf) {
+	GetBucketLocation_success(s)
+	GetBucketLocation_non_exist(s)
+	GetBucketLocation_no_access(s)
+}
+
 func TestPutObject(s *S3Conf) {
 	PutObject_non_existing_bucket(s)
 	PutObject_special_chars(s)
@@ -708,6 +714,7 @@ func TestFullFlow(s *S3Conf) {
 	TestPutBucketTagging(s)
 	TestGetBucketTagging(s)
 	TestDeleteBucketTagging(s)
+	TestGetBucketLocation(s)
 	TestPutObject(s)
 	TestHeadObject(s)
 	TestGetObjectAttributes(s)
@@ -791,6 +798,7 @@ func TestScoutfs(s *S3Conf) {
 	TestPutBucketTagging(s)
 	TestGetBucketTagging(s)
 	TestDeleteBucketTagging(s)
+	TestGetBucketLocation(s)
 	TestPutObject(s)
 	TestHeadObject(s)
 	TestGetObjectAttributes(s)
@@ -1092,6 +1100,9 @@ func GetIntTests() IntTests {
 		"DeleteBucketTagging_non_existing_object":                                 DeleteBucketTagging_non_existing_object,
 		"DeleteBucketTagging_success_status":                                      DeleteBucketTagging_success_status,
 		"DeleteBucketTagging_success":                                             DeleteBucketTagging_success,
+		"GetBucketLocation_success":                                               GetBucketLocation_success,
+		"GetBucketLocation_non_exist":                                             GetBucketLocation_non_exist,
+		"GetBucketLocation_no_access":                                             GetBucketLocation_no_access,
 		"PutObject_non_existing_bucket":                                           PutObject_non_existing_bucket,
 		"PutObject_special_chars":                                                 PutObject_special_chars,
 		"PutObject_tagging":                                                       PutObject_tagging,


### PR DESCRIPTION
GetBucketLocation is being deprecated by AWS, but is still used by some clients. We don't need any backend handlers for this since the region is managed by the frontend. All we need is to test for bucket existence, so we can use HeadBucket for this.

Fixes #1499