### PR TITLE
fix: fixes PutObjectRetention error cases and object lock error code/message.

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -90,7 +90,7 @@ type Backend interface {
 	// object lock operations
 	PutObjectLockConfiguration(_ context.Context, bucket string, config []byte) error
 	GetObjectLockConfiguration(_ context.Context, bucket string) ([]byte, error)
-	PutObjectRetention(_ context.Context, bucket, object, versionId string, bypass bool, retention []byte) error
+	PutObjectRetention(_ context.Context, bucket, object, versionId string, retention []byte) error
 	GetObjectRetention(_ context.Context, bucket, object, versionId string) ([]byte, error)
 	PutObjectLegalHold(_ context.Context, bucket, object, versionId string, status bool) error
 	GetObjectLegalHold(_ context.Context, bucket, object, versionId string) (*bool, error)
@@ -267,7 +267,7 @@ func (BackendUnsupported) PutObjectLockConfiguration(_ context.Context, bucket s
 func (BackendUnsupported) GetObjectLockConfiguration(_ context.Context, bucket string) ([]byte, error) {
 	return nil, s3err.GetAPIError(s3err.ErrNotImplemented)
 }
-func (BackendUnsupported) PutObjectRetention(_ context.Context, bucket, object, versionId string, bypass bool, retention []byte) error {
+func (BackendUnsupported) PutObjectRetention(_ context.Context, bucket, object, versionId string, retention []byte) error {
 	return s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 func (BackendUnsupported) GetObjectRetention(_ context.Context, bucket, object, versionId string) ([]byte, error) {

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -1558,7 +1558,7 @@ func (s *S3Proxy) GetObjectLockConfiguration(ctx context.Context, bucket string)
 	return nil, s3err.GetAPIError(s3err.ErrObjectLockConfigurationNotFound)
 }
 
-func (s *S3Proxy) PutObjectRetention(ctx context.Context, bucket, object, versionId string, bypass bool, retention []byte) error {
+func (s *S3Proxy) PutObjectRetention(ctx context.Context, bucket, object, versionId string, retention []byte) error {
 	return s3err.GetAPIError(s3err.ErrNotImplemented)
 }
 

--- a/s3api/controllers/backend_moq_test.go
+++ b/s3api/controllers/backend_moq_test.go
@@ -161,7 +161,7 @@ var _ backend.Backend = &BackendMock{}
 //			PutObjectLockConfigurationFunc: func(contextMoqParam context.Context, bucket string, config []byte) error {
 //				panic("mock out the PutObjectLockConfiguration method")
 //			},
-//			PutObjectRetentionFunc: func(contextMoqParam context.Context, bucket string, object string, versionId string, bypass bool, retention []byte) error {
+//			PutObjectRetentionFunc: func(contextMoqParam context.Context, bucket string, object string, versionId string, retention []byte) error {
 //				panic("mock out the PutObjectRetention method")
 //			},
 //			PutObjectTaggingFunc: func(contextMoqParam context.Context, bucket string, object string, tags map[string]string) error {
@@ -331,7 +331,7 @@ type BackendMock struct {
 	PutObjectLockConfigurationFunc func(contextMoqParam context.Context, bucket string, config []byte) error
 
 	// PutObjectRetentionFunc mocks the PutObjectRetention method.
-	PutObjectRetentionFunc func(contextMoqParam context.Context, bucket string, object string, versionId string, bypass bool, retention []byte) error
+	PutObjectRetentionFunc func(contextMoqParam context.Context, bucket string, object string, versionId string, retention []byte) error
 
 	// PutObjectTaggingFunc mocks the PutObjectTagging method.
 	PutObjectTaggingFunc func(contextMoqParam context.Context, bucket string, object string, tags map[string]string) error
@@ -722,8 +722,6 @@ type BackendMock struct {
 			Object string
 			// VersionId is the versionId argument value.
 			VersionId string
-			// Bypass is the bypass argument value.
-			Bypass bool
 			// Retention is the retention argument value.
 			Retention []byte
 		}
@@ -2554,7 +2552,7 @@ func (mock *BackendMock) PutObjectLockConfigurationCalls() []struct {
 }
 
 // PutObjectRetention calls PutObjectRetentionFunc.
-func (mock *BackendMock) PutObjectRetention(contextMoqParam context.Context, bucket string, object string, versionId string, bypass bool, retention []byte) error {
+func (mock *BackendMock) PutObjectRetention(contextMoqParam context.Context, bucket string, object string, versionId string, retention []byte) error {
 	if mock.PutObjectRetentionFunc == nil {
 		panic("BackendMock.PutObjectRetentionFunc: method is nil but Backend.PutObjectRetention was just called")
 	}
@@ -2563,20 +2561,18 @@ func (mock *BackendMock) PutObjectRetention(contextMoqParam context.Context, buc
 		Bucket          string
 		Object          string
 		VersionId       string
-		Bypass          bool
 		Retention       []byte
 	}{
 		ContextMoqParam: contextMoqParam,
 		Bucket:          bucket,
 		Object:          object,
 		VersionId:       versionId,
-		Bypass:          bypass,
 		Retention:       retention,
 	}
 	mock.lockPutObjectRetention.Lock()
 	mock.calls.PutObjectRetention = append(mock.calls.PutObjectRetention, callInfo)
 	mock.lockPutObjectRetention.Unlock()
-	return mock.PutObjectRetentionFunc(contextMoqParam, bucket, object, versionId, bypass, retention)
+	return mock.PutObjectRetentionFunc(contextMoqParam, bucket, object, versionId, retention)
 }
 
 // PutObjectRetentionCalls gets all the calls that were made to PutObjectRetention.
@@ -2588,7 +2584,6 @@ func (mock *BackendMock) PutObjectRetentionCalls() []struct {
 	Bucket          string
 	Object          string
 	VersionId       string
-	Bypass          bool
 	Retention       []byte
 } {
 	var calls []struct {
@@ -2596,7 +2591,6 @@ func (mock *BackendMock) PutObjectRetentionCalls() []struct {
 		Bucket          string
 		Object          string
 		VersionId       string
-		Bypass          bool
 		Retention       []byte
 	}
 	mock.lockPutObjectRetention.RLock()

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -553,9 +553,9 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		HTTPStatusCode: http.StatusConflict,
 	},
 	ErrObjectLocked: {
-		Code:           "InvalidRequest",
-		Description:    "Object is WORM protected and cannot be overwritten.",
-		HTTPStatusCode: http.StatusBadRequest,
+		Code:           "AccessDenied",
+		Description:    "Access Denied because object protected by object lock.",
+		HTTPStatusCode: http.StatusForbidden,
 	},
 	ErrPastObjectLockRetainDate: {
 		Code:           "InvalidRequest",

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -619,6 +619,8 @@ func TestPutObjectRetention(s *S3Conf) {
 	PutObjectRetention_expired_retain_until_date(s)
 	PutObjectRetention_invalid_mode(s)
 	PutObjectRetention_overwrite_compliance_mode(s)
+	PutObjectRetention_overwrite_compliance_with_compliance(s)
+	PutObjectRetention_overwrite_governance_with_governance(s)
 	PutObjectRetention_overwrite_governance_without_bypass_specified(s)
 	PutObjectRetention_overwrite_governance_with_permission(s)
 	PutObjectRetention_success(s)
@@ -1440,6 +1442,8 @@ func GetIntTests() IntTests {
 		"PutObjectRetention_expired_retain_until_date":                            PutObjectRetention_expired_retain_until_date,
 		"PutObjectRetention_invalid_mode":                                         PutObjectRetention_invalid_mode,
 		"PutObjectRetention_overwrite_compliance_mode":                            PutObjectRetention_overwrite_compliance_mode,
+		"PutObjectRetention_overwrite_compliance_with_compliance":                 PutObjectRetention_overwrite_compliance_with_compliance,
+		"PutObjectRetention_overwrite_governance_with_governance":                 PutObjectRetention_overwrite_governance_with_governance,
 		"PutObjectRetention_overwrite_governance_without_bypass_specified":        PutObjectRetention_overwrite_governance_without_bypass_specified,
 		"PutObjectRetention_overwrite_governance_with_permission":                 PutObjectRetention_overwrite_governance_with_permission,
 		"PutObjectRetention_success":                                              PutObjectRetention_success,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -1139,15 +1139,9 @@ func checkWORMProtection(client *s3.Client, bucket, object string) error {
 		Key:    &object,
 	})
 	cancel()
-	if err := checkSdkApiErr(err, "InvalidRequest"); err != nil {
+	if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectLocked)); err != nil {
 		return err
 	}
-	// client sdk regression issue prevents getting full error message,
-	// change back to below once this is fixed:
-	// https://github.com/aws/aws-sdk-go-v2/issues/2921
-	// if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectLocked)); err != nil {
-	// 	return err
-	// }
 
 	ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
 	_, err = client.DeleteObject(ctx, &s3.DeleteObjectInput{
@@ -1155,15 +1149,9 @@ func checkWORMProtection(client *s3.Client, bucket, object string) error {
 		Key:    &object,
 	})
 	cancel()
-	if err := checkSdkApiErr(err, "InvalidRequest"); err != nil {
+	if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectLocked)); err != nil {
 		return err
 	}
-	// client sdk regression issue prevents getting full error message,
-	// change back to below once this is fixed:
-	// https://github.com/aws/aws-sdk-go-v2/issues/2921
-	// if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectLocked)); err != nil {
-	// 	return err
-	// }
 
 	ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
 	_, err = client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
@@ -1177,15 +1165,9 @@ func checkWORMProtection(client *s3.Client, bucket, object string) error {
 		},
 	})
 	cancel()
-	if err := checkSdkApiErr(err, "InvalidRequest"); err != nil {
+	if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectLocked)); err != nil {
 		return err
 	}
-	// client sdk regression issue prevents getting full error message,
-	// change back to below once this is fixed:
-	// https://github.com/aws/aws-sdk-go-v2/issues/2921
-	// if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrObjectLocked)); err != nil {
-	// 	return err
-	// }
 
 	return nil
 }


### PR DESCRIPTION
Fixes #1559
Fixes #1330

This PR focuses on three main changes:

1. **Fix object lock error codes and descriptions** When an object was WORM-protected and delete/overwrite was disallowed due to object lock configurations, the gateway incorrectly returned the `s3.ErrObjectLocked` error code and description. These have now been corrected.
2. **Update `PutObjectRetention` behavior** Previously, when an object already had a retention mode set, the gateway only allowed modifications if the mode was changed from `GOVERNANCE` to `COMPLIANCE`, and only when the user had the `s3:BypassGovernanceRetention` permission. The logic has been updated: if the existing retention mode is the same as the one being applied, the operation is now allowed regardless of other factors.
3. **Fix error checks in integration tests (AWS SDK regression)** Due to an AWS SDK regression, integration tests were previously limited to checking partial error descriptions. This issue seems to be resolved for some actions (though the ticket is still open: https://github.com/aws/aws-sdk-go-v2/issues/2921). Error checks have been reverted back to full description comparisons where possible.