### PR TITLE
fix: previous pr was not rebased before merging and caused a build error

### DIFF
--- a/s3api/controllers/bucket-get.go
+++ b/s3api/controllers/bucket-get.go
@@ -629,14 +629,14 @@ func (c S3ApiController) GetBucketLocation(ctx *fiber.Ctx) (*Response, error) {
 	parsedAcl := utils.ContextKeyParsedAcl.Get(ctx).(auth.ACL)
 
 	err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
-		Readonly:       c.readonly,
-		Acl:            parsedAcl,
-		AclPermission:  auth.PermissionRead,
-		IsRoot:         isRoot,
-		Acc:            acct,
-		Bucket:         bucket,
-		Action:         auth.GetBucketLocationAction,
-		IsBucketPublic: isPublicBucket,
+		Readonly:        c.readonly,
+		Acl:             parsedAcl,
+		AclPermission:   auth.PermissionRead,
+		IsRoot:          isRoot,
+		Acc:             acct,
+		Bucket:          bucket,
+		Action:          auth.GetBucketLocationAction,
+		IsPublicRequest: isPublicBucket,
 	})
 	if err != nil {
 		return &Response{


### PR DESCRIPTION
There was a change to the auth.VerifyAccess that changed IsPublicBucket to IsPublicRequest, but another PR
(GetBucketLocation) that was merged at the same time (and not rebased) was using the old version.

Update this to fix the build.