### PR TITLE
feat: prevents locked objects overwrite with CopyObject and CompleteMultipartUpload

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -325,6 +325,15 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 
 	ifMatch, ifNoneMatch := utils.ParsePreconditionMatchHeaders(ctx)
 
+	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, []types.ObjectIdentifier{{Key: &key}}, true, isBucketPublic, c.be, true)
+	if err != nil {
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, err
+	}
+
 	res, versid, err := c.be.CompleteMultipartUpload(ctx.Context(),
 		&s3.CompleteMultipartUploadInput{
 			Bucket:   &bucket,

--- a/s3api/controllers/object-put.go
+++ b/s3api/controllers/object-put.go
@@ -531,6 +531,15 @@ func (c S3ApiController) CopyObject(ctx *fiber.Ctx) (*Response, error) {
 
 	preconditionHdrs := utils.ParsePreconditionHeaders(ctx, utils.WithCopySource())
 
+	err = auth.CheckObjectAccess(ctx.Context(), bucket, acct.Access, []types.ObjectIdentifier{{Key: &key}}, true, false, c.be, true)
+	if err != nil {
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, err
+	}
+
 	res, err := c.be.CopyObject(ctx.Context(),
 		s3response.CopyObjectInput{
 			Bucket:                      &bucket,

--- a/s3api/controllers/object-put_test.go
+++ b/s3api/controllers/object-put_test.go
@@ -892,6 +892,24 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 			},
 		},
 		{
+			name: "object is locked",
+			input: testInput{
+				locals: defaultLocals,
+				headers: map[string]string{
+					"X-Amz-Copy-Source": "bucket/object",
+				},
+				extraMockErr: s3err.GetAPIError(s3err.ErrObjectLocked),
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{
+						BucketOwner: "root",
+					},
+				},
+				err: s3err.GetAPIError(s3err.ErrObjectLocked),
+			},
+		},
+		{
 			name: "backend returns error",
 			input: testInput{
 				locals: defaultLocals,
@@ -900,6 +918,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 				headers: map[string]string{
 					"X-Amz-Copy-Source": "bucket/object",
 				},
+				extraMockErr: s3err.GetAPIError(s3err.ErrObjectLockConfigurationNotFound),
 			},
 			output: testOutput{
 				response: &Response{
@@ -930,6 +949,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 						ETag: utils.GetStringPtr("ETag"),
 					},
 				},
+				extraMockErr: s3err.GetAPIError(s3err.ErrObjectLockConfigurationNotFound),
 			},
 			output: testOutput{
 				response: &Response{
@@ -958,6 +978,12 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 				},
 				GetBucketPolicyFunc: func(contextMoqParam context.Context, bucket string) ([]byte, error) {
 					return nil, s3err.GetAPIError(s3err.ErrAccessDenied)
+				},
+				GetBucketVersioningFunc: func(contextMoqParam context.Context, bucket string) (s3response.GetBucketVersioningOutput, error) {
+					return s3response.GetBucketVersioningOutput{}, s3err.GetAPIError(s3err.ErrNotImplemented)
+				},
+				GetObjectLockConfigurationFunc: func(contextMoqParam context.Context, bucket string) ([]byte, error) {
+					return nil, tt.input.extraMockErr
 				},
 			}
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -714,7 +714,12 @@ func TestWORMProtection(ts *TestState) {
 	ts.Run(WORMProtection_bucket_object_lock_governance_bypass_delete_multiple)
 	ts.Run(WORMProtection_object_lock_retention_compliance_locked)
 	ts.Run(WORMProtection_object_lock_retention_governance_locked)
-	ts.Run(WORMProtection_object_lock_retention_governance_bypass_overwrite)
+	ts.Run(WORMProtection_object_lock_retention_governance_bypass_overwrite_put)
+	ts.Run(WORMProtection_object_lock_retention_governance_bypass_overwrite_copy)
+	ts.Run(WORMProtection_object_lock_retention_governance_bypass_overwrite_mp)
+	ts.Run(WORMProtection_unable_to_overwrite_locked_object_put)
+	ts.Run(WORMProtection_unable_to_overwrite_locked_object_copy)
+	ts.Run(WORMProtection_unable_to_overwrite_locked_object_mp)
 	ts.Run(WORMProtection_object_lock_retention_governance_bypass_delete)
 	ts.Run(WORMProtection_object_lock_retention_governance_bypass_delete_mul)
 	ts.Run(WORMProtection_object_lock_legal_hold_locked)
@@ -1522,7 +1527,12 @@ func GetIntTests() IntTests {
 		"WORMProtection_bucket_object_lock_governance_bypass_delete_multiple":     WORMProtection_bucket_object_lock_governance_bypass_delete_multiple,
 		"WORMProtection_object_lock_retention_compliance_locked":                  WORMProtection_object_lock_retention_compliance_locked,
 		"WORMProtection_object_lock_retention_governance_locked":                  WORMProtection_object_lock_retention_governance_locked,
-		"WORMProtection_object_lock_retention_governance_bypass_overwrite":        WORMProtection_object_lock_retention_governance_bypass_overwrite,
+		"WORMProtection_object_lock_retention_governance_bypass_overwrite_put":    WORMProtection_object_lock_retention_governance_bypass_overwrite_put,
+		"WORMProtection_object_lock_retention_governance_bypass_overwrite_copy":   WORMProtection_object_lock_retention_governance_bypass_overwrite_copy,
+		"WORMProtection_object_lock_retention_governance_bypass_overwrite_mp":     WORMProtection_object_lock_retention_governance_bypass_overwrite_mp,
+		"WORMProtection_unable_to_overwrite_locked_object_put":                    WORMProtection_unable_to_overwrite_locked_object_put,
+		"WORMProtection_unable_to_overwrite_locked_object_copy":                   WORMProtection_unable_to_overwrite_locked_object_copy,
+		"WORMProtection_unable_to_overwrite_locked_object_mp":                     WORMProtection_unable_to_overwrite_locked_object_mp,
 		"WORMProtection_object_lock_retention_governance_bypass_delete":           WORMProtection_object_lock_retention_governance_bypass_delete,
 		"WORMProtection_object_lock_retention_governance_bypass_delete_mul":       WORMProtection_object_lock_retention_governance_bypass_delete_mul,
 		"WORMProtection_object_lock_legal_hold_locked":                            WORMProtection_object_lock_legal_hold_locked,


### PR DESCRIPTION
Closes #1566

When an object is locked and bucket versioning is not configured at the gateway level, any object overwrite request should be rejected with an object locked error. The `PutObject` operation already follows this behavior, but `CopyObject` and `CompleteMultipartUpload` were missing this check. This change introduces the locking mechanism for `CopyObject` and `CompleteMultipartUpload` operations.