### PR TITLE
fix: fixes checksum header and algorithm mismatch error

### DIFF
--- a/s3api/utils/utils.go
+++ b/s3api/utils/utils.go
@@ -522,14 +522,14 @@ func ParseChecksumHeadersAndSdkAlgo(ctx *fiber.Ctx) (types.ChecksumAlgorithm, Ch
 	}
 
 	for al, val := range checksums {
+		if !IsValidChecksum(val, al) {
+			return sdkAlgorithm, checksums, s3err.GetInvalidChecksumHeaderErr(fmt.Sprintf("x-amz-checksum-%v", strings.ToLower(string(al))))
+		}
+
 		// If any other checksum value is provided,
 		// rather than x-amz-sdk-checksum-algorithm
 		if sdkAlgorithm != "" && sdkAlgorithm != al {
-			return sdkAlgorithm, checksums, s3err.GetAPIError(s3err.ErrChecksumSDKAlgoMismatch)
-		}
-
-		if !IsValidChecksum(val, al) {
-			return sdkAlgorithm, checksums, s3err.GetInvalidChecksumHeaderErr(fmt.Sprintf("x-amz-checksum-%v", strings.ToLower(string(al))))
+			return sdkAlgorithm, checksums, s3err.GetInvalidChecksumHeaderErr("x-amz-sdk-checksum-algorithm")
 		}
 		sdkAlgorithm = al
 	}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -386,6 +386,7 @@ func TestUploadPart(ts *TestState) {
 	if !ts.conf.azureTests {
 		ts.Run(UploadPart_multiple_checksum_headers)
 		ts.Run(UploadPart_invalid_checksum_header)
+		ts.Run(UploadPart_checksum_header_and_algo_mismatch)
 		ts.Run(UploadPart_checksum_algorithm_mistmatch_on_initialization)
 		ts.Run(UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value)
 		ts.Run(UploadPart_incorrect_checksums)
@@ -1313,6 +1314,7 @@ func GetIntTests() IntTests {
 		"UploadPart_non_existing_mp_upload":                                       UploadPart_non_existing_mp_upload,
 		"UploadPart_multiple_checksum_headers":                                    UploadPart_multiple_checksum_headers,
 		"UploadPart_invalid_checksum_header":                                      UploadPart_invalid_checksum_header,
+		"UploadPart_checksum_header_and_algo_mismatch":                            UploadPart_checksum_header_and_algo_mismatch,
 		"UploadPart_checksum_algorithm_mistmatch_on_initialization":               UploadPart_checksum_algorithm_mistmatch_on_initialization,
 		"UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value":    UploadPart_checksum_algorithm_mistmatch_on_initialization_with_value,
 		"UploadPart_incorrect_checksums":                                          UploadPart_incorrect_checksums,


### PR DESCRIPTION
Fixes #1598

`PutObject` and `UploadPart` accept x-amz-checksum-* calculated checksum headers and `x-amz-sdk-checksum-algorithm`. If the checksum algorithm specified in sdk algorithm doesn't match the one in x-amz-checksum-*, it now returns the correct error message: `Value for x-amz-sdk-checksum-algorithm header is invalid.`.