### PR TITLE
fix: correct a few object lock behaviors

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1644,24 +1644,6 @@ func (az *Azure) DeleteBucketCors(ctx context.Context, bucket string) error {
 }
 
 func (az *Azure) PutObjectLockConfiguration(ctx context.Context, bucket string, config []byte) error {
-	cfg, err := az.getContainerMetaData(ctx, bucket, string(keyBucketLock))
-	if err != nil {
-		return err
-	}
-
-	if len(cfg) == 0 {
-		return s3err.GetAPIError(s3err.ErrObjectLockConfigurationNotAllowed)
-	}
-
-	var bucketLockCfg auth.BucketLockConfig
-	if err := json.Unmarshal(cfg, &bucketLockCfg); err != nil {
-		return fmt.Errorf("unmarshal object lock config: %w", err)
-	}
-
-	if !bucketLockCfg.Enabled {
-		return s3err.GetAPIError(s3err.ErrObjectLockConfigurationNotAllowed)
-	}
-
 	return az.setContainerMetaData(ctx, bucket, string(keyBucketLock), config)
 }
 

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -549,7 +549,7 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	},
 	ErrObjectLockConfigurationNotAllowed: {
 		Code:           "InvalidBucketState",
-		Description:    "Object Lock configuration cannot be enabled on existing buckets.",
+		Description:    "Versioning must be 'Enabled' on the bucket to apply a Object Lock configuration",
 		HTTPStatusCode: http.StatusConflict,
 	},
 	ErrObjectLocked: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -597,7 +597,9 @@ func TestCORSMiddleware(s *S3Conf) {
 func TestPutObjectLockConfiguration(s *S3Conf) {
 	PutObjectLockConfiguration_non_existing_bucket(s)
 	PutObjectLockConfiguration_empty_config(s)
-	PutObjectLockConfiguration_not_enabled_on_bucket_creation(s)
+	if !s.versioningEnabled {
+		PutObjectLockConfiguration_not_enabled_on_bucket_creation(s)
+	}
 	PutObjectLockConfiguration_invalid_status(s)
 	PutObjectLockConfiguration_invalid_mode(s)
 	PutObjectLockConfiguration_both_years_and_days(s)
@@ -615,7 +617,6 @@ func TestPutObjectRetention(s *S3Conf) {
 	PutObjectRetention_non_existing_bucket(s)
 	PutObjectRetention_non_existing_object(s)
 	PutObjectRetention_unset_bucket_object_lock_config(s)
-	PutObjectRetention_disabled_bucket_object_lock_config(s)
 	PutObjectRetention_expired_retain_until_date(s)
 	PutObjectRetention_invalid_mode(s)
 	PutObjectRetention_overwrite_compliance_mode(s)
@@ -640,7 +641,6 @@ func TestPutObjectLegalHold(s *S3Conf) {
 	PutObjectLegalHold_invalid_body(s)
 	PutObjectLegalHold_invalid_status(s)
 	PutObjectLegalHold_unset_bucket_object_lock_config(s)
-	PutObjectLegalHold_disabled_bucket_object_lock_config(s)
 	PutObjectLegalHold_success(s)
 }
 
@@ -773,7 +773,9 @@ func TestFullFlow(s *S3Conf) {
 	TestGetObjectRetention(s)
 	TestPutObjectLegalHold(s)
 	TestGetObjectLegalHold(s)
-	TestWORMProtection(s)
+	if !s.versioningEnabled {
+		TestWORMProtection(s)
+	}
 	TestAccessControl(s)
 	TestRouter(s)
 	// FIXME: The tests should pass for azure as well
@@ -926,7 +928,14 @@ func TestAccessControl(s *S3Conf) {
 func TestPublicBuckets(s *S3Conf) {
 	PublicBucket_default_private_bucket(s)
 	PublicBucket_public_bucket_policy(s)
-	PublicBucket_public_object_policy(s)
+	if !s.versioningEnabled {
+		// This test targets gateway actions when bucket grants
+		// public access to object operations: no specific
+		// bucket versioning operations. As object version cleanup
+		// is hard to perform, run the test only on the versioning-disabled
+		// gateway instance
+		PublicBucket_public_object_policy(s)
+	}
 	PublicBucket_public_acl(s)
 	PublicBucket_signed_streaming_payload(s)
 	PublicBucket_incorrect_sha256_hash(s)
@@ -993,6 +1002,7 @@ func TestVersioning(s *S3Conf) {
 	Versioning_UploadPartCopy_non_existing_versionId(s)
 	Versioning_UploadPartCopy_from_an_object_version(s)
 	// Object lock configuration
+	Versioning_object_lock_not_enabled_on_bucket_creation(s)
 	Versioning_Enable_object_lock(s)
 	Versioning_status_switch_to_suspended_with_object_lock(s)
 	// Object-Lock Retention
@@ -1438,7 +1448,6 @@ func GetIntTests() IntTests {
 		"PutObjectRetention_non_existing_bucket":                                  PutObjectRetention_non_existing_bucket,
 		"PutObjectRetention_non_existing_object":                                  PutObjectRetention_non_existing_object,
 		"PutObjectRetention_unset_bucket_object_lock_config":                      PutObjectRetention_unset_bucket_object_lock_config,
-		"PutObjectRetention_disabled_bucket_object_lock_config":                   PutObjectRetention_disabled_bucket_object_lock_config,
 		"PutObjectRetention_expired_retain_until_date":                            PutObjectRetention_expired_retain_until_date,
 		"PutObjectRetention_invalid_mode":                                         PutObjectRetention_invalid_mode,
 		"PutObjectRetention_overwrite_compliance_mode":                            PutObjectRetention_overwrite_compliance_mode,
@@ -1457,7 +1466,6 @@ func GetIntTests() IntTests {
 		"PutObjectLegalHold_invalid_body":                                         PutObjectLegalHold_invalid_body,
 		"PutObjectLegalHold_invalid_status":                                       PutObjectLegalHold_invalid_status,
 		"PutObjectLegalHold_unset_bucket_object_lock_config":                      PutObjectLegalHold_unset_bucket_object_lock_config,
-		"PutObjectLegalHold_disabled_bucket_object_lock_config":                   PutObjectLegalHold_disabled_bucket_object_lock_config,
 		"PutObjectLegalHold_success":                                              PutObjectLegalHold_success,
 		"GetObjectLegalHold_non_existing_bucket":                                  GetObjectLegalHold_non_existing_bucket,
 		"GetObjectLegalHold_non_existing_object":                                  GetObjectLegalHold_non_existing_object,
@@ -1590,6 +1598,7 @@ func GetIntTests() IntTests {
 		"Versioning_Multipart_Upload_overwrite_an_object":                         Versioning_Multipart_Upload_overwrite_an_object,
 		"Versioning_UploadPartCopy_non_existing_versionId":                        Versioning_UploadPartCopy_non_existing_versionId,
 		"Versioning_UploadPartCopy_from_an_object_version":                        Versioning_UploadPartCopy_from_an_object_version,
+		"Versioning_object_lock_not_enabled_on_bucket_creation":                   Versioning_object_lock_not_enabled_on_bucket_creation,
 		"Versioning_Enable_object_lock":                                           Versioning_Enable_object_lock,
 		"Versioning_status_switch_to_suspended_with_object_lock":                  Versioning_status_switch_to_suspended_with_object_lock,
 		"Versioning_PutObjectRetention_invalid_versionId":                         Versioning_PutObjectRetention_invalid_versionId,


### PR DESCRIPTION
Fixes #1565
Fixes #1561
Fixes #1300

This PR focuses on three main changes:

1. **Prioritizing object-level lock configuration over bucket-level default retention** When an object is uploaded with a specific retention configuration, it takes precedence over the bucket’s default retention set via `PutObjectLockConfiguration`. If the object’s retention expires, the object must become available for write operations, even if the bucket-level default retention is still active.

2. **Preventing object lock configuration from being disabled once enabled** To align with AWS S3 behavior, once object lock is enabled for a bucket, it can no longer be disabled. Previously, sending an empty `Enabled` field in the payload would disable object lock. Now, this behavior is removed—an empty `Enabled` field will result in a `MalformedXML` error. This creates a challenge for integration tests that need to clean up locked objects in order to delete the bucket. To handle this, a method has been implemented that:

   * Removes any legal hold if present.
   * Applies a temporary retention with a "retain until" date set 3 seconds ahead.
   * Waits for 3 seconds before deleting the object and bucket.

3. **Allowing object lock to be enabled on existing buckets via `PutObjectLockConfiguration`** Object lock can now be enabled on an existing bucket if it wasn’t enabled at creation time.

   * If versioning is enabled at the gateway level, the behavior matches AWS S3: object lock can only be enabled when bucket versioning status is `Enabled`.
   * If versioning is not enabled at the gateway level, object lock can always be enabled on existing buckets via `PutObjectLockConfiguration`.
   * In Azure (which does not support bucket versioning), enabling object lock is always allowed.

   This change also fixes the error message returned in this scenario for better clarity.