### PR TITLE
fix: sets crc64nvme as defualt checksum for complete mp action

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -217,7 +217,7 @@ func TestGetObject(ts *TestState) {
 	ts.Run(GetObject_zero_len_with_range)
 	ts.Run(GetObject_dir_with_range)
 	ts.Run(GetObject_invalid_parent)
-	ts.Run(GetObject_large_object)
+	ts.Sync(GetObject_large_object)
 	ts.Run(GetObject_conditional_reads)
 	//TODO: remove the condition after implementing checksums in azure
 	if !ts.conf.azureTests {

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -12970,7 +12970,7 @@ func CompleteMultipartUpload_should_ignore_the_final_checksum(s *S3Conf) error {
 			MultipartUpload: &types.CompletedMultipartUpload{
 				Parts: cParts,
 			},
-			ChecksumSHA1: getPtr("Kq5sNclPz7QV2+lfQIuc6R7oRu0="), // should ignore this
+			ChecksumCRC64NVME: getPtr("vqf3hRLTlJw="), // should ignore this
 		})
 		cancel()
 		if err != nil {
@@ -12993,9 +12993,10 @@ func CompleteMultipartUpload_should_ignore_the_final_checksum(s *S3Conf) error {
 			return fmt.Errorf("expected nil sha256 checksum, insted got %v",
 				*res.ChecksumSHA256)
 		}
-		if res.ChecksumCRC64NVME != nil {
-			return fmt.Errorf("expected nil crc64nvme checksum, insted got %v",
-				*res.ChecksumSHA256)
+		// If no checksum is specified on mp creation, it should default
+		// to crc64nvme
+		if res.ChecksumCRC64NVME == nil {
+			return fmt.Errorf("expected non nil crc64nvme checksum")
 		}
 
 		return nil
@@ -24659,9 +24660,8 @@ func Versioning_WORM_CompleteMultipartUpload_overwrite_locked_object(s *S3Conf) 
 			MultipartUpload: &types.CompletedMultipartUpload{
 				Parts: []types.CompletedPart{
 					{
-						ETag:              part.ETag,
-						PartNumber:        part.PartNumber,
-						ChecksumCRC64NVME: part.ChecksumCRC64NVME,
+						ETag:       part.ETag,
+						PartNumber: part.PartNumber,
 					},
 				},
 			},
@@ -24679,7 +24679,6 @@ func Versioning_WORM_CompleteMultipartUpload_overwrite_locked_object(s *S3Conf) 
 			Size:         &dataLen,
 			VersionId:    res.VersionId,
 			StorageClass: types.ObjectVersionStorageClassStandard,
-			ChecksumType: res.ChecksumType,
 		}
 
 		result := []types.ObjectVersion{version, v}

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -518,7 +518,7 @@ func putObjectWithData(lgth int64, input *s3.PutObjectInput, client *s3.Client) 
 		input.Body = r
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), longTimeout)
 	res, err := client.PutObject(ctx, input)
 	cancel()
 	if err != nil {


### PR DESCRIPTION
Fixes #1547

When no checksum is specified during multipart upload initialization, the complete multipart upload request should default to **CRC64NVME FULL_OBJECT**. The checksum will not be stored in the final object metadata, as it is used solely for data integrity verification. Note that although CRC64NVME is composable, it is calculated using the standard hash reader, since the part checksums are missing and the final checksum calculation is instead based directly on the parts data.