### PR TITLE
feat: implement conditional writes

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -532,3 +532,41 @@ func EvaluatePreconditions(etag string, modTime time.Time, preconditions PreCond
 
 	return nil
 }
+
+// EvaluateMatchPreconditions evaluates if-match and if-none-match preconditions
+func EvaluateMatchPreconditions(etag string, ifMatch, ifNoneMatch *string) error {
+	if ifMatch != nil && *ifMatch != etag {
+		return errPreconditionFailed
+	}
+	if ifNoneMatch != nil && *ifNoneMatch == etag {
+		return errPreconditionFailed
+	}
+
+	return nil
+}
+
+type ObjectDeletePreconditions struct {
+	IfMatch            *string
+	IfMatchLastModTime *time.Time
+	IfMatchSize        *int64
+}
+
+// EvaluateObjectDeletePreconditions evaluates preconditions for DeleteObject
+func EvaluateObjectDeletePreconditions(etag string, modTime time.Time, size int64, preconditions ObjectDeletePreconditions) error {
+	ifMatch := preconditions.IfMatch
+	if ifMatch != nil && *ifMatch != etag {
+		return errPreconditionFailed
+	}
+
+	ifMatchTime := preconditions.IfMatchLastModTime
+	if ifMatchTime != nil && ifMatchTime.Unix() != modTime.Unix() {
+		return errPreconditionFailed
+	}
+
+	ifMatchSize := preconditions.IfMatchSize
+	if ifMatchSize != nil && *ifMatchSize != size {
+		return errPreconditionFailed
+	}
+
+	return nil
+}

--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -323,6 +323,8 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 		}, err
 	}
 
