### PR TITLE
fix: #1527 - case-insensitive x-amz-checksum-mode header value

### DIFF
--- a/s3api/controllers/object-get.go
+++ b/s3api/controllers/object-get.go
@@ -379,7 +379,7 @@ func (c S3ApiController) GetObject(ctx *fiber.Ctx) (*Response, error) {
 	key := strings.TrimPrefix(ctx.Path(), fmt.Sprintf("/%s/", bucket))
 	versionId := ctx.Query("versionId")
 	acceptRange := ctx.Get("Range")
-	checksumMode := types.ChecksumMode(ctx.Get("x-amz-checksum-mode"))
+	checksumMode := types.ChecksumMode(strings.ToUpper(ctx.Get("x-amz-checksum-mode", "")))
 	partNumberQuery := int32(ctx.QueryInt("partNumber", -1))
 
 	// Extract response override query parameters

--- a/s3api/controllers/object-head.go
+++ b/s3api/controllers/object-head.go
@@ -80,7 +80,7 @@ func (c S3ApiController) HeadObject(ctx *fiber.Ctx) (*Response, error) {
 		partNumber = &partNumberQuery
 	}
 
-	checksumMode := types.ChecksumMode(ctx.Get("x-amz-checksum-mode"))
+	checksumMode := types.ChecksumMode(strings.ToUpper(ctx.Get("x-amz-checksum-mode", "")))
 	if checksumMode != "" && checksumMode != types.ChecksumModeEnabled {
 		debuglogger.Logf("invalid x-amz-checksum-mode header value: %v", checksumMode)
 		return &Response{

--- a/s3api/controllers/object-head_test.go
+++ b/s3api/controllers/object-head_test.go
@@ -113,6 +113,9 @@ func TestS3ApiController_HeadObject(t *testing.T) {
 					"partNumber": "4",
 				},
 				locals: defaultLocals,
+				headers: map[string]string{
+					"x-amz-checksum-mode": "enabled",
+				},
 				beRes: &s3.HeadObjectOutput{
 					ETag:          utils.GetStringPtr("ETag"),
 					ContentType:   utils.GetStringPtr("application/xml"),


### PR DESCRIPTION

Use case-insensitive lookup of x-amz-checksum-mode header value to
support compatibility with AWS S3 client library.

