### PR TITLE
feat: adds bucket policy version support

### DIFF
--- a/auth/bucket_policy_version.go
+++ b/auth/bucket_policy_version.go
@@ -1,0 +1,32 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+type PolicyVersion string
+
+const (
+	PolicyVersion2008 PolicyVersion = "2008-10-17"
+	PolicyVersion2012 PolicyVersion = "2012-10-17"
+)
+
+// isValid checks if the policy version is valid or not
+func (pv PolicyVersion) isValid() bool {
+	switch pv {
+	case PolicyVersion2008, PolicyVersion2012:
+		return true
+	default:
+		return false
+	}
+}

--- a/auth/bucket_policy_version_test.go
+++ b/auth/bucket_policy_version_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package auth
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyVersion_isValid(t *testing.T) {
+	tests := []struct {
+		name  string // description of this test case
+		value string
+		want  bool
+	}{
+		{"valid 2008", "2008-10-17", true},
+		{"valid 2012", "2012-10-17", true},
+		{"invalid empty", "", false},
+		{"invalid 1", "invalid", false},
+		{"invalid 2", "2010-10-17", false},
+		{"invalid 3", "2006-00-12", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PolicyVersion(tt.value).isValid()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -536,6 +536,7 @@ func TestPutBucketPolicy(ts *TestState) {
 	ts.Run(PutBucketPolicy_explicit_deny)
 	ts.Run(PutBucketPolicy_multi_wildcard_resource)
 	ts.Run(PutBucketPolicy_any_char_match)
+	ts.Run(PutBucketPolicy_version)
 	ts.Run(PutBucketPolicy_success)
 }
 
@@ -1412,6 +1413,7 @@ func GetIntTests() IntTests {
 		"PutBucketPolicy_explicit_deny":                                           PutBucketPolicy_explicit_deny,
 		"PutBucketPolicy_multi_wildcard_resource":                                 PutBucketPolicy_multi_wildcard_resource,
 		"PutBucketPolicy_any_char_match":                                          PutBucketPolicy_any_char_match,
+		"PutBucketPolicy_version":                                                 PutBucketPolicy_version,
 		"PutBucketPolicy_success":                                                 PutBucketPolicy_success,
 		"GetBucketPolicy_non_existing_bucket":                                     GetBucketPolicy_non_existing_bucket,
 		"GetBucketPolicy_not_set":                                                 GetBucketPolicy_not_set,


### PR DESCRIPTION
Closes #1536

Adds bucket policy version support. Two versions are supported: **2008-10-17** and **2012-10-17**. If the `Version` field is omitted in the bucket policy document, it defaults to **2008-10-17**. However, if an empty string (`""`) is provided, it is considered invalid.