### PR TITLE
fix: fixes sigv4 and presigned url auth errors.

### DIFF
--- a/s3api/middlewares/presign-auth.go
+++ b/s3api/middlewares/presign-auth.go
@@ -32,8 +32,13 @@ func VerifyPresignedV4Signature(root RootUserConfig, iam auth.IAMService, region
 		if utils.ContextKeyPublicBucket.IsSet(ctx) {
 			return nil
 		}
-		if ctx.Query("X-Amz-Signature") == "" {
+		if !utils.IsPresignedURLAuth(ctx) {
 			return nil
+		}
+
+		if ctx.Request().URI().QueryArgs().Has("X-Amz-Security-Token") {
+			// OIDC Authorization with X-Amz-Security-Token is not supported
+			return s3err.QueryAuthErrors.SecurityTokenNotSupported()
 		}
 
 		// Set in the context the "authenticated" key, in case the authentication succeeds,

--- a/s3api/middlewares/public-bucket.go
+++ b/s3api/middlewares/public-bucket.go
@@ -31,7 +31,7 @@ import (
 func AuthorizePublicBucketAccess(be backend.Backend, s3action string, policyPermission auth.Action, permission auth.Permission) fiber.Handler {
 	return func(ctx *fiber.Ctx) error {
 		// skip for authenticated requests
-		if ctx.Query("X-Amz-Algorithm") != "" || ctx.Get("Authorization") != "" {
+		if utils.IsPresignedURLAuth(ctx) || ctx.Get("Authorization") != "" {
 			return nil
 		}
 

--- a/s3err/presigned-urls.go
+++ b/s3err/presigned-urls.go
@@ -1,0 +1,95 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package s3err
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Factory for building AuthorizationQueryParametersError errors.
+func authQueryParamError(format string, args ...any) APIError {
+	return APIError{
+		Code:           "AuthorizationQueryParametersError",
+		Description:    fmt.Sprintf(format, args...),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+var QueryAuthErrors = struct {
+	UnsupportedAlgorithm  func() APIError
+	MalformedCredential   func() APIError
+	IncorrectService      func(string) APIError
+	IncorrectRegion       func(expected, actual string) APIError
+	IncorrectTerminal     func(string) APIError
+	InvalidDateFormat     func(string) APIError
+	DateMismatch          func(expected, actual string) APIError
+	ExpiresTooLarge       func() APIError
+	ExpiresNegative       func() APIError
+	ExpiresNumber         func() APIError
+	MissingRequiredParams func() APIError
+	InvalidXAmzDateFormat func() APIError
+	RequestNotYetValid    func() APIError
+	RequestExpired        func() APIError
+	InvalidAccessKeyId    func() APIError
+	// a custom non-AWS error
+	OnlyHMACSupported         func() APIError
+	SecurityTokenNotSupported func() APIError
+}{
+
+	UnsupportedAlgorithm: func() APIError {
+		return authQueryParamError(`X-Amz-Algorithm only supports "AWS4-HMAC-SHA256 and AWS4-ECDSA-P256-SHA256"`)
+	},
+	MalformedCredential: func() APIError {
+		return authQueryParamError(`Error parsing the X-Amz-Credential parameter; the Credential is mal-formed; expecting "<YOUR-AKID>/YYYYMMDD/REGION/SERVICE/aws4_request".`)
+	},
+	IncorrectService: func(s string) APIError {
+		return authQueryParamError(`Error parsing the X-Amz-Credential parameter; incorrect service %q. This endpoint belongs to "s3".`, s)
+	},
+	IncorrectRegion: func(expected, actual string) APIError {
+		return authQueryParamError(`Error parsing the X-Amz-Credential parameter; the region %q is wrong; expecting %q`, actual, expected)
+	},
+	IncorrectTerminal: func(s string) APIError {
+		return authQueryParamError(`Error parsing the X-Amz-Credential parameter; incorrect terminal %q. This endpoint uses "aws4_request".`, s)
+	},
+	InvalidDateFormat: func(s string) APIError {
+		return authQueryParamError(`Error parsing the X-Amz-Credential parameter; incorrect date format %q. This date in the credential must be in the format "yyyyMMdd".`, s)
+	},
+	DateMismatch: func(expected, actual string) APIError {
+		return authQueryParamError(`Invalid credential date %q. This date is not the same as X-Amz-Date: %q.`, expected, actual)
+	},
+	ExpiresTooLarge: func() APIError {
+		return authQueryParamError("X-Amz-Expires must be less than a week (in seconds); that is, the given X-Amz-Expires must be less than 604800 seconds")
+	},
+	ExpiresNegative: func() APIError {
+		return authQueryParamError("X-Amz-Expires must be non-negative")
+	},
+	ExpiresNumber: func() APIError {
+		return authQueryParamError("X-Amz-Expires should be a number")
+	},
+	MissingRequiredParams: func() APIError {
+		return authQueryParamError("Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.")
+	},
+	InvalidXAmzDateFormat: func() APIError {
+		return authQueryParamError(`X-Amz-Date must be in the ISO8601 Long Format "yyyyMMdd'T'HHmmss'Z'"`)
+	},
+	// a custom non-AWS error
+	OnlyHMACSupported: func() APIError {
+		return authQueryParamError("X-Amz-Algorithm only supports \"AWS4-HMAC-SHA256\"")
+	},
+	SecurityTokenNotSupported: func() APIError {
+		return authQueryParamError("Authorization with X-Amz-Security-Token is not supported")
+	},
+}

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -98,8 +98,8 @@ const (
 	ErrBucketTaggingLimited
 	ErrObjectTaggingLimited
 	ErrInvalidURLEncodedTagging
-	ErrAuthHeaderEmpty
-	ErrSignatureVersionNotSupported
+	ErrInvalidAuthHeader
+	ErrUnsupportedAuthorizationType
 	ErrMalformedPOSTRequest
 	ErrPOSTFileRequired
 	ErrPostPolicyConditionInvalidFormat
@@ -107,24 +107,13 @@ const (
 	ErrEntityTooLarge
 	ErrMissingFields
 	ErrMissingCredTag
-	ErrCredMalformed
 	ErrMalformedXML
-	ErrMalformedDate
-	ErrMalformedPresignedDate
 	ErrMalformedCredentialDate
 	ErrMissingSignHeadersTag
 	ErrMissingSignTag
 	ErrUnsignedHeaders
-	ErrInvalidQueryParams
-	ErrInvalidQuerySignatureAlgo
 	ErrExpiredPresignRequest
-	ErrMalformedExpires
-	ErrNegativeExpires
-	ErrMaximumExpires
 	ErrSignatureDoesNotMatch
-	ErrSignatureDateDoesNotMatch
-	ErrSignatureTerminationStr
-	ErrSignatureIncorrService
 	ErrContentSHA256Mismatch
 	ErrInvalidSHA256Paylod
 	ErrMissingContentLength
@@ -402,14 +391,14 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "The XML you provided was not well-formed or did not validate against our published schema.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrAuthHeaderEmpty: {
+	ErrInvalidAuthHeader: {
 		Code:           "InvalidArgument",
 		Description:    "Authorization header is invalid -- one and only one ' ' (space) required.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrSignatureVersionNotSupported: {
-		Code:           "InvalidRequest",
-		Description:    "The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.",
+	ErrUnsupportedAuthorizationType: {
+		Code:           "InvalidArgument",
+		Description:    "Unsupported Authorization Type",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrMalformedPOSTRequest: {
@@ -447,21 +436,6 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "Missing Credential field for this request.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrCredMalformed: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "Error parsing the X-Amz-Credential parameter; the Credential is mal-formed; expecting \"<YOUR-AKID>/YYYYMMDD/REGION/SERVICE/aws4_request\".",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrMalformedDate: {
-		Code:           "MalformedDate",
-		Description:    "Invalid date format header, expected to be in ISO8601, RFC1123 or RFC1123Z time format.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrMalformedPresignedDate: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "X-Amz-Date must be in the ISO8601 Long Format \"yyyyMMdd'T'HHmmss'Z'\".",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
 	ErrMissingSignHeadersTag: {
 		Code:           "InvalidArgument",
 		Description:    "Signature header missing SignedHeaders field.",
@@ -477,35 +451,10 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "There were headers present in the request which were not signed.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrInvalidQueryParams: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "Query-string authentication version 4 requires the X-Amz-Algorithm, X-Amz-Credential, X-Amz-Signature, X-Amz-Date, X-Amz-SignedHeaders, and X-Amz-Expires parameters.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrInvalidQuerySignatureAlgo: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "X-Amz-Algorithm only supports \"AWS4-HMAC-SHA256\".",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
 	ErrExpiredPresignRequest: {
 		Code:           "AccessDenied",
 		Description:    "Request has expired.",
 		HTTPStatusCode: http.StatusForbidden,
-	},
-	ErrMalformedExpires: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "X-Amz-Expires should be a number.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrNegativeExpires: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "X-Amz-Expires must be non-negative.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrMaximumExpires: {
-		Code:           "AuthorizationQueryParametersError",
-		Description:    "X-Amz-Expires must be less than a week (in seconds); that is, the given X-Amz-Expires must be less than 604800 seconds.",
-		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidAccessKeyID: {
 		Code:           "InvalidAccessKeyId",
@@ -520,21 +469,6 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrSignatureDoesNotMatch: {
 		Code:           "SignatureDoesNotMatch",
 		Description:    "The request signature we calculated does not match the signature you provided. Check your key and signing method.",
-		HTTPStatusCode: http.StatusForbidden,
-	},
-	ErrSignatureDateDoesNotMatch: {
-		Code:           "SignatureDoesNotMatch",
-		Description:    "Date in Credential scope does not match YYYYMMDD from ISO-8601 version of date from HTTP.",
-		HTTPStatusCode: http.StatusForbidden,
-	},
-	ErrSignatureTerminationStr: {
-		Code:           "SignatureDoesNotMatch",
-		Description:    "Credential should be scoped with a valid terminator: 'aws4_request'.",
-		HTTPStatusCode: http.StatusForbidden,
-	},
-	ErrSignatureIncorrService: {
-		Code:           "SignatureDoesNotMatch",
-		Description:    "Credential should be scoped to correct service: s3.",
 		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrContentSHA256Mismatch: {
@@ -659,7 +593,7 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	},
 	ErrRequestTimeTooSkewed: {
 		Code:           "RequestTimeTooSkewed",
-		Description:    "The difference between the request time and the server's time is too large.",
+		Description:    "The difference between the request time and the current time is too large.",
 		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrInvalidBucketAclWithObjectOwnership: {

--- a/s3err/sigv4.go
+++ b/s3err/sigv4.go
@@ -1,0 +1,77 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package s3err
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// Factory for building AuthorizationHeaderMalformed errors.
+func malformedAuthError(format string, args ...any) APIError {
+	return APIError{
+		Code:           "AuthorizationHeaderMalformed",
+		Description:    fmt.Sprintf("The authorization header is malformed; %s", fmt.Sprintf(format, args...)),
+		HTTPStatusCode: http.StatusForbidden,
+	}
+}
+
+var MalformedAuth = struct {
+	InvalidDateFormat    func(string) APIError
+	MalformedCredential  func() APIError
+	MissingCredential    func() APIError
+	MissingSignature     func() APIError
+	MissingSignedHeaders func() APIError
+	InvalidTerminal      func(string) APIError
+	IncorrectRegion      func(expected, actual string) APIError
+	IncorrectService     func(string) APIError
+	MalformedComponent   func(string) APIError
+	MissingComponents    func() APIError
+	DateMismatch         func() APIError
+}{
+	InvalidDateFormat: func(s string) APIError {
+		return malformedAuthError("incorrect date format %q. This date in the credential must be in the format \"yyyyMMdd\".", s)
+	},
+	MalformedCredential: func() APIError {
+		return malformedAuthError("the Credential is mal-formed; expecting \"<YOUR-AKID>/YYYYMMDD/REGION/SERVICE/aws4_request\".")
+	},
+	MissingCredential: func() APIError {
+		return malformedAuthError("missing Credential.")
+	},
+	MissingSignature: func() APIError {
+		return malformedAuthError("missing Signature.")
+	},
+	MissingSignedHeaders: func() APIError {
+		return malformedAuthError("missing SignedHeaders.")
+	},
+	InvalidTerminal: func(s string) APIError {
+		return malformedAuthError("incorrect terminal %q. This endpoint uses \"aws4_request\".", s)
+	},
+	IncorrectRegion: func(expected, actual string) APIError {
+		return malformedAuthError("the region %q is wrong; expecting %q", actual, expected)
+	},
+	IncorrectService: func(s string) APIError {
+		return malformedAuthError("incorrect service %q. This endpoint belongs to \"s3\".", s)
+	},
+	MalformedComponent: func(s string) APIError {
+		return malformedAuthError("the authorization component %q is malformed.", s)
+	},
+	MissingComponents: func() APIError {
+		return malformedAuthError("the authorization header requires three components: Credential, SignedHeaders, and Signature.")
+	},
+	DateMismatch: func() APIError {
+		return malformedAuthError("The authorization header is malformed; Invalid credential date. Date is not the same as X-Amz-Date.")
+	},
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -17,16 +17,20 @@ package integration
 func TestAuthentication(s *S3Conf) {
 	Authentication_invalid_auth_header(s)
 	Authentication_unsupported_signature_version(s)
-	Authentication_malformed_credentials(s)
-	Authentication_malformed_credentials_invalid_parts(s)
-	Authentication_credentials_terminated_string(s)
+	Authentication_missing_components(s)
+	Authentication_malformed_component(s)
+	Authentication_missing_credentials(s)
+	Authentication_missing_signedheaders(s)
+	Authentication_missing_signature(s)
+	Authentication_malformed_credential(s)
+	Authentication_credentials_invalid_terminal(s)
 	Authentication_credentials_incorrect_service(s)
 	Authentication_credentials_incorrect_region(s)
 	Authentication_credentials_invalid_date(s)
 	Authentication_credentials_future_date(s)
 	Authentication_credentials_past_date(s)
 	Authentication_credentials_non_existing_access_key(s)
-	Authentication_invalid_signed_headers(s)
+	//TODO: handle the case with signed headers
 	Authentication_missing_date_header(s)
 	Authentication_invalid_date_header(s)
 	Authentication_date_mismatch(s)
@@ -37,10 +41,13 @@ func TestAuthentication(s *S3Conf) {
 }
 
 func TestPresignedAuthentication(s *S3Conf) {
+	PresignedAuth_security_token_not_supported(s)
 	PresignedAuth_unsupported_algorithm(s)
+	PresignedAuth_ECDSA_not_supported(s)
+	PresignedAuth_missing_signature_query_param(s)
 	PresignedAuth_missing_credentials_query_param(s)
 	PresignedAuth_malformed_creds_invalid_parts(s)
-	PresignedAuth_malformed_creds_invalid_parts(s)
+	PresignedAuth_creds_invalid_terminal(s)
 	PresignedAuth_creds_incorrect_service(s)
 	PresignedAuth_creds_incorrect_region(s)
 	PresignedAuth_creds_invalid_date(s)
@@ -1020,16 +1027,19 @@ func GetIntTests() IntTests {
 	return IntTests{
 		"Authentication_invalid_auth_header":                                      Authentication_invalid_auth_header,
 		"Authentication_unsupported_signature_version":                            Authentication_unsupported_signature_version,
-		"Authentication_malformed_credentials":                                    Authentication_malformed_credentials,
-		"Authentication_malformed_credentials_invalid_parts":                      Authentication_malformed_credentials_invalid_parts,
-		"Authentication_credentials_terminated_string":                            Authentication_credentials_terminated_string,
+		"Authentication_missing_components":                                       Authentication_missing_components,
+		"Authentication_malformed_component":                                      Authentication_malformed_component,
+		"Authentication_missing_credentials":                                      Authentication_missing_credentials,
+		"Authentication_missing_signedheaders":                                    Authentication_missing_signedheaders,
+		"Authentication_missing_signature":                                        Authentication_missing_signature,
+		"Authentication_malformed_credential":                                     Authentication_malformed_credential,
+		"Authentication_credentials_invalid_terminal":                             Authentication_credentials_invalid_terminal,
 		"Authentication_credentials_incorrect_service":                            Authentication_credentials_incorrect_service,
 		"Authentication_credentials_incorrect_region":                             Authentication_credentials_incorrect_region,
 		"Authentication_credentials_invalid_date":                                 Authentication_credentials_invalid_date,
 		"Authentication_credentials_future_date":                                  Authentication_credentials_future_date,
 		"Authentication_credentials_past_date":                                    Authentication_credentials_past_date,
 		"Authentication_credentials_non_existing_access_key":                      Authentication_credentials_non_existing_access_key,
-		"Authentication_invalid_signed_headers":                                   Authentication_invalid_signed_headers,
 		"Authentication_missing_date_header":                                      Authentication_missing_date_header,
 		"Authentication_invalid_date_header":                                      Authentication_invalid_date_header,
 		"Authentication_date_mismatch":                                            Authentication_date_mismatch,
@@ -1037,10 +1047,13 @@ func GetIntTests() IntTests {
 		"Authentication_invalid_sha256_payload_hash":                              Authentication_invalid_sha256_payload_hash,
 		"Authentication_incorrect_md5":                                            Authentication_incorrect_md5,
 		"Authentication_signature_error_incorrect_secret_key":                     Authentication_signature_error_incorrect_secret_key,
+		"PresignedAuth_security_token_not_supported":                              PresignedAuth_security_token_not_supported,
 		"PresignedAuth_unsupported_algorithm":                                     PresignedAuth_unsupported_algorithm,
+		"PresignedAuth_ECDSA_not_supported":                                       PresignedAuth_ECDSA_not_supported,
+		"PresignedAuth_missing_signature_query_param":                             PresignedAuth_missing_signature_query_param,
 		"PresignedAuth_missing_credentials_query_param":                           PresignedAuth_missing_credentials_query_param,
 		"PresignedAuth_malformed_creds_invalid_parts":                             PresignedAuth_malformed_creds_invalid_parts,
-		"PresignedAuth_creds_invalid_terminator":                                  PresignedAuth_creds_invalid_terminator,
+		"PresignedAuth_creds_invalid_terminal":                                    PresignedAuth_creds_invalid_terminal,
 		"PresignedAuth_creds_incorrect_service":                                   PresignedAuth_creds_incorrect_service,
 		"PresignedAuth_creds_incorrect_region":                                    PresignedAuth_creds_incorrect_region,
 		"PresignedAuth_creds_invalid_date":                                        PresignedAuth_creds_invalid_date,


### PR DESCRIPTION
Fixes #1540
Fixes #1538
Fixes #1513
Fixes #1425

Fixes SigV4 authentication and presigned URL error handling. Adds two sets of errors in the `s3err` package for these authentication mechanisms.

* Adds a check to return a custom "not supported" error when `X-Amz-Security-Token` is present in presigned URLs.
* Adds a check to return a custom "not supported" error when the `AWS4-ECDSA-P256-SHA256` algorithm is used in presigned URLs.