### PR TITLE
auth/vault: add Vault namespace support

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -107,42 +107,45 @@ var (
 )
 
 type Opts struct {
-	RootAccount            Account
-	Dir                    string
-	LDAPServerURL          string
-	LDAPBindDN             string
-	LDAPPassword           string
-	LDAPQueryBase          string
-	LDAPObjClasses         string
-	LDAPAccessAtr          string
-	LDAPSecretAtr          string
-	LDAPRoleAtr            string
-	LDAPUserIdAtr          string
-	LDAPGroupIdAtr         string
-	VaultEndpointURL       string
-	VaultSecretStoragePath string
-	VaultAuthMethod        string
-	VaultMountPath         string
-	VaultRootToken         string
-	VaultRoleId            string
-	VaultRoleSecret        string
-	VaultServerCert        string
-	VaultClientCert        string
-	VaultClientCertKey     string
-	S3Access               string
-	S3Secret               string
-	S3Region               string
-	S3Bucket               string
-	S3Endpoint             string
-	S3DisableSSlVerfiy     bool
-	CacheDisable           bool
-	CacheTTL               int
-	CachePrune             int
-	IpaHost                string
-	IpaVaultName           string
-	IpaUser                string
-	IpaPassword            string
-	IpaInsecure            bool
+	RootAccount                 Account
+	Dir                         string
+	LDAPServerURL               string
+	LDAPBindDN                  string
+	LDAPPassword                string
+	LDAPQueryBase               string
+	LDAPObjClasses              string
+	LDAPAccessAtr               string
+	LDAPSecretAtr               string
+	LDAPRoleAtr                 string
+	LDAPUserIdAtr               string
+	LDAPGroupIdAtr              string
+	VaultEndpointURL            string
+	VaultNamespace              string
+	VaultSecretStoragePath      string
+	VaultSecretStorageNamespace string
+	VaultAuthMethod             string
+	VaultAuthNamespace          string
+	VaultMountPath              string
+	VaultRootToken              string
+	VaultRoleId                 string
+	VaultRoleSecret             string
+	VaultServerCert             string
+	VaultClientCert             string
+	VaultClientCertKey          string
+	S3Access                    string
+	S3Secret                    string
+	S3Region                    string
+	S3Bucket                    string
+	S3Endpoint                  string
+	S3DisableSSlVerfiy          bool
+	CacheDisable                bool
+	CacheTTL                    int
+	CachePrune                  int
+	IpaHost                     string
+	IpaVaultName                string
+	IpaUser                     string
+	IpaPassword                 string
+	IpaInsecure                 bool
 }
 
 func New(o *Opts) (IAMService, error) {
@@ -164,8 +167,8 @@ func New(o *Opts) (IAMService, error) {
 		fmt.Printf("initializing S3 IAM with '%v/%v'\n",
 			o.S3Endpoint, o.S3Bucket)
 	case o.VaultEndpointURL != "":
-		svc, err = NewVaultIAMService(o.RootAccount, o.VaultEndpointURL, o.VaultSecretStoragePath,
-			o.VaultAuthMethod, o.VaultMountPath, o.VaultRootToken, o.VaultRoleId, o.VaultRoleSecret,
+		svc, err = NewVaultIAMService(o.RootAccount, o.VaultEndpointURL, o.VaultNamespace, o.VaultSecretStoragePath, o.VaultSecretStorageNamespace,
+			o.VaultAuthMethod, o.VaultAuthNamespace, o.VaultMountPath, o.VaultRootToken, o.VaultRoleId, o.VaultRoleSecret,
 			o.VaultServerCert, o.VaultClientCert, o.VaultClientCertKey)
 		fmt.Printf("initializing Vault IAM with %q\n", o.VaultEndpointURL)
 	case o.IpaHost != "":


### PR DESCRIPTION
# Add Vault namespace support to IAM

This adds namespace aware config for Vault (or OpenBao). Namespaces are applied with `vault.WithNamespace(...)` on both auth requests and KV operations.

## New optional CLI flags

- `--iam-vault-namespace`
- `--iam-vault-auth-namespace`
- `--iam-vault-secret-storage-namespace`

## Behavior

- Auth requests use the auth namespace  
- KV operations use the secret storage namespace  
- If a specific namespace is not set, the shared namespace is used  
- With AppRole, different auth and secret namespaces are rejected. Root token allows different namespaces

## Notes

- OpenBao recently added namespaces (not available in Vault Community edition): https://openbao.org/blog/namespaces-announcement
- The CLI parameter `--iam-vault-auth-namespace` should maybe be removed, it might not make sense because AppRole tokens are scoped to a single namespace and root token flows do not use auth at all
- First time writing Go here, but I decided to give it a Go anyway 😜 feedback welcome

## Testing

```bash
# Start OpenBao in dev
bao server -dev -dev-root-token-id=dev-root-token

# Point CLI and log in
export BAO_DEV_ROOT_TOKEN="dev-root-token"
export BAO_ADDR="http://localhost:8200"
bao login "$BAO_DEV_ROOT_TOKEN"

# Create namespace
bao namespace create versitygw

# Enable KV v2 at default mount kv-v2
bao secrets enable -ns versitygw kv-v2

# Policy for kv-v2/data/versitygw/*
bao policy write -ns versitygw vgw-policy - <<'EOF'
path "kv-v2/data/versitygw/*"     { capabilities = ["create", "read", "update", "delete", "list"] }
path "kv-v2/metadata"              { capabilities = ["read", "list"] }
path "kv-v2/metadata/versitygw/*"  { capabilities = ["read", "list", "delete", "update"] }
EOF

# Enable AppRole and bind the policy
bao auth enable -ns versitygw approle
bao write -ns versitygw auth/approle/role/versitygw \
  token_policies=vgw-policy \
  token_period=24h \
  secret_id_ttl=0 \
  secret_id_num_uses=0

# Fetch role and secret ids
ROLE_ID=$(bao read -ns versitygw -format=json auth/approle/role/versitygw/role-id | jq -r .data.role_id)
SECRET_ID=$(bao write -ns versitygw -f -format=json auth/approle/role/versitygw/secret-id | jq -r .data.secret_id)

# Start VersityGW with AppRole
go run ./cmd/versitygw \
  --debug \
  --iam-vault-endpoint-url "$BAO_ADDR" \
  --iam-vault-namespace versitygw \
  --iam-vault-role-id "$ROLE_ID" \
  --iam-vault-role-secret "$SECRET_ID" \
  --iam-vault-secret-storage-path versitygw \
  --access test \
  --secret test \
  posix /tmp/gw

# Or with a root token targeting the secret namespace
go run ./cmd/versitygw \
  --debug \
  --iam-vault-endpoint-url "$BAO_ADDR" \
  --iam-vault-root-token "$BAO_DEV_ROOT_TOKEN" \
  --iam-vault-secret-storage-path versitygw \
  --iam-vault-secret-storage-namespace versitygw \
  --access test \
  --secret test \
  posix /tmp/gw

# Admin actions
export ADMIN_ACCESS_KEY=test
export ADMIN_SECRET_KEY=test
export ADMIN_ENDPOINT_URL=http://localhost:7070

go run ./cmd/versitygw admin create-user --access myuser --secret upass --role user
go run ./cmd/versitygw admin list-users
go run ./cmd/versitygw admin delete-user --access myuser