+	ifMatch, ifNoneMatch := utils.ParsePreconditionMatchHeaders(ctx)
+
 	res, versid, err := c.be.CompleteMultipartUpload(ctx.Context(),
 		&s3.CompleteMultipartUploadInput{
 			Bucket:   &bucket,
@@ -338,6 +340,8 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 			ChecksumSHA256:    utils.GetStringPtr(checksums[types.ChecksumAlgorithmSha256]),
 			ChecksumCRC64NVME: utils.GetStringPtr(checksums[types.ChecksumAlgorithmCrc64nvme]),
 			ChecksumType:      checksumType,
+			IfMatch:           ifMatch,
+			IfNoneMatch:       ifNoneMatch,
 		})
 	return &Response{
 		Data: res,

--- a/s3api/controllers/object-put_test.go
+++ b/s3api/controllers/object-put_test.go
@@ -837,42 +837,6 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid copy source modified since",
-			input: testInput{
-				locals: defaultLocals,
-				headers: map[string]string{
-					"X-Amz-Copy-Source":                   "bucket/object",
-					"X-Amz-Copy-Source-If-Modified-Since": "invalid_date",
-				},
-			},
-			output: testOutput{
-				response: &Response{
-					MetaOpts: &MetaOptions{
-						BucketOwner: "root",
-					},
-				},
-				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket),
-			},
-		},
-		{
-			name: "invalid copy source unmodified since",
-			input: testInput{
-				locals: defaultLocals,
-				headers: map[string]string{
-					"X-Amz-Copy-Source":                     "bucket/object",
-					"X-Amz-Copy-Source-If-Unmodified-Since": "invalid_date",
-				},
-			},
-			output: testOutput{
-				response: &Response{
-					MetaOpts: &MetaOptions{
-						BucketOwner: "root",
-					},
-				},
-				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket),
-			},
-		},
-		{
 			name: "invalid metadata directive",
 			input: testInput{
 				locals: defaultLocals,

--- a/s3api/utils/precondition.go
+++ b/s3api/utils/precondition.go
@@ -1,0 +1,138 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/debuglogger"
+)
+
+// ConditionalHeaders holds the conditional header values
+type ConditionalHeaders struct {
+	IfMatch       *string
+	IfNoneMatch   *string
+	IfModSince    *time.Time
+	IfUnmodeSince *time.Time
+}
+
+type precondtionCfg struct {
+	withCopySource bool
+}
+
+type preconditionOpt func(*precondtionCfg)
+
+func WithCopySource() preconditionOpt {
+	return func(o *precondtionCfg) { o.withCopySource = true }
+}
+
+// ParsePreconditionHeaders parses the precondition headers:
+// - If-Match
+// - If-None-Match
+// - If-Modified-Since
+// - If-Unmodified-Since
+func ParsePreconditionHeaders(ctx *fiber.Ctx, opts ...preconditionOpt) ConditionalHeaders {
+	ifMatch, ifNoneMatch := ParsePreconditionMatchHeaders(ctx, opts...)
+	ifModSince, ifUnmodeSince := ParsePreconditionDateHeaders(ctx, opts...)
+
+	return ConditionalHeaders{
+		IfMatch:       ifMatch,
+		IfNoneMatch:   ifNoneMatch,
+		IfModSince:    ifModSince,
+		IfUnmodeSince: ifUnmodeSince,
+	}
+}
+
+// ParsePreconditionMatchHeaders extracts "If-Match" and "If-None-Match" headers from fiber Ctx
+func ParsePreconditionMatchHeaders(ctx *fiber.Ctx, opts ...preconditionOpt) (*string, *string) {
+	cfg := new(precondtionCfg)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	prefix := ""
+	if cfg.withCopySource {
+		prefix = "X-Amz-Copy-Source-"
+	}
+	return GetStringPtr(ctx.Get(prefix + "If-Match")), GetStringPtr(ctx.Get(prefix + "If-None-Match"))
+}
+
+// ParsePreconditionDateHeaders parses the "If-Modified-Since" and "If-Unmodified-Since"
+// headers from fiber context to *time.Time
+func ParsePreconditionDateHeaders(ctx *fiber.Ctx, opts ...preconditionOpt) (*time.Time, *time.Time) {
+	cfg := new(precondtionCfg)
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	prefix := ""
+	if cfg.withCopySource {
+		prefix = "X-Amz-Copy-Source-"
+	}
+
+	ifModSince := ctx.Get(prefix + "If-Modified-Since")
+	ifUnmodSince := ctx.Get(prefix + "If-Unmodified-Since")
+
+	ifModSinceParsed := ParsePreconditionDateHeader(ifModSince)
+	ifUnmodSinceParsed := ParsePreconditionDateHeader(ifUnmodSince)
+
+	return ifModSinceParsed, ifUnmodSinceParsed
+}
+
+// ParsePreconditionDateHeader tries to parse the given date string as
+// - RFC1123
+// - RFC3339
+// both are valid
+func ParsePreconditionDateHeader(date string) *time.Time {
+	if date == "" {
+		return nil
+	}
+	// try to parse as RFC1123
+	parsed, err := time.Parse(time.RFC1123, date)
+	if err == nil {
+		// ignore future dates
+		if parsed.After(time.Now()) {
+			return nil
+		}
+
+		return &parsed
+	}
+
+	// try to parse as RFC3339
+	parsed, err = time.Parse(time.RFC3339, date)
+	if err == nil {
+		// ignore future dates
+		if parsed.After(time.Now()) {
+			return nil
+		}
+
+		return &parsed
+	}
+
+	return nil
+}
+
+// ParseIfMatchSize parses the 'x-amz-if-match-size' to *int64
+// if parsing fails, returns nil
+func ParseIfMatchSize(ctx *fiber.Ctx) *int64 {
+	ifMatchSizeHdr := ctx.Get("x-amz-if-match-size")
+	ifMatchSize, err := strconv.ParseInt(ifMatchSizeHdr, 10, 64)
+	if err != nil {
+		debuglogger.Logf("failed to parse 'x-amz-if-match-size': %s", ifMatchSizeHdr)
+		return nil
+	}
+
+	return &ifMatchSize
+}

--- a/s3api/utils/utils.go
+++ b/s3api/utils/utils.go
@@ -642,59 +642,6 @@ func ParseCreateMpChecksumHeaders(ctx *fiber.Ctx) (types.ChecksumAlgorithm, type
 	return algo, chType, nil
 }
 
-// ConditionalHeaders holds the conditional header values
-type ConditionalHeaders struct {
-	IfMatch       *string
-	IfNoneMatch   *string
-	IfModSince    *time.Time
-	IfUnmodeSince *time.Time
-}
-
-// ParsePreconditionHeaders parses the precondition headers:
-// - If-Match
-// - If-None-Match
-// - If-Modified-Since
-// - If-Unmodified-Since
-func ParsePreconditionHeaders(ctx *fiber.Ctx) ConditionalHeaders {
-	ifMatch, ifNoneMatch := ParsePreconditionMatchHeaders(ctx)
-	ifModSince, ifUnmodeSince := ParsePreconditionDateHeaders(ctx)
-
-	return ConditionalHeaders{
-		IfMatch:       ifMatch,
-		IfNoneMatch:   ifNoneMatch,
-		IfModSince:    ifModSince,
-		IfUnmodeSince: ifUnmodeSince,
-	}
-}
-
-// ParsePreconditionMatchHeaders extracts "If-Match" and "If-None-Match" headers from fiber Ctx
-func ParsePreconditionMatchHeaders(ctx *fiber.Ctx) (*string, *string) {
-	return GetStringPtr(ctx.Get("If-Match")), GetStringPtr(ctx.Get("If-None-Match"))
-}
-
-// ParsePreconditionDateHeaders parses the "If-Modified-Since" and "If-Unmodified-Since"
-// headers from fiber context to *time.Time
-func ParsePreconditionDateHeaders(ctx *fiber.Ctx) (*time.Time, *time.Time) {
-	ifModSince := ctx.Get("If-Modified-Since")
-	ifUnmodSince := ctx.Get("If-Unmodified-Since")
-
-	var ifModSinceParsed, ifUnmodSinceParsed *time.Time
-
-	// the time format should be a valid RFC1123
-	// if parsing fails, ignore the error and leave the value as nil
-	modParsed, err := time.Parse(time.RFC1123, ifModSince)
-	if err == nil {
-		ifModSinceParsed = &modParsed
-	}
-
-	unmodParsed, err := time.Parse(time.RFC1123, ifUnmodSince)
-	if err == nil {
-		ifUnmodSinceParsed = &unmodParsed
-	}
-
-	return ifModSinceParsed, ifUnmodSinceParsed
-}
-
 // TagLimit specifies the allowed tag count in a tag set
 type TagLimit int
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -149,6 +149,7 @@ func TestPutObject(s *S3Conf) {
 	PutObject_with_object_lock(s)
 	PutObject_invalid_legal_hold(s)
 	PutObject_invalid_object_lock_mode(s)
+	PutObject_conditional_writes(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		PutObject_checksum_algorithm_and_header_mismatch(s)
@@ -279,6 +280,7 @@ func TestDeleteObject(s *S3Conf) {
 	DeleteObject_non_existing_dir_object(s)
 	DeleteObject_directory_object(s)
 	DeleteObject_non_empty_dir_obj(s)
+	DeleteObject_conditional_writes(s)
 	DeleteObject_success(s)
 	DeleteObject_success_status_code(s)
 }
@@ -307,6 +309,7 @@ func TestCopyObject(s *S3Conf) {
 	CopyObject_invalid_object_lock_mode(s)
 	CopyObject_with_legal_hold(s)
 	CopyObject_with_retention_lock(s)
+	CopyObject_conditional_reads(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		CopyObject_invalid_checksum_algorithm(s)
@@ -398,6 +401,7 @@ func TestUploadPartCopy(s *S3Conf) {
 		UploadPartCopy_should_copy_the_checksum(s)
 		UploadPartCopy_should_not_copy_the_checksum(s)
 		UploadPartCopy_should_calculate_the_checksum(s)
+		UploadPartCopy_conditional_reads(s)
 	}
 }
 
@@ -437,6 +441,7 @@ func TestAbortMultipartUpload(s *S3Conf) {
 	AbortMultipartUpload_incorrect_object_key(s)
 	AbortMultipartUpload_success(s)
 	AbortMultipartUpload_success_status_code(s)
+	AbortMultipartUpload_if_match_initiated_time(s)
 }
 
 func TestCompleteMultipartUpload(s *S3Conf) {
@@ -448,6 +453,7 @@ func TestCompleteMultipartUpload(s *S3Conf) {
 	CompleteMultipartUpload_empty_parts(s)
 	CompleteMultipartUpload_incorrect_parts_order(s)
 	CompleteMultipartUpload_mpu_object_size(s)
+	CompleteMultipartUpload_conditional_writes(s)
 	//TODO: remove the condition after implementing checksums in azure
 	if !s.azureTests {
 		CompleteMultipartUpload_invalid_checksum_type(s)
@@ -1053,6 +1059,7 @@ func GetIntTests() IntTests {
 		"PutObject_with_object_lock":                                              PutObject_with_object_lock,
 		"PutObject_invalid_legal_hold":                                            PutObject_invalid_legal_hold,
 		"PutObject_invalid_object_lock_mode":                                      PutObject_invalid_object_lock_mode,
+		"PutObject_conditional_writes":                                            PutObject_conditional_writes,
 		"PutObject_invalid_credentials":                                           PutObject_invalid_credentials,
 		"PutObject_checksum_algorithm_and_header_mismatch":                        PutObject_checksum_algorithm_and_header_mismatch,
 		"PutObject_multiple_checksum_headers":                                     PutObject_multiple_checksum_headers,
@@ -1184,6 +1191,7 @@ func GetIntTests() IntTests {
 		"DeleteObject_non_existing_object":                                        DeleteObject_non_existing_object,
 		"DeleteObject_directory_object_noslash":                                   DeleteObject_directory_object_noslash,
 		"DeleteObject_non_empty_dir_obj":                                          DeleteObject_non_empty_dir_obj,
+		"DeleteObject_conditional_writes":                                         DeleteObject_conditional_writes,
 		"DeleteObject_name_too_long":                                              DeleteObject_name_too_long,
 		"CopyObject_overwrite_same_dir_object":                                    CopyObject_overwrite_same_dir_object,
 		"CopyObject_overwrite_same_file_object":                                   CopyObject_overwrite_same_file_object,
@@ -1211,6 +1219,7 @@ func GetIntTests() IntTests {
 		"CopyObject_invalid_object_lock_mode":                                     CopyObject_invalid_object_lock_mode,
 		"CopyObject_with_legal_hold":                                              CopyObject_with_legal_hold,
 		"CopyObject_with_retention_lock":                                          CopyObject_with_retention_lock,
+		"CopyObject_conditional_reads":                                            CopyObject_conditional_reads,
 		"CopyObject_invalid_checksum_algorithm":                                   CopyObject_invalid_checksum_algorithm,
 		"CopyObject_create_checksum_on_copy":                                      CopyObject_create_checksum_on_copy,
 		"CopyObject_should_copy_the_existing_checksum":                            CopyObject_should_copy_the_existing_checksum,
@@ -1270,6 +1279,7 @@ func GetIntTests() IntTests {
 		"UploadPartCopy_exceeding_copy_source_range":                              UploadPartCopy_exceeding_copy_source_range,
 		"UploadPartCopy_greater_range_than_obj_size":                              UploadPartCopy_greater_range_than_obj_size,
 		"UploadPartCopy_by_range_success":                                         UploadPartCopy_by_range_success,
+		"UploadPartCopy_conditional_reads":                                        UploadPartCopy_conditional_reads,
 		"UploadPartCopy_should_copy_the_checksum":                                 UploadPartCopy_should_copy_the_checksum,
 		"UploadPartCopy_should_not_copy_the_checksum":                             UploadPartCopy_should_not_copy_the_checksum,
 		"UploadPartCopy_should_calculate_the_checksum":                            UploadPartCopy_should_calculate_the_checksum,
@@ -1295,6 +1305,7 @@ func GetIntTests() IntTests {
 		"AbortMultipartUpload_incorrect_object_key":                               AbortMultipartUpload_incorrect_object_key,
 		"AbortMultipartUpload_success":                                            AbortMultipartUpload_success,
 		"AbortMultipartUpload_success_status_code":                                AbortMultipartUpload_success_status_code,
+		"AbortMultipartUpload_if_match_initiated_time":                            AbortMultipartUpload_if_match_initiated_time,
 		"CompletedMultipartUpload_non_existing_bucket":                            CompletedMultipartUpload_non_existing_bucket,
 		"CompleteMultipartUpload_invalid_part_number":                             CompleteMultipartUpload_invalid_part_number,
 		"CompleteMultipartUpload_invalid_ETag":                                    CompleteMultipartUpload_invalid_ETag,
@@ -1302,6 +1313,7 @@ func GetIntTests() IntTests {
 		"CompleteMultipartUpload_empty_parts":                                     CompleteMultipartUpload_empty_parts,
 		"CompleteMultipartUpload_incorrect_parts_order":                           CompleteMultipartUpload_incorrect_parts_order,
 		"CompleteMultipartUpload_mpu_object_size":                                 CompleteMultipartUpload_mpu_object_size,
+		"CompleteMultipartUpload_conditional_writes":                              CompleteMultipartUpload_conditional_writes,
 		"CompleteMultipartUpload_invalid_checksum_type":                           CompleteMultipartUpload_invalid_checksum_type,
 		"CompleteMultipartUpload_invalid_checksum_part":                           CompleteMultipartUpload_invalid_checksum_part,
 		"CompleteMultipartUpload_multiple_checksum_part":                          CompleteMultipartUpload_multiple_checksum_part,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -518,11 +518,15 @@ type putObjectOutput struct {
 }
 
 func putObjectWithData(lgth int64, input *s3.PutObjectInput, client *s3.Client) (*putObjectOutput, error) {
-	data := make([]byte, lgth)
-	rand.Read(data)
-	csum := sha256.Sum256(data)
-	r := bytes.NewReader(data)
-	input.Body = r
+	var csum [32]byte
+	var data []byte
+	if input.Body == nil {
+		data = make([]byte, lgth)
+		rand.Read(data)
+		csum = sha256.Sum256(data)
+		r := bytes.NewReader(data)
+		input.Body = r
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 	res, err := client.PutObject(ctx, input)


### PR DESCRIPTION
Closes #821

**Implements conditional operations across object APIs:**

* **PutObject** and **CompleteMultipartUpload**: Supports conditional writes with `If-Match` and `If-None-Match` headers (ETag comparisons). Evaluation is based on an existing object with the same key in the bucket. The operation is allowed only if the preconditions are satisfied. If no object exists for the key, these headers are ignored.

* **CopyObject** and **UploadPartCopy**: Adds conditional reads on the copy source object with the following headers:

  * `x-amz-copy-source-if-match`
  * `x-amz-copy-source-if-none-match`
  * `x-amz-copy-source-if-modified-since`
  * `x-amz-copy-source-if-unmodified-since` The first two are ETag comparisons, while the latter two compare against the copy source’s `LastModified` timestamp.

* **AbortMultipartUpload**: Supports the `x-amz-if-match-initiated-time` header, which is true only if the multipart upload’s initialization time matches.

* **DeleteObject**: Adds support for:

  * `If-Match` (ETag comparison)
  * `x-amz-if-match-last-modified-time` (LastModified comparison)
  * `x-amz-if-match-size` (object size comparison)

Additionally, this PR updates precondition date parsing logic to support both **RFC1123** and **RFC3339** formats. Dates set in the future are ignored, matching AWS S3 behavior.