### PR TITLE
fix: NotImplemented for GetObject/HeadObject PartNumber

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -408,6 +408,11 @@ func (az *Azure) DeleteBucketTagging(ctx context.Context, bucket string) error {
 }
 
 func (az *Azure) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.GetObjectOutput, error) {
+	if input.PartNumber != nil {
+		// querying an object with part number is not supported
+		return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
+	}
+
 	client, err := az.getBlobClient(*input.Bucket, *input.Key)
 	if err != nil {
 		return nil, err
@@ -482,48 +487,8 @@ func (az *Azure) GetObject(ctx context.Context, input *s3.GetObjectInput) (*s3.G
 
 func (az *Azure) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s3.HeadObjectOutput, error) {
 	if input.PartNumber != nil {
-		client, err := az.getBlockBlobClient(*input.Bucket, *input.Key)
-		if err != nil {
-			return nil, err
-		}
-
-		res, err := client.GetBlockList(ctx, blockblob.BlockListTypeUncommitted, nil)
-		if err != nil {
-			return nil, azureErrToS3Err(err)
-		}
-
-		if res.ETag != nil && res.LastModified != nil {
-			err = backend.EvaluatePreconditions(convertAzureEtag(res.ETag), *res.LastModified,
-				backend.PreConditions{
-					IfMatch:       input.IfMatch,
-					IfNoneMatch:   input.IfNoneMatch,
-					IfModSince:    input.IfModifiedSince,
-					IfUnmodeSince: input.IfUnmodifiedSince,
-				})
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		partsCount := int32(len(res.UncommittedBlocks))
-
-		for _, block := range res.UncommittedBlocks {
-			partNumber, err := decodeBlockId(*block.Name)
-			if err != nil {
-				return nil, err
-			}
-
-			if partNumber == int(*input.PartNumber) {
-				return &s3.HeadObjectOutput{
-					ContentLength: block.Size,
-					ETag:          block.Name,
-					PartsCount:    &partsCount,
-					StorageClass:  types.StorageClassStandard,
-				}, nil
-			}
-		}
-
-		return nil, s3err.GetAPIError(s3err.ErrNoSuchKey)
+		// querying an object with part number is not supported
+		return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
 	}
 
 	client, err := az.getBlobClient(*input.Bucket, *input.Key)

--- a/s3api/controllers/object-get_test.go
+++ b/s3api/controllers/object-get_test.go
@@ -711,6 +711,23 @@ func TestS3ApiController_GetObject(t *testing.T) {
 			},
 		},
 		{
+			name: "invalid part number",
+			input: testInput{
+				locals: defaultLocals,
+				queries: map[string]string{
+					"partNumber": "-2",
+				},
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{
+						BucketOwner: "root",
+					},
+				},
+				err: s3err.GetAPIError(s3err.ErrInvalidPartNumber),
+			},
+		},
+		{
 			name: "backend returns error",
 			input: testInput{
 				locals: defaultLocals,
@@ -733,8 +750,6 @@ func TestS3ApiController_GetObject(t *testing.T) {
 				err: s3err.GetAPIError(s3err.ErrInvalidAccessKeyID),
 			},
 		},
-		// TODO: add a test case for overflowing content-length
-		// simulate a 32 bit arch to test the case
 		{
 			name: "successful response",
 			input: testInput{

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -171,8 +171,7 @@ func TestPutObject(s *S3Conf) {
 func TestHeadObject(s *S3Conf) {
 	HeadObject_non_existing_object(s)
 	HeadObject_invalid_part_number(s)
-	HeadObject_non_existing_mp(s)
-	HeadObject_mp_success(s)
+	HeadObject_part_number_not_supported(s)
 	HeadObject_directory_object_noslash(s)
 	HeadObject_non_existing_dir_object(s)
 	HeadObject_invalid_parent_dir(s)
@@ -222,6 +221,8 @@ func TestGetObject(s *S3Conf) {
 	GetObject_overrides_success(s)
 	GetObject_overrides_presign_success(s)
 	GetObject_overrides_fail_public(s)
+	GetObject_invalid_part_number(s)
+	GetObject_part_number_not_supported(s)
 }
 
 func TestListObjects(s *S3Conf) {
@@ -1117,8 +1118,7 @@ func GetIntTests() IntTests {
 		"PutObject_racey_success":                                                 PutObject_racey_success,
 		"HeadObject_non_existing_object":                                          HeadObject_non_existing_object,
 		"HeadObject_invalid_part_number":                                          HeadObject_invalid_part_number,
-		"HeadObject_non_existing_mp":                                              HeadObject_non_existing_mp,
-		"HeadObject_mp_success":                                                   HeadObject_mp_success,
+		"HeadObject_part_number_not_supported":                                    HeadObject_part_number_not_supported,
 		"HeadObject_directory_object_noslash":                                     HeadObject_directory_object_noslash,
 		"HeadObject_non_existing_dir_object":                                      HeadObject_non_existing_dir_object,
 		"HeadObject_name_too_long":                                                HeadObject_name_too_long,
@@ -1154,6 +1154,8 @@ func GetIntTests() IntTests {
 		"GetObject_overrides_success":                                             GetObject_overrides_success,
 		"GetObject_overrides_presign_success":                                     GetObject_overrides_presign_success,
 		"GetObject_overrides_fail_public":                                         GetObject_overrides_fail_public,
+		"GetObject_invalid_part_number":                                           GetObject_invalid_part_number,
+		"GetObject_part_number_not_supported":                                     GetObject_part_number_not_supported,
 		"ListObjects_non_existing_bucket":                                         ListObjects_non_existing_bucket,
 		"ListObjects_with_prefix":                                                 ListObjects_with_prefix,
 		"ListObjects_truncated":                                                   ListObjects_truncated,


### PR DESCRIPTION
Fixes #1520

Removes the incorrect logic for HeadObject returning successful response, when querying an incomplete multipart upload.

Implements the logic to return `NotImplemented` error if `GetObject`/`HeadObject` is attempted with `partNumber` in azure and posix backends. The front-end part is preserved to be used in s3 proxy backend.