### PR TITLE
fix: adds request body check for CopyObject and UploadPartCopy

### DIFF
--- a/s3api/controllers/object-put.go
+++ b/s3api/controllers/object-put.go
@@ -354,6 +354,15 @@ func (c S3ApiController) UploadPartCopy(ctx *fiber.Ctx) (*Response, error) {
 		}, err
 	}
 
+	if len(ctx.Request().Body()) != 0 {
+		debuglogger.Logf("expected empty request body")
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, s3err.GetAPIError(s3err.ErrNonEmptyRequestBody)
+	}
+
 	if partNumber < minPartNumber || partNumber > maxPartNumber {
 		debuglogger.Logf("invalid part number: %d", partNumber)
 		return &Response{
@@ -488,6 +497,15 @@ func (c S3ApiController) CopyObject(ctx *fiber.Ctx) (*Response, error) {
 				BucketOwner: parsedAcl.Owner,
 			},
 		}, err
+	}
+
+	if len(ctx.Request().Body()) != 0 {
+		debuglogger.Logf("expected empty request body")
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, s3err.GetAPIError(s3err.ErrNonEmptyRequestBody)
 	}
 
 	metadata := utils.GetUserMetaData(&ctx.Request().Header)

--- a/s3api/controllers/object-put_test.go
+++ b/s3api/controllers/object-put_test.go
@@ -600,6 +600,27 @@ func TestS3ApiController_UploadPartCopy(t *testing.T) {
 			},
 		},
 		{
+			name: "non empty request body",
+			input: testInput{
+				locals: defaultLocals,
+				headers: map[string]string{
+					"X-Amz-Copy-Source": "bucket/object",
+				},
+				queries: map[string]string{
+					"partNumber": "2",
+				},
+				body: []byte("body"),
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{
+						BucketOwner: "root",
+					},
+				},
+				err: s3err.GetAPIError(s3err.ErrNonEmptyRequestBody),
+			},
+		},
+		{
 			name: "invalid part number",
 			input: testInput{
 				locals: defaultLocals,
@@ -696,6 +717,7 @@ func TestS3ApiController_UploadPartCopy(t *testing.T) {
 					locals:  tt.input.locals,
 					headers: tt.input.headers,
 					queries: tt.input.queries,
+					body:    tt.input.body,
 				})
 		})
 	}
@@ -815,6 +837,24 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 					},
 				},
 				err: s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket),
+			},
+		},
+		{
+			name: "invalid copy source",
+			input: testInput{
+				locals: defaultLocals,
+				headers: map[string]string{
+					"X-Amz-Copy-Source": "bucket/object",
+				},
+				body: []byte("body"),
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{
+						BucketOwner: "root",
+					},
+				},
+				err: s3err.GetAPIError(s3err.ErrNonEmptyRequestBody),
 			},
 		},
 		{
@@ -999,6 +1039,7 @@ func TestS3ApiController_CopyObject(t *testing.T) {
 				ctxInputs{
 					locals:  tt.input.locals,
 					headers: tt.input.headers,
+					body:    tt.input.body,
 				})
 		})
 	}

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -87,6 +87,7 @@ const (
 	ErrInvalidPartOrder
 	ErrInvalidCompleteMpPartNumber
 	ErrInternalError
+	ErrNonEmptyRequestBody
 	ErrInvalidCopyDest
 	ErrInvalidCopySourceRange
 	ErrInvalidCopySourceBucket
@@ -317,6 +318,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "InternalError",
 		Description:    "We encountered an internal error, please try again.",
 		HTTPStatusCode: http.StatusInternalServerError,
+	},
+	ErrNonEmptyRequestBody: {
+		Code:           "InvalidRequest",
+		Description:    "The request included a body. Requests of this type must not include a non-empty body.",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidPart: {
 		Code:           "InvalidPart",


### PR DESCRIPTION
Fixes #1242

S3 returns a specific error for actions that expect an empty request body but receive a non-empty one. Such actions include **CopyObject** and **UploadPartCopy**, which are HTTP PUT requests with no request body. This implementation adds a check for these actions and returns the corresponding error.