### PR TITLE
fix: head object should set X-Amz-Bucket-Region on access denied

### DIFF
--- a/s3api/controllers/bucket-head.go
+++ b/s3api/controllers/bucket-head.go
@@ -15,10 +15,13 @@
 package controllers
 
 import (
+	"errors"
+
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/gofiber/fiber/v2"
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/s3api/utils"
+	"github.com/versity/versitygw/s3err"
 )
 
 func (c S3ApiController) HeadBucket(ctx *fiber.Ctx) (*Response, error) {
@@ -42,6 +45,9 @@ func (c S3ApiController) HeadBucket(ctx *fiber.Ctx) (*Response, error) {
 		})
 	if err != nil {
 		return &Response{
+			Headers: map[string]*string{
+				"X-Amz-Bucket-Region": utils.GetStringPtr(region),
+			},
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,
 			},
@@ -54,6 +60,17 @@ func (c S3ApiController) HeadBucket(ctx *fiber.Ctx) (*Response, error) {
 		})
 
 	if err != nil {
+		if errors.Is(err, s3err.GetAPIError(s3err.ErrAccessDenied)) {
+			return &Response{
+				// access denied for head object still returns region header
+				Headers: map[string]*string{
+					"X-Amz-Bucket-Region": utils.GetStringPtr(region),
+				},
+				MetaOpts: &MetaOptions{
+					BucketOwner: parsedAcl.Owner,
+				},
+			}, err
+		}
 		return &Response{
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,

--- a/s3api/controllers/bucket-head_test.go
+++ b/s3api/controllers/bucket-head_test.go
@@ -48,6 +48,9 @@ func TestS3ApiController_HeadBucket(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"X-Amz-Bucket-Region": utils.GetStringPtr(region),
+					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 					},


### PR DESCRIPTION
The HeadObject API states that the x-amz-bucket-region header will still get set for an access denied error to correctly indicate region of bucket. This is needed due to the way polices work across regions in aws, and some apps rely on this behavior.

See notes in GetBucketLocation:
In a bucket's home Region, calls to the GetBucketLocation operation are governed by the bucket's policy. In other Regions, the bucket policy doesn't apply, which means that cross-account access won't be authorized. However, calls to the HeadBucket operation always return the bucket’s location through an HTTP response header, whether access to the bucket is authorized or not. Therefore, we recommend using the HeadBucket operation for bucket Region discovery and to avoid using the GetBucketLocation operation.

Fixes #1500