### PR TITLE
fix: adds validation for bucket canned ACL

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/debuglogger"
 	"github.com/versity/versitygw/s3err"
 )
 
@@ -492,4 +493,15 @@ func UpdateBucketACLOwner(ctx context.Context, be backend.Backend, bucket, newOw
 	}
 
 	return be.DeleteBucketPolicy(ctx, bucket)
+}
+
+// ValidateCannedACL validates bucket canned acl value
+func ValidateCannedACL(acl string) error {
+	switch types.BucketCannedACL(acl) {
+	case types.BucketCannedACLPrivate, types.BucketCannedACLPublicRead, types.BucketCannedACLPublicReadWrite, "":
+		return nil
+	default:
+		debuglogger.Logf("invalid bucket canned acl: %v", acl)
+		return s3err.GetAPIError(s3err.ErrInvalidArgument)
+	}
 }

--- a/s3api/controllers/bucket-put_test.go
+++ b/s3api/controllers/bucket-put_test.go
@@ -729,7 +729,9 @@ func TestS3ApiController_CreateBucket(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
-					MetaOpts: &MetaOptions{},
+					MetaOpts: &MetaOptions{
+						BucketOwner: adminAcc.Access,
+					},
 				},
 				err: s3err.GetAPIError(s3err.ErrInvalidBucketName),
 			},
@@ -747,6 +749,24 @@ func TestS3ApiController_CreateBucket(t *testing.T) {
 					MetaOpts: &MetaOptions{BucketOwner: adminAcc.Access},
 				},
 				err: s3err.GetAPIError(s3err.ErrMalformedXML),
+			},
+		},
+
+		{
+			name: "invalid canned acl",
+			input: testInput{
+				locals: map[utils.ContextKey]any{
+					utils.ContextKeyAccount: adminAcc,
+				},
+				headers: map[string]string{
+					"x-amz-acl": "invalid_acl",
+				},
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{BucketOwner: adminAcc.Access},
+				},
+				err: s3err.GetAPIError(s3err.ErrInvalidArgument),
 			},
 		},
 		{
@@ -777,7 +797,9 @@ func TestS3ApiController_CreateBucket(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
-					MetaOpts: &MetaOptions{},
+					MetaOpts: &MetaOptions{
+						BucketOwner: adminAcc.Access,
+					},
 				},
 				err: s3err.APIError{
 					Code:           "InvalidArgument",
@@ -1079,7 +1101,7 @@ func TestS3ApiController_PutBucketAcl(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidRequest),
+				err: s3err.GetAPIError(s3err.ErrInvalidArgument),
 			},
 		},
 		{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -174,6 +174,7 @@ const (
 	ErrCORSIsNotEnabled
 	ErrNotModified
 	ErrInvalidLocationConstraint
+	ErrInvalidArgument
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -766,6 +767,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrInvalidLocationConstraint: {
 		Code:           "InvalidLocationConstraint",
 		Description:    "The specified location-constraint is not valid",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidArgument: {
+		Code:           "InvalidArgument",
+		Description:    "",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/tests/integration/CreateBucket.go
+++ b/tests/integration/CreateBucket.go
@@ -490,3 +490,16 @@ func CreateBucket_tag_count_limit(s *S3Conf) error {
 		return checkApiErr(err, s3err.GetAPIError(s3err.ErrBucketTaggingLimited))
 	})
 }
+
+func CreateBucket_invalid_canned_acl(s *S3Conf) error {
+	testName := "CreateBucket_invalid_canned_acl"
+	return actionHandlerNoSetup(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.CreateBucket(ctx, &s3.CreateBucketInput{
+			Bucket: &bucket,
+			ACL:    types.BucketCannedACL("invalid_acl"),
+		})
+		cancel()
+		return checkSdkApiErr(err, "InvalidArgument")
+	})
+}

--- a/tests/integration/PutBucketAcl.go
+++ b/tests/integration/PutBucketAcl.go
@@ -71,6 +71,21 @@ func PutBucketAcl_none_of_the_options_specified(s *S3Conf) error {
 	}, withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
 }
 
