### PR TITLE
fix: fixes the checksum type/algo mismatch error in create mp

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -866,7 +866,7 @@ func GetChecksumBadDigestErr(algo types.ChecksumAlgorithm) APIError {
 func GetChecksumSchemaMismatchErr(algo types.ChecksumAlgorithm, t types.ChecksumType) APIError {
 	return APIError{
 		Code:           "InvalidRequest",
-		Description:    fmt.Sprintf("The %v checksum type cannot be used with the %v checksum algorithm.", algo, strings.ToLower(string(t))),
+		Description:    fmt.Sprintf("The %v checksum type cannot be used with the %v checksum algorithm.", strings.ToUpper(string(t)), strings.ToLower(string(algo))),
 		HTTPStatusCode: http.StatusBadRequest,
 	}
 }

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -364,6 +364,7 @@ func TestCreateMultipartUpload(ts *TestState) {
 	if !ts.conf.azureTests {
 		ts.Run(CreateMultipartUpload_invalid_checksum_algorithm)
 		ts.Run(CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type)
+		ts.Run(CreateMultipartUpload_type_algo_mismatch)
 		ts.Run(CreateMultipartUpload_invalid_checksum_type)
 		ts.Run(CreateMultipartUpload_valid_algo_type)
 	}
@@ -1288,6 +1289,7 @@ func GetIntTests() IntTests {
 		"CreateMultipartUpload_invalid_object_lock_mode":                          CreateMultipartUpload_invalid_object_lock_mode,
 		"CreateMultipartUpload_invalid_checksum_algorithm":                        CreateMultipartUpload_invalid_checksum_algorithm,
 		"CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type":       CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type,
+		"CreateMultipartUpload_type_algo_mismatch":                                CreateMultipartUpload_type_algo_mismatch,
 		"CreateMultipartUpload_invalid_checksum_type":                             CreateMultipartUpload_invalid_checksum_type,
 		"CreateMultipartUpload_valid_algo_type":                                   CreateMultipartUpload_valid_algo_type,
 		"CreateMultipartUpload_success":                                           CreateMultipartUpload_success,

--- a/tests/integration/tests.go
+++ b/tests/integration/tests.go
@@ -9319,6 +9319,27 @@ func CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type(s *S3Conf
 	})
 }
 
+func CreateMultipartUpload_type_algo_mismatch(s *S3Conf) error {
+	testName := "CreateMultipartUpload_type_algo_mismatch"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		for i, test := range []struct {
+			chType types.ChecksumType
+			algo   types.ChecksumAlgorithm
+		}{
+			{types.ChecksumTypeComposite, types.ChecksumAlgorithmCrc64nvme},
+			{types.ChecksumTypeFullObject, types.ChecksumAlgorithmSha1},
+			{types.ChecksumTypeFullObject, types.ChecksumAlgorithmSha256},
+		} {
+			_, err := createMp(s3client, bucket, "my-obj", withChecksum(test.algo), withChecksumType(test.chType))
+			if err := checkApiErr(err, s3err.GetChecksumSchemaMismatchErr(test.algo, test.chType)); err != nil {
+				return fmt.Errorf("test %v failed: %w", i, err)
+			}
+		}
+
+		return nil
+	})
+}
+
 func CreateMultipartUpload_valid_algo_type(s *S3Conf) error {
 	testName := "CreateMultipartUpload_valid_algo_type"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {


### PR DESCRIPTION
Fixes #1329

Fixes the checksum type/algorithm mismatch error in `CreateMultipartUpload`. The algorithm an type were messed in the error description. It also adds an integration test to target the unsupported checksum type/algorithm pairs.