### PR TITLE
feat: add option to disable strict bucket name checks

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -570,3 +570,19 @@ func EvaluateObjectDeletePreconditions(etag string, modTime time.Time, size int6
 
 	return nil
 }
+
+// IsValidDirectoryName returns true if the string is a valid name
+// for a directory
+func IsValidDirectoryName(name string) bool {
+	// directories may not contain a path separator
+	if strings.ContainsRune(name, '/') {
+		return false
+	}
+
+	// directories may not contain null character
+	if strings.ContainsRune(name, 0) {
+		return false
+	}
+
+	return true
+}

--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -30,11 +30,12 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 	metastore := meta.XattrMeta{}
 
 	p, err := posix.New(rootdir, metastore, posix.PosixOpts{
-		ChownUID:      opts.ChownUID,
-		ChownGID:      opts.ChownGID,
-		BucketLinks:   opts.BucketLinks,
-		NewDirPerm:    opts.NewDirPerm,
-		VersioningDir: opts.VersioningDir,
+		ChownUID:            opts.ChownUID,
+		ChownGID:            opts.ChownGID,
+		BucketLinks:         opts.BucketLinks,
+		NewDirPerm:          opts.NewDirPerm,
+		VersioningDir:       opts.VersioningDir,
+		ValidateBucketNames: opts.ValidateBucketNames,
 	})
 	if err != nil {
 		return nil, err

--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/versity/versitygw/metrics"
 	"github.com/versity/versitygw/s3api"
 	"github.com/versity/versitygw/s3api/middlewares"
+	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3event"
 	"github.com/versity/versitygw/s3log"
 )
@@ -58,6 +59,7 @@ var (
 	pprof                                  string
 	quiet                                  bool
 	readonly                               bool
+	disableStrictBucketNames               bool
 	iamDir                                 string
 	ldapURL, ldapBindDN, ldapPassword      string
 	ldapQueryBase, ldapObjClasses          string
@@ -557,6 +559,12 @@ func initFlags() []cli.Flag {
 			EnvVars:     []string{"VGW_READ_ONLY"},
 			Destination: &readonly,
 		},
+		&cli.BoolFlag{
+			Name:        "disable-strict-bucket-names",
+			Usage:       "allow relaxed bucket naming (disables strict validation checks)",
+			EnvVars:     []string{"VGW_DISABLE_STRICT_BUCKET_NAMES"},
+			Destination: &disableStrictBucketNames,
+		},
 		&cli.StringFlag{
 			Name:        "metrics-service-name",
 			Usage:       "service name tag for metrics, hostname if blank",
@@ -615,6 +623,8 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 	if rootUserAccess == "" || rootUserSecret == "" {
 		return fmt.Errorf("root user access and secret key must be provided")
 	}
+
+	utils.SetBucketNameValidationStrict(!disableStrictBucketNames)
 
 	if pprof != "" {
 		// listen on specified port for pprof debug

--- a/cmd/versitygw/posix.go
+++ b/cmd/versitygw/posix.go
@@ -120,12 +120,13 @@ func runPosix(ctx *cli.Context) error {
 	}
 
 	opts := posix.PosixOpts{
-		ChownUID:       chownuid,
-		ChownGID:       chowngid,
-		BucketLinks:    bucketlinks,
-		VersioningDir:  versioningDir,
-		NewDirPerm:     fs.FileMode(dirPerms),
-		ForceNoTmpFile: forceNoTmpFile,
+		ChownUID:            chownuid,
+		ChownGID:            chowngid,
+		BucketLinks:         bucketlinks,
+		VersioningDir:       versioningDir,
+		NewDirPerm:          fs.FileMode(dirPerms),
+		ForceNoTmpFile:      forceNoTmpFile,
+		ValidateBucketNames: disableStrictBucketNames,
 	}
 
 	var ms meta.MetadataStorer

--- a/cmd/versitygw/scoutfs.go
+++ b/cmd/versitygw/scoutfs.go
@@ -113,6 +113,7 @@ func runScoutfs(ctx *cli.Context) error {
 	opts.NewDirPerm = fs.FileMode(dirPerms)
 	opts.DisableNoArchive = disableNoArchive
 	opts.VersioningDir = versioningDir
+	opts.ValidateBucketNames = disableStrictBucketNames
 
 	be, err := scoutfs.New(ctx.Args().Get(0), opts)
 	if err != nil {

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -120,6 +120,12 @@ ROOT_SECRET_ACCESS_KEY=
 # https://<VGW_ENDPOINT>/<bucket>
 #VGW_VIRTUAL_DOMAIN=
 
+# By default, versitygw will enforce similar bucket naming rules as described
+# in https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+# Set to true to allow legacy or non-DNS-compliant bucket names by skipping
+# strict validation checks.
+#VGW_DISABLE_STRICT_BUCKET_NAMES=false
+
 ###############
 # Access Logs #
 ###############

--- a/s3api/utils/utils_test.go
+++ b/s3api/utils/utils_test.go
@@ -231,6 +231,28 @@ func TestIsValidBucketName(t *testing.T) {
 	}
 }
 
+func TestSetBucketNameValidationStrict(t *testing.T) {
+	SetBucketNameValidationStrict(true)
+	t.Cleanup(func() {
+		SetBucketNameValidationStrict(true)
+	})
+
+	invalidBucket := "Invalid_Bucket"
+	if IsValidBucketName(invalidBucket) {
+		t.Fatalf("expected %q to be invalid with strict validation", invalidBucket)
+	}
+
+	SetBucketNameValidationStrict(false)
+	if !IsValidBucketName(invalidBucket) {
+		t.Fatalf("expected %q to be accepted when strict validation disabled", invalidBucket)
+	}
+
+	SetBucketNameValidationStrict(true)
+	if IsValidBucketName(invalidBucket) {
+		t.Fatalf("expected %q to be invalid after re-enabling strict validation", invalidBucket)
+	}
+}
+
 func TestParseUint(t *testing.T) {
 	type args struct {
 		str string


### PR DESCRIPTION
Some systems may choose to allow non-aws compliant bucket names and/or handle the bucket naem validation in the backend instead. This adds the option to turn off the strict bucket name validation checks in the frontend API handlers.

Fixes #1564