### PR TITLE
fix: removes trailing / for bucket operations in host-style parser

### DIFF
--- a/s3api/middlewares/host-style-parser.go
+++ b/s3api/middlewares/host-style-parser.go
@@ -32,6 +32,10 @@ func HostStyleParser(virtualDomain string) fiber.Handler {
 			return ctx.Next()
 		}
 		path := ctx.Path()
+		if path == "/" {
+			// omit the trailing / for bucket operations
+			path = ""
+		}
 		pathStyleUrl := fmt.Sprintf("/%v%v", bucket, path)
 		ctx.Path(pathStyleUrl)
 


### PR DESCRIPTION
For bucket operations a typical host-style request looks like `bucket.host/`. `HostStyleParser` parses the bucket from host header and appends in the path, by changing the requests to `path-styled`. For bucket operations the original request path is `bucket.host/`, after reconsturction it looks like `/bucket/`: a trailing `/` is added at the end.

The PR adds a check to not append this trailing `/` at the end for bucket operations, to keep consistency with path-style requests.