### PR TITLE
fix: lex sort order of listobjectversions backend.WalkVersions

### DIFF
--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -23080,7 +23080,7 @@ func ListObjectVersions_multiple_object_versions_truncated(s *S3Conf) error {
 
 		if !compareVersions(versions[:maxKeys], out.Versions) {
 			return fmt.Errorf("expected the resulting object versions to be %v, instead got %v",
-				versions[:maxKeys], out.Versions)
+				sprintVersions(versions[:maxKeys]), sprintVersions(out.Versions))
 		}
 
 		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
@@ -23116,7 +23116,7 @@ func ListObjectVersions_multiple_object_versions_truncated(s *S3Conf) error {
 
 		if !compareVersions(versions[maxKeys:], out.Versions) {
 			return fmt.Errorf("expected the resulting object versions to be %v, instead got %v",
-				versions[maxKeys:], out.Versions)
+				sprintVersions(versions[:maxKeys]), sprintVersions(out.Versions))
 		}
 
 		return nil

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1839,3 +1839,16 @@ func sprintPrefixes(cpfx []types.CommonPrefix) string {
 
 	return strings.Join(names, ",")
 }
+
+func sprintVersions(objects []types.ObjectVersion) string {
+	if len(objects) == 0 {
+		return ""
+	}
+
+	names := make([]string, len(objects))
+	for i, obj := range objects {
+		names[i] = fmt.Sprintf("%v/%v", *obj.Key, obj.VersionId)
+	}
+
+	return strings.Join(names, ",")
+}


### PR DESCRIPTION
Similar to:
  8e18b43116d889a6053f75e6be93121d5c92ba70
  fix: lex sort order of listobjects backend.Walk
But now the "Versions" walk.

The original backend.WalkVersions function used the native WalkDir and ReadDir which did not guarantee lexicographic ordering of results for cases where including directory slash changes the sort order. This caused incorrect paginated responses because S3 APIs require strict lexicographic ordering where directories with trailing slashes sort correctly relative to files. For example, dir1/a.b/ must come before dir1/a/ in the results, but fs.WalkDir was returning them in filesystem sort order which reversed the order due to not taking in account the trailing "/".