### PR TITLE
feat: adds x-amz-object-size in PutObject response headers

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -367,6 +367,7 @@ func (az *Azure) PutObject(ctx context.Context, po s3response.PutObjectInput) (s
 
 	return s3response.PutObjectOutput{
 		ETag: convertAzureEtag(uploadResp.ETag),
+		Size: po.ContentLength,
 	}, nil
 }
 

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -938,6 +938,7 @@ func (s *S3Proxy) PutObject(ctx context.Context, input s3response.PutObjectInput
 		ChecksumCRC64NVME: output.ChecksumCRC64NVME,
 		ChecksumSHA1:      output.ChecksumSHA1,
 		ChecksumSHA256:    output.ChecksumSHA256,
+		Size:              output.Size,
 	}, nil
 }
 

--- a/s3api/controllers/object-put.go
+++ b/s3api/controllers/object-put.go
@@ -725,6 +725,7 @@ func (c S3ApiController) PutObject(ctx *fiber.Ctx) (*Response, error) {
 			"x-amz-checksum-sha256":    res.ChecksumSHA256,
 			"x-amz-checksum-type":      utils.ConvertToStringPtr(res.ChecksumType),
 			"x-amz-version-id":         &res.VersionID,
+			"x-amz-object-size":        utils.ConvertPtrToStringPtr(res.Size),
 		},
 		MetaOpts: &MetaOptions{
 			ContentLength: contentLength,

--- a/s3api/controllers/object-put_test.go
+++ b/s3api/controllers/object-put_test.go
@@ -1036,6 +1036,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 func TestS3ApiController_PutObject(t *testing.T) {
 	str := ""
 	emptyStringPtr := &str
+	objSize := int64(120)
 
 	tests := []struct {
 		name   string
@@ -1148,6 +1149,7 @@ func TestS3ApiController_PutObject(t *testing.T) {
 						"x-amz-checksum-sha256":    nil,
 						"x-amz-checksum-type":      nil,
 						"x-amz-version-id":         emptyStringPtr,
+						"x-amz-object-size":        nil,
 					},
 					MetaOpts: &MetaOptions{
 						BucketOwner:   "root",
@@ -1188,6 +1190,7 @@ func TestS3ApiController_PutObject(t *testing.T) {
 					ChecksumCRC64NVME: utils.GetStringPtr("crc64nvme"),
 					ChecksumType:      types.ChecksumTypeComposite,
 					VersionID:         "versionId",
+					Size:              &objSize,
 				},
 			},
 			output: testOutput{
@@ -1201,6 +1204,7 @@ func TestS3ApiController_PutObject(t *testing.T) {
 						"x-amz-checksum-sha256":    utils.GetStringPtr("sha256"),
 						"x-amz-checksum-type":      utils.GetStringPtr(string(types.ChecksumTypeComposite)),
 						"x-amz-version-id":         utils.GetStringPtr("versionId"),
+						"x-amz-object-size":        utils.ConvertToStringPtr(objSize),
 					},
 					MetaOpts: &MetaOptions{
 						BucketOwner:   "root",

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -37,6 +37,7 @@ type PutObjectOutput struct {
 	ChecksumSHA1      *string
 	ChecksumSHA256    *string
 	ChecksumCRC64NVME *string
+	Size              *int64
 	ChecksumType      types.ChecksumType
 }
 

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -17,6 +17,7 @@ package integration
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -1797,4 +1798,14 @@ func testOPTIONSEdnpoint(s *S3Conf, bucket, origin, method string, headers strin
 	}
 
 	return comparePreflightResult(expected, result)
+}
+
+func calculateEtag(data []byte) (string, error) {
+	h := md5.New()
+	_, err := h.Write(data)
+	if err != nil {
+		return "", err
+	}
+	dataSum := h.Sum(nil)
+	return fmt.Sprintf("\"%s\"", hex.EncodeToString(dataSum[:])), nil
 }


### PR DESCRIPTION
Closes #1518

Adds the `x-amz-object-size` header to the `PutObject` response, indicating the size of the uploaded object. This change is applied to the POSIX, Azure, and S3 proxy backends.