### PR TITLE
fix: changes empty mp parts error on CompleteMultipartUpload

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -278,7 +278,7 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,
 			},
-		}, s3err.GetAPIError(s3err.ErrEmptyParts)
+		}, s3err.GetAPIError(s3err.ErrMalformedXML)
 	}
 
 	var mpuObjectSize *int64

--- a/s3api/controllers/object-post_test.go
+++ b/s3api/controllers/object-post_test.go
@@ -404,7 +404,7 @@ func TestS3ApiController_CompleteMultipartUpload(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrEmptyParts),
+				err: s3err.GetAPIError(s3err.ErrMalformedXML),
 			},
 		},
 		{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -82,7 +82,6 @@ const (
 	ErrInvalidPartNumberMarker
 	ErrInvalidObjectAttributes
 	ErrInvalidPart
-	ErrEmptyParts
 	ErrInvalidPartNumber
 	ErrInvalidPartOrder
 	ErrInvalidCompleteMpPartNumber
@@ -309,11 +308,6 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidPart: {
 		Code:           "InvalidPart",
 		Description:    "One or more of the specified parts could not be found.  The part may not have been uploaded, or the specified entity tag may not match the part's entity tag.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrEmptyParts: {
-		Code:           "InvalidRequest",
-		Description:    "You must specify at least one part",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidPartNumber: {

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -13012,7 +13012,7 @@ func CompleteMultipartUpload_empty_parts(s *S3Conf) error {
 			},
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrEmptyParts)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedXML)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Fixes #1328

If `CompleteMultipartUpload` is attempted with empty `Parts` list, the gateway used to return `InvalidRequest`. Now it's changed to `MalformedXML`.