### PR TITLE
feat: implements tagging support for CreateBucket

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -173,6 +173,7 @@ const (
 	ErrMissingCORSOrigin
 	ErrCORSIsNotEnabled
 	ErrNotModified
+	ErrInvalidLocationConstraint
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -761,6 +762,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "NotModified",
 		Description:    "Not Modified",
 		HTTPStatusCode: http.StatusNotModified,
+	},
+	ErrInvalidLocationConstraint: {
+		Code:           "InvalidLocationConstraint",
+		Description:    "The specified location-constraint is not valid",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 
 	// non aws errors

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -728,3 +728,8 @@ type LocationConstraint struct {
 	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LocationConstraint"`
 	Value   string   `xml:",chardata"`
 }
+
+type CreateBucketConfiguration struct {
+	LocationConstraint string
+	TagSet             []types.Tag `xml:"Tags>Tag"`
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -80,6 +80,11 @@ func TestCreateBucket(ts *TestState) {
 	ts.Run(CreateBucket_non_default_acl)
 	ts.Run(CreateDeleteBucket_success)
 	ts.Run(CreateBucket_default_object_lock)
+	ts.Run(CreateBucket_invalid_location_constraint)
+	ts.Run(CreateBucket_long_tags)
+	ts.Run(CreateBucket_invalid_tags)
+	ts.Run(CreateBucket_duplicate_keys)
+	ts.Run(CreateBucket_tag_count_limit)
 }
 
 func TestHeadBucket(ts *TestState) {
@@ -1135,6 +1140,11 @@ func GetIntTests() IntTests {
 		"CreateBucket_default_acl":                                                CreateBucket_default_acl,
 		"CreateBucket_non_default_acl":                                            CreateBucket_non_default_acl,
 		"CreateBucket_default_object_lock":                                        CreateBucket_default_object_lock,
+		"CreateBucket_invalid_location_constraint":                                CreateBucket_invalid_location_constraint,
+		"CreateBucket_long_tags":                                                  CreateBucket_long_tags,
+		"CreateBucket_invalid_tags":                                               CreateBucket_invalid_tags,
+		"CreateBucket_duplicate_keys":                                             CreateBucket_duplicate_keys,
+		"CreateBucket_tag_count_limit":                                            CreateBucket_tag_count_limit,
 		"HeadBucket_non_existing_bucket":                                          HeadBucket_non_existing_bucket,
 		"HeadBucket_success":                                                      HeadBucket_success,
 		"ListBuckets_as_user":                                                     ListBuckets_as_user,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -265,7 +265,8 @@ func actionHandler(s *S3Conf, testName string, handler func(s3client *s3.Client,
 func actionHandlerNoSetup(s *S3Conf, testName string, handler func(s3client *s3.Client, bucket string) error, _ ...setupOpt) error {
 	runF(testName)
 	client := s.GetClient()
-	handlerErr := handler(client, "")
+	bucket := getBucketName()
+	handlerErr := handler(client, bucket)
 	if handlerErr != nil {
 		failF("%v: %v", testName, handlerErr)
 	}


### PR DESCRIPTION
Closes #1595

This implementation diverges from AWS S3 behavior. The `CreateBucket` request body is no longer ignored. Based on the S3 request body schema, the gateway parses only the `LocationConstraint` and `Tags` fields. If the `LocationConstraint` does not match the gateway’s region, it returns an `InvalidLocationConstraint` error.

In AWS S3, tagging during bucket creation is supported only for directory buckets. The gateway extends this support to general-purpose buckets.

If the request body is malformed, the gateway returns a `MalformedXML` error.