### PR TITLE
fix: adds checks for x-amz-content-sha256 in anonymous requests

### DIFF
--- a/s3api/utils/chunk-reader.go
+++ b/s3api/utils/chunk-reader.go
@@ -133,6 +133,25 @@ func IsUnsignedStreamingPayload(str string) bool {
 	return payloadType(str) == payloadTypeStreamingUnsignedTrailer
 }
 
+// IsAnonymousPayloadHashSupported returns error if payload hash
+// is streaming signed.
+// e.g.
+// "STREAMING-AWS4-HMAC-SHA256-PAYLOAD", "STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD" ...
+func IsAnonymousPayloadHashSupported(hash string) error {
+	switch payloadType(hash) {
+	case payloadTypeStreamingEcdsa, payloadTypeStreamingEcdsaTrailer, payloadTypeStreamingSigned, payloadTypeStreamingSignedTrailer:
+		return s3err.GetAPIError(s3err.ErrUnsupportedAnonymousSignedStreaming)
+	}
+
+	return nil
+}
+
+// IsUnsignedPaylod checks if the provided payload hash type
+// is "UNSIGNED-PAYLOAD"
+func IsUnsignedPaylod(hash string) bool {
+	return hash == string(payloadTypeUnsigned)
+}
+
 // IsChunkEncoding checks for streaming/unsigned authorization types
 func IsStreamingPayload(str string) bool {
 	pt := payloadType(str)

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -116,6 +116,7 @@ const (
 	ErrSignatureDoesNotMatch
 	ErrContentSHA256Mismatch
 	ErrInvalidSHA256Paylod
+	ErrUnsupportedAnonymousSignedStreaming
 	ErrMissingContentLength
 	ErrInvalidAccessKeyID
 	ErrRequestNotReadyYet
@@ -479,6 +480,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidSHA256Paylod: {
 		Code:           "InvalidArgument",
 		Description:    "x-amz-content-sha256 must be UNSIGNED-PAYLOAD, STREAMING-UNSIGNED-PAYLOAD-TRAILER, STREAMING-AWS4-HMAC-SHA256-PAYLOAD, STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER, STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD, STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD-TRAILER or a valid sha256 value.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrUnsupportedAnonymousSignedStreaming: {
+		Code:           "InvalidRequest",
+		Description:    "Anonymous requests don't support this x-amz-content-sha256 value. Please use UNSIGNED-PAYLOAD or STREAMING-UNSIGNED-PAYLOAD-TRAILER.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrMissingContentLength: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -926,6 +926,8 @@ func TestPublicBuckets(s *S3Conf) {
 	PublicBucket_public_bucket_policy(s)
 	PublicBucket_public_object_policy(s)
 	PublicBucket_public_acl(s)
+	PublicBucket_signed_streaming_payload(s)
+	PublicBucket_incorrect_sha256_hash(s)
 }
 
 func TestVersioning(s *S3Conf) {
@@ -1534,6 +1536,8 @@ func GetIntTests() IntTests {
 		"PublicBucket_public_bucket_policy":                                       PublicBucket_public_bucket_policy,
 		"PublicBucket_public_object_policy":                                       PublicBucket_public_object_policy,
 		"PublicBucket_public_acl":                                                 PublicBucket_public_acl,
+		"PublicBucket_signed_streaming_payload":                                   PublicBucket_signed_streaming_payload,
+		"PublicBucket_incorrect_sha256_hash":                                      PublicBucket_incorrect_sha256_hash,
 		"PutBucketVersioning_non_existing_bucket":                                 PutBucketVersioning_non_existing_bucket,
 		"PutBucketVersioning_invalid_status":                                      PutBucketVersioning_invalid_status,
 		"PutBucketVersioning_success_enabled":                                     PutBucketVersioning_success_enabled,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1064,8 +1064,7 @@ func grantPublicBucketPolicy(client *s3.Client, bucket string, tp policyType) er
 	case policyTypeObject:
 		doc = genPolicyDoc("Allow", `"*"`, `"s3:*"`, fmt.Sprintf(`"arn:aws:s3:::%s/*"`, bucket))
 	case policyTypeFull:
-		template := `
-		{
+		template := `{
 			"Statement": [
 				{
 					"Effect":  "Allow",


### PR DESCRIPTION
Fixes #1554
Fixes #1423

The gateway previously ignored the `x-amz-content-sha256` header for anonymous unsigned requests to public buckets. This PR adds hash calculation for this header and correctly handles special payload types.

It also fixes the case where a signed streaming payload (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD...`) is used with anonymous requests. In this scenario, the gateway now returns a specific "not supported" error, consistent with S3 behavior.