+func PutBucketAcl_invalid_canned_acl(s *S3Conf) error {
+	testName := "PutBucketAcl_invalid_canned_acl"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.PutBucketAcl(ctx, &s3.PutBucketAclInput{
+			Bucket: &bucket,
+			ACL:    types.BucketCannedACL("invalid_acl"),
+		})
+		cancel()
+		// the expected error message is empty for this case
+		// only check the error Code
+		return checkSdkApiErr(err, "InvalidArgument")
+	}, withOwnership(types.ObjectOwnershipBucketOwnerPreferred))
+}
+
 func PutBucketAcl_invalid_acl_canned_and_acp(s *S3Conf) error {
 	testName := "PutBucketAcl_invalid_acl_canned_and_acp"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -85,6 +85,7 @@ func TestCreateBucket(ts *TestState) {
 	ts.Run(CreateBucket_invalid_tags)
 	ts.Run(CreateBucket_duplicate_keys)
 	ts.Run(CreateBucket_tag_count_limit)
+	ts.Run(CreateBucket_invalid_canned_acl)
 }
 
 func TestHeadBucket(ts *TestState) {
@@ -509,6 +510,7 @@ func TestPutBucketAcl(ts *TestState) {
 	ts.Run(PutBucketAcl_non_existing_bucket)
 	ts.Run(PutBucketAcl_disabled)
 	ts.Run(PutBucketAcl_none_of_the_options_specified)
+	ts.Run(PutBucketAcl_invalid_canned_acl)
 	ts.Run(PutBucketAcl_invalid_acl_canned_and_acp)
 	ts.Run(PutBucketAcl_invalid_acl_canned_and_grants)
 	ts.Run(PutBucketAcl_invalid_acl_acp_and_grants)
@@ -1145,6 +1147,7 @@ func GetIntTests() IntTests {
 		"CreateBucket_invalid_tags":                                               CreateBucket_invalid_tags,
 		"CreateBucket_duplicate_keys":                                             CreateBucket_duplicate_keys,
 		"CreateBucket_tag_count_limit":                                            CreateBucket_tag_count_limit,
+		"CreateBucket_invalid_canned_acl":                                         CreateBucket_invalid_canned_acl,
 		"HeadBucket_non_existing_bucket":                                          HeadBucket_non_existing_bucket,
 		"HeadBucket_success":                                                      HeadBucket_success,
 		"ListBuckets_as_user":                                                     ListBuckets_as_user,
@@ -1410,6 +1413,7 @@ func GetIntTests() IntTests {
 		"PutBucketAcl_non_existing_bucket":                                        PutBucketAcl_non_existing_bucket,
 		"PutBucketAcl_disabled":                                                   PutBucketAcl_disabled,
 		"PutBucketAcl_none_of_the_options_specified":                              PutBucketAcl_none_of_the_options_specified,
+		"PutBucketAcl_invalid_canned_acl":                                         PutBucketAcl_invalid_canned_acl,
 		"PutBucketAcl_invalid_acl_canned_and_acp":                                 PutBucketAcl_invalid_acl_canned_and_acp,
 		"PutBucketAcl_invalid_acl_canned_and_grants":                              PutBucketAcl_invalid_acl_canned_and_grants,
 		"PutBucketAcl_invalid_acl_acp_and_grants":                                 PutBucketAcl_invalid_acl_acp_and_grants,


### PR DESCRIPTION
Fixes #1379

Adds validation for bucket canned ACLs in `CreateBucket` and `PutBucketAcl`. The gateway supports three values: `private`, `public-read`, and `public-read-write`. All other values (including `authenticated-read`, which is not supported) are considered invalid and result in an `InvalidArgument` error with an empty error message.