### PR TITLE
fix: fixes the bucket/object tagging key/value name validation

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -317,14 +317,12 @@ func ParseObjectTags(tagging string) (map[string]string, error) {
 	return tagSet, nil
 }
 
-var validTagComponent = regexp.MustCompile(`^[a-zA-Z0-9:/_.\-+ ]+$`)
+// tag component (key/value) name rule regexp
+// https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_Tag.html
+var validTagComponent = regexp.MustCompile(`^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`)
 
-// isValidTagComponent matches strings which contain letters, decimal digits,
-// and special chars: '/', '_', '-', '+', '.', ' ' (space)
+// isValidTagComponent validates the tag component(key/value) name
 func isValidTagComponent(str string) bool {
-	if str == "" {
-		return true
-	}
 	return validTagComponent.Match([]byte(str))
 }
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -125,6 +125,7 @@ func TestDeleteBucketOwnershipControls(ts *TestState) {
 func TestPutBucketTagging(ts *TestState) {
 	ts.Run(PutBucketTagging_non_existing_bucket)
 	ts.Run(PutBucketTagging_long_tags)
+	ts.Run(PutBucketTagging_invalid_tags)
 	ts.Run(PutBucketTagging_duplicate_keys)
 	ts.Run(PutBucketTagging_tag_count_limit)
 	ts.Run(PutBucketTagging_success)
@@ -337,6 +338,7 @@ func TestPutObjectTagging(ts *TestState) {
 	ts.Run(PutObjectTagging_long_tags)
 	ts.Run(PutObjectTagging_duplicate_keys)
 	ts.Run(PutObjectTagging_tag_count_limit)
+	ts.Run(PutObjectTagging_invalid_tags)
 	ts.Run(PutObjectTagging_success)
 }
 
@@ -1146,6 +1148,7 @@ func GetIntTests() IntTests {
 		"DeleteBucketOwnershipControls_success":                                   DeleteBucketOwnershipControls_success,
 		"PutBucketTagging_non_existing_bucket":                                    PutBucketTagging_non_existing_bucket,
 		"PutBucketTagging_long_tags":                                              PutBucketTagging_long_tags,
+		"PutBucketTagging_invalid_tags":                                           PutBucketTagging_invalid_tags,
 		"PutBucketTagging_duplicate_keys":                                         PutBucketTagging_duplicate_keys,
 		"PutBucketTagging_tag_count_limit":                                        PutBucketTagging_tag_count_limit,
 		"PutBucketTagging_success":                                                PutBucketTagging_success,
@@ -1277,6 +1280,7 @@ func GetIntTests() IntTests {
 		"PutObjectTagging_long_tags":                                              PutObjectTagging_long_tags,
 		"PutObjectTagging_duplicate_keys":                                         PutObjectTagging_duplicate_keys,
 		"PutObjectTagging_tag_count_limit":                                        PutObjectTagging_tag_count_limit,
+		"PutObjectTagging_invalid_tags":                                           PutObjectTagging_invalid_tags,
 		"PutObjectTagging_success":                                                PutObjectTagging_success,
 		"GetObjectTagging_non_existing_object":                                    GetObjectTagging_non_existing_object,
 		"GetObjectTagging_unset_tags":                                             GetObjectTagging_unset_tags,


### PR DESCRIPTION
Fixes #1579

S3 enforces a specific rule for validating bucket and object tag key/value names. This PR integrates the regexp pattern used by S3 for tag validation. Official S3 documentation for tag validation rules: [AWS S3 Tag](https://docs.aws.amazon.com/AmazonS3/latest/API/API_control_Tag.html)

There are two types of tagging inputs for buckets and objects:

1. **On existing buckets/objects** — used in the `PutObjectTagging` and `PutBucketTagging` actions, where tags are provided in the request body.
2. **On object creation** — used in the `PutObject`, `CreateMultipartUpload`, and `CopyObject` actions, where tags are provided in the request headers and must be URL-encoded.

This implementation ensures correct validation for both types of tag inputs.