### PR TITLE
fix: implements proper error handling for malformed http requests

### DIFF
--- a/s3api/server.go
+++ b/s3api/server.go
@@ -199,6 +199,13 @@ func globalErrorHandler(ctx *fiber.Ctx, er error) error {
 				ctx.Status(http.StatusBadRequest)
 				return nil
 			}
+			if strings.Contains(fiberErr.Message, "error when reading request headers") {
+				// This error means fiber failed to parse the incoming request
+				// which is a malfoedmed one. Return a BadRequest in this case
+				err := s3err.GetAPIError(s3err.ErrCannotParseHTTPRequest)
+				ctx.Status(err.HTTPStatusCode)
+				return ctx.Send(s3err.GetAPIErrorResponse(err, "", "", ""))
+			}
 		}
 
 		// additionally log the internal error

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -97,6 +97,7 @@ const (
 	ErrDuplicateTagKey
 	ErrBucketTaggingLimited
 	ErrObjectTaggingLimited
+	ErrCannotParseHTTPRequest
 	ErrInvalidURLEncodedTagging
 	ErrInvalidAuthHeader
 	ErrUnsupportedAuthorizationType
@@ -380,6 +381,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrObjectTaggingLimited: {
 		Code:           "BadRequest",
 		Description:    "Object tags cannot be greater than 10",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrCannotParseHTTPRequest: {
+		Code:           "BadRequest",
+		Description:    "An error occurred when parsing the HTTP request.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidURLEncodedTagging: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -217,7 +217,7 @@ func TestGetObject(ts *TestState) {
 	ts.Run(GetObject_zero_len_with_range)
 	ts.Run(GetObject_dir_with_range)
 	ts.Run(GetObject_invalid_parent)
-	ts.Run(GetObject_large_object)
+	ts.Sync(GetObject_large_object)
 	ts.Run(GetObject_conditional_reads)
 	//TODO: remove the condition after implementing checksums in azure
 	if !ts.conf.azureTests {


### PR DESCRIPTION
Fixes #1364

When a completely malformed request is sent to the gateway, Fiber/Fasthttp fails to parse the request, and the code execution never reaches the routers or handlers. Instead, the error is caught by the global error handler. These kinds of errors (malformed requests that fail during request parsing) are prefixed with **"error when reading request headers"** in Fiber. The implementation adds a check in the global error handler for this specific error message and returns an S3-like XML **BadRequest** error instead.