### PR TITLE
feat: implements fiber panic recovery

### DIFF
--- a/debuglogger/logger.go
+++ b/debuglogger/logger.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync/atomic"
 
@@ -25,17 +26,38 @@ import (
 )
 
 type Color string
+type prefix string
 
 const (
 	green  Color = "\033[32m"
 	yellow Color = "\033[33m"
 	blue   Color = "\033[34m"
+	red    Color = "\033[31m"
 	Purple Color = "\033[0;35m"
+
+	prefixPanic        prefix = "[PANIC]: "
+	prefixInernalError prefix = "[INTERNAL ERROR]: "
+	prefixInfo         prefix = "[INFO]: "
+	prefixDebug        prefix = "[DEBUG]: "
 
 	reset      = "\033[0m"
 	borderChar = "─"
 	boxWidth   = 120
 )
+
+// Panic prints the panics out in the console
+func Panic(er error) {
+	printError(prefixPanic, er)
+}
+
+// InernalError prints the internal error out in the console
+func InernalError(er error) {
+	printError(prefixInernalError, er)
+}
+
+func printError(prefix prefix, er error) {
+	fmt.Fprintf(os.Stderr, string(red)+string(prefix)+"%v"+reset+"\n", er)
+}
 
 // Logs http request details: headers, body, params, query args
 func LogFiberRequestDetails(ctx *fiber.Ctx) {
@@ -102,8 +124,8 @@ func Logf(format string, v ...any) {
 	if !debugEnabled.Load() {
 		return
 	}
-	debugPrefix := "[DEBUG]: "
-	fmt.Printf(string(yellow)+debugPrefix+format+reset+"\n", v...)
+
+	fmt.Printf(string(yellow)+string(prefixDebug)+format+reset+"\n", v...)
 }
 
 // Infof prints out green info block with [INFO]: prefix
@@ -111,8 +133,8 @@ func Infof(format string, v ...any) {
 	if !debugEnabled.Load() {
 		return
 	}
-	debugPrefix := "[INFO]: "
-	fmt.Printf(string(green)+debugPrefix+format+reset+"\n", v...)
+
+	fmt.Printf(string(green)+string(prefixInfo)+format+reset+"\n", v...)
 }
 
 var debugIAMEnabled atomic.Bool
@@ -133,8 +155,8 @@ func IAMLogf(format string, v ...any) {
 	if !debugIAMEnabled.Load() {
 		return
 	}
-	debugPrefix := "[DEBUG]: "
-	fmt.Printf(string(yellow)+debugPrefix+format+reset+"\n", v...)
+
+	fmt.Printf(string(yellow)+string(prefixDebug)+format+reset+"\n", v...)
 }
 
 // PrintInsideHorizontalBorders prints the text inside horizontal

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -18,7 +18,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/versity/versitygw/auth"
@@ -201,7 +200,7 @@ func ProcessController(ctx *fiber.Ctx, controller Controller, s3action string, s
 			return ctx.Send(s3err.GetAPIErrorResponse(serr, "", "", ""))
 		}
 
-		fmt.Fprintf(os.Stderr, "Internal Error, %v\n", err)
+		debuglogger.InernalError(err)
 		ctx.Status(http.StatusInternalServerError)
 
 		// If the error is not 's3err.APIError' return 'InternalError'

--- a/s3api/server_test.go
+++ b/s3api/server_test.go
@@ -16,65 +16,11 @@ package s3api
 
 import (
 	"crypto/tls"
-	"reflect"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
-	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/backend"
-	"github.com/versity/versitygw/s3api/middlewares"
 )
-
-func TestNew(t *testing.T) {
-	type args struct {
-		app  *fiber.App
-		be   backend.Backend
-		port string
-		root middlewares.RootUserConfig
-	}
-
-	app := fiber.New()
-	be := backend.BackendUnsupported{}
-	router := S3ApiRouter{}
-	port := ":7070"
-
-	tests := []struct {
-		name            string
-		args            args
-		wantS3ApiServer *S3ApiServer
-		wantErr         bool
-	}{
-		{
-			name: "Create S3 api server",
-			args: args{
-				app:  app,
-				be:   be,
-				port: port,
-				root: middlewares.RootUserConfig{},
-			},
-			wantS3ApiServer: &S3ApiServer{
-				app:     app,
-				port:    port,
-				router:  &router,
-				backend: be,
-			},
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotS3ApiServer, err := New(tt.args.app, tt.args.be, tt.args.root,
-				tt.args.port, "us-east-1", &auth.IAMServiceInternal{}, nil, nil, nil, nil)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !reflect.DeepEqual(gotS3ApiServer, tt.wantS3ApiServer) {
-				t.Errorf("New() = %v, want %v", gotS3ApiServer, tt.wantS3ApiServer)
-			}
-		})
-	}
-}
 
 func TestS3ApiServer_Serve(t *testing.T) {
 	tests := []struct {

--- a/s3api/utils/context-keys.go
+++ b/s3api/utils/context-keys.go
@@ -19,7 +19,7 @@ import (
 )
 
 // Region, StartTime, IsRoot, Account, AccessKey context locals
-// are set to defualut values in middlewares.SetDefaultValues
+// are set to default values in middlewares.SetDefaultValues
 // to avoid the nil interface conversions
 type ContextKey string
 
@@ -35,6 +35,7 @@ const (
 	ContextKeySkipResBodyLog ContextKey = "skip-res-body-log"
 	ContextKeyBodyReader     ContextKey = "body-reader"
 	ContextKeySkip           ContextKey = "__skip"
+	ContextKeyStack          ContextKey = "stack"
 )
 
 func (ck ContextKey) Values() []ContextKey {


### PR DESCRIPTION
Fiber includes a built-in panic recovery middleware that catches panics in route handlers and middlewares, preventing the server from crashing and allowing it to recover. Alongside this, a stack trace handler has been implemented to store system panics in the context locals (stack).

Both the S3 API server and the Admin server use a global error handler to catch unexpected exceptions and recovered panics. The middleware’s logic is to log the panic or internal error and return an S3-style internal server error response.

Additionally, dedicated **Panic** and **InternalError** loggers have been added to the `s3api` debug logger to record system panics and internal errors in the console.