### PR TITLE
Allow self-signed ldaps certificates

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -119,6 +119,7 @@ type Opts struct {
 	LDAPRoleAtr                 string
 	LDAPUserIdAtr               string
 	LDAPGroupIdAtr              string
+	LDAPTLSSkipVerify           bool
 	VaultEndpointURL            string
 	VaultNamespace              string
 	VaultSecretStoragePath      string
@@ -159,7 +160,7 @@ func New(o *Opts) (IAMService, error) {
 	case o.LDAPServerURL != "":
 		svc, err = NewLDAPService(o.RootAccount, o.LDAPServerURL, o.LDAPBindDN, o.LDAPPassword,
 			o.LDAPQueryBase, o.LDAPAccessAtr, o.LDAPSecretAtr, o.LDAPRoleAtr, o.LDAPUserIdAtr,
-			o.LDAPGroupIdAtr, o.LDAPObjClasses)
+			o.LDAPGroupIdAtr, o.LDAPObjClasses, o.LDAPTLSSkipVerify)
 		fmt.Printf("initializing LDAP IAM with %q\n", o.LDAPServerURL)
 	case o.S3Endpoint != "":
 		svc, err = NewS3(o.RootAccount, o.S3Access, o.S3Secret, o.S3Region, o.S3Bucket,

--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -65,6 +65,7 @@ var (
 	ldapQueryBase, ldapObjClasses          string
 	ldapAccessAtr, ldapSecAtr, ldapRoleAtr string
 	ldapUserIdAtr, ldapGroupIdAtr          string
+	ldapTLSSkipVerify                      bool
 	vaultEndpointURL, vaultNamespace       string
 	vaultSecretStoragePath                 string
 	vaultSecretStorageNamespace            string
@@ -404,6 +405,12 @@ func initFlags() []cli.Flag {
 			EnvVars:     []string{"VGW_IAM_LDAP_GROUP_ID_ATR"},
 			Destination: &ldapGroupIdAtr,
 		},
+		&cli.BoolFlag{
+			Name:        "iam-ldap-tls-skip-verify",
+			Usage:       "disable TLS certificate verification for LDAP connections (insecure, for self-signed certificates)",
+			EnvVars:     []string{"VGW_IAM_LDAP_TLS_SKIP_VERIFY"},
+			Destination: &ldapTLSSkipVerify,
+		},
 		&cli.StringFlag{
 			Name:        "iam-vault-endpoint-url",
 			Usage:       "vault server url",
@@ -692,6 +699,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		LDAPRoleAtr:                 ldapRoleAtr,
 		LDAPUserIdAtr:               ldapUserIdAtr,
 		LDAPGroupIdAtr:              ldapGroupIdAtr,
+		LDAPTLSSkipVerify:           ldapTLSSkipVerify,
 		VaultEndpointURL:            vaultEndpointURL,
 		VaultNamespace:              vaultNamespace,
 		VaultSecretStoragePath:      vaultSecretStoragePath,

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -279,6 +279,11 @@ ROOT_SECRET_ACCESS_KEY=
 #VGW_IAM_LDAP_ROLE_ATR=
 #VGW_IAM_LDAP_USER_ID_ATR=
 #VGW_IAM_LDAP_GROUP_ID_ATR=
+# Disable TLS certificate verification for LDAP connections (insecure, allows
+# self-signed certificates). This should only be used in testing environments
+# or when using self-signed certificates. The default is false (verification
+# enabled).
+#VGW_IAM_LDAP_TLS_SKIP_VERIFY=false
 
 # The FreeIPA options will enable the FreeIPA IAM service with accounts stored
 # in an external FreeIPA service. Currently the FreeIPA IAM service only


### PR DESCRIPTION
When using LDAP IAM with self-signed certificates (common in development/testing environments or internal infrastructure), VersityGW would reject the connection due to certificate verification failures. This PR adds an optional configuration to disable TLS certificate verification for LDAP connections.

**New Environment Variable**: `VGW_IAM_LDAP_TLS_SKIP_VERIFY` (default: `false`)
  - When set to `true`, disables TLS certificate verification for LDAPS connections
  - When set to `false` or omitted, enforces strict certificate validation (default behavior)

## Testing

- ✅ Code compiles successfully
- ✅ Existing LDAP tests passed
- ✅ Docker image builds and runs
- ✅ Deployed on Local OnPrem Kubernetes Environment and successfully uploaded files after authentication