### PR TITLE
feat: adds projectID prop in IAM user account

### DIFF
--- a/auth/iam.go
+++ b/auth/iam.go
@@ -45,11 +45,12 @@ func (r Role) IsValid() bool {
 
 // Account is a gateway IAM account
 type Account struct {
-	Access  string `json:"access"`
-	Secret  string `json:"secret"`
-	Role    Role   `json:"role"`
-	UserID  int    `json:"userID"`
-	GroupID int    `json:"groupID"`
+	Access    string `json:"access"`
+	Secret    string `json:"secret"`
+	Role      Role   `json:"role"`
+	UserID    int    `json:"userID"`
+	GroupID   int    `json:"groupID"`
+	ProjectID int    `json:"projectID"`
 }
 
 type ListUserAccountsResult struct {
@@ -58,10 +59,11 @@ type ListUserAccountsResult struct {
 
 // Mutable props, which could be changed when updating an IAM account
 type MutableProps struct {
-	Secret  *string `json:"secret"`
-	Role    Role    `json:"role"`
-	UserID  *int    `json:"userID"`
-	GroupID *int    `json:"groupID"`
+	Secret    *string `json:"secret"`
+	Role      Role    `json:"role"`
+	UserID    *int    `json:"userID"`
+	GroupID   *int    `json:"groupID"`
+	ProjectID *int    `json:"projectID"`
 }
 
 func (m MutableProps) Validate() error {
@@ -81,6 +83,9 @@ func updateAcc(acc *Account, props MutableProps) {
 	}
 	if props.UserID != nil {
 		acc.UserID = *props.UserID
+	}
+	if props.ProjectID != nil {
+		acc.ProjectID = *props.ProjectID
 	}
 	if props.Role != "" {
 		acc.Role = props.Role
@@ -119,6 +124,7 @@ type Opts struct {
 	LDAPRoleAtr                 string
 	LDAPUserIdAtr               string
 	LDAPGroupIdAtr              string
+	LDAPProjectIdAtr            string
 	LDAPTLSSkipVerify           bool
 	VaultEndpointURL            string
 	VaultNamespace              string
@@ -160,7 +166,7 @@ func New(o *Opts) (IAMService, error) {
 	case o.LDAPServerURL != "":
 		svc, err = NewLDAPService(o.RootAccount, o.LDAPServerURL, o.LDAPBindDN, o.LDAPPassword,
 			o.LDAPQueryBase, o.LDAPAccessAtr, o.LDAPSecretAtr, o.LDAPRoleAtr, o.LDAPUserIdAtr,
-			o.LDAPGroupIdAtr, o.LDAPObjClasses, o.LDAPTLSSkipVerify)
+			o.LDAPGroupIdAtr, o.LDAPProjectIdAtr, o.LDAPObjClasses, o.LDAPTLSSkipVerify)
 		fmt.Printf("initializing LDAP IAM with %q\n", o.LDAPServerURL)
 	case o.S3Endpoint != "":
 		svc, err = NewS3(o.RootAccount, o.S3Access, o.S3Secret, o.S3Region, o.S3Bucket,

--- a/auth/iam_internal.go
+++ b/auth/iam_internal.go
@@ -194,11 +194,12 @@ func (s *IAMServiceInternal) ListUserAccounts() ([]Account, error) {
 	var accs []Account
 	for _, k := range keys {
 		accs = append(accs, Account{
-			Access:  k,
-			Secret:  conf.AccessAccounts[k].Secret,
-			Role:    conf.AccessAccounts[k].Role,
-			UserID:  conf.AccessAccounts[k].UserID,
-			GroupID: conf.AccessAccounts[k].GroupID,
+			Access:    k,
+			Secret:    conf.AccessAccounts[k].Secret,
+			Role:      conf.AccessAccounts[k].Role,
+			UserID:    conf.AccessAccounts[k].UserID,
+			GroupID:   conf.AccessAccounts[k].GroupID,
+			ProjectID: conf.AccessAccounts[k].ProjectID,
 		})
 	}
 

--- a/auth/iam_ipa.go
+++ b/auth/iam_ipa.go
@@ -132,6 +132,7 @@ func (ipa *IpaIAMService) GetUserAccount(access string) (Account, error) {
 	userResult := struct {
 		Gidnumber []string
 		Uidnumber []string
+		PidNumber []string
 	}{}
 
 	err = ipa.rpc(req, &userResult)
@@ -147,12 +148,17 @@ func (ipa *IpaIAMService) GetUserAccount(access string) (Account, error) {
 	if err != nil {
 		return Account{}, fmt.Errorf("ipa gid invalid: %w", err)
 	}
+	pId, err := strconv.Atoi(userResult.PidNumber[0])
+	if err != nil {
+		return Account{}, fmt.Errorf("ipa pid invalid: %w", err)
+	}
 
 	account := Account{
-		Access:  access,
-		Role:    RoleUser,
-		UserID:  uid,
-		GroupID: gid,
+		Access:    access,
+		Role:      RoleUser,
+		UserID:    uid,
+		GroupID:   gid,
+		ProjectID: pId,
 	}
 
 	session_key := make([]byte, 16)

--- a/auth/iam_s3_object.go
+++ b/auth/iam_s3_object.go
@@ -205,11 +205,12 @@ func (s *IAMServiceS3) ListUserAccounts() ([]Account, error) {
 	var accs []Account
 	for _, k := range keys {
 		accs = append(accs, Account{
-			Access:  k,
-			Secret:  conf.AccessAccounts[k].Secret,
-			Role:    conf.AccessAccounts[k].Role,
-			UserID:  conf.AccessAccounts[k].UserID,
-			GroupID: conf.AccessAccounts[k].GroupID,
+			Access:    k,
+			Secret:    conf.AccessAccounts[k].Secret,
+			Role:      conf.AccessAccounts[k].Role,
+			UserID:    conf.AccessAccounts[k].UserID,
+			GroupID:   conf.AccessAccounts[k].GroupID,
+			ProjectID: conf.AccessAccounts[k].ProjectID,
 		})
 	}
 

--- a/auth/iam_vault.go
+++ b/auth/iam_vault.go
@@ -369,12 +369,21 @@ func parseVaultUserAccount(data map[string]any, access string) (acc Account, err
 	if err != nil {
 		return acc, errInvalidUser
 	}
+	projectIdJson, ok := usrAcc["projectID"].(json.Number)
+	if !ok {
+		return acc, errInvalidUser
+	}
+	projectID, err := projectIdJson.Int64()
+	if err != nil {
+		return acc, errInvalidUser
+	}
 
 	return Account{
-		Access:  acss,
-		Secret:  secret,
-		Role:    Role(role),
-		UserID:  int(userId),
-		GroupID: int(groupId),
+		Access:    acss,
+		Secret:    secret,
+		Role:      Role(role),
+		UserID:    int(userId),
+		GroupID:   int(groupId),
+		ProjectID: int(projectID),
 	}, nil
 }

--- a/cmd/versitygw/admin.go
+++ b/cmd/versitygw/admin.go
@@ -82,6 +82,11 @@ func adminCommand() *cli.Command {
 						Usage:   "groupID for the new user",
 						Aliases: []string{"gi"},
 					},
+					&cli.IntFlag{
+						Name:    "project-id",
+						Usage:   "projectID for the new user",
+						Aliases: []string{"pi"},
+					},
 				},
 			},
 			{
@@ -114,6 +119,11 @@ func adminCommand() *cli.Command {
 						Name:    "group-id",
 						Usage:   "groupID for the new user",
 						Aliases: []string{"gi"},
+					},
+					&cli.IntFlag{
+						Name:    "project-id",
+						Usage:   "projectID for the new user",
+						Aliases: []string{"pi"},
 					},
 				},
 			},
@@ -214,7 +224,7 @@ func initHTTPClient() *http.Client {
 
 func createUser(ctx *cli.Context) error {
 	access, secret, role := ctx.String("access"), ctx.String("secret"), ctx.String("role")
-	userID, groupID := ctx.Int("user-id"), ctx.Int("group-id")
+	userID, groupID, projectID := ctx.Int("user-id"), ctx.Int("group-id"), ctx.Int("project-id")
 	if access == "" || secret == "" {
 		return fmt.Errorf("invalid input parameters for the new user access/secret keys")
 	}
@@ -223,11 +233,12 @@ func createUser(ctx *cli.Context) error {
 	}
 
 	acc := auth.Account{
-		Access:  access,
-		Secret:  secret,
-		Role:    auth.Role(role),
-		UserID:  userID,
-		GroupID: groupID,
+		Access:    access,
+		Secret:    secret,
+		Role:      auth.Role(role),
+		UserID:    userID,
+		GroupID:   groupID,
+		ProjectID: projectID,
 	}
 
 	accxml, err := xml.Marshal(acc)
@@ -316,7 +327,14 @@ func deleteUser(ctx *cli.Context) error {
 }
 
 func updateUser(ctx *cli.Context) error {
-	access, secret, userId, groupId, role := ctx.String("access"), ctx.String("secret"), ctx.Int("user-id"), ctx.Int("group-id"), auth.Role(ctx.String("role"))
+	access, secret, userId, groupId, projectID, role :=
+		ctx.String("access"),
+		ctx.String("secret"),
+		ctx.Int("user-id"),
+		ctx.Int("group-id"),
+		ctx.Int("projectID"),
+		auth.Role(ctx.String("role"))
+
 	props := auth.MutableProps{}
 	if ctx.IsSet("role") {
 		if !role.IsValid() {
@@ -332,6 +350,9 @@ func updateUser(ctx *cli.Context) error {
 	}
 	if ctx.IsSet("group-id") {
 		props.GroupID = &groupId
+	}
+	if ctx.IsSet("project-id") {
+		props.ProjectID = &projectID
 	}
 
 	propsxml, err := xml.Marshal(props)
@@ -433,10 +454,10 @@ const (
 func printAcctTable(accs []auth.Account) {
 	w := new(tabwriter.Writer)
 	w.Init(os.Stdout, minwidth, tabwidth, padding, padchar, flags)
-	fmt.Fprintln(w, "Account\tRole\tUserID\tGroupID")
-	fmt.Fprintln(w, "-------\t----\t------\t-------")
+	fmt.Fprintln(w, "Account\tRole\tUserID\tGroupID\tProjectID")
+	fmt.Fprintln(w, "-------\t----\t------\t-------\t---------")
 	for _, acc := range accs {
-		fmt.Fprintf(w, "%v\t%v\t%v\t%v\n", acc.Access, acc.Role, acc.UserID, acc.GroupID)
+		fmt.Fprintf(w, "%v\t%v\t%v\t%v\t%v\n", acc.Access, acc.Role, acc.UserID, acc.GroupID, acc.ProjectID)
 	}
 	fmt.Fprintln(w)
 	w.Flush()

--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -65,6 +65,7 @@ var (
 	ldapQueryBase, ldapObjClasses          string
 	ldapAccessAtr, ldapSecAtr, ldapRoleAtr string
 	ldapUserIdAtr, ldapGroupIdAtr          string
+	ldapProjectIdAtr                       string
 	ldapTLSSkipVerify                      bool
 	vaultEndpointURL, vaultNamespace       string
 	vaultSecretStoragePath                 string
@@ -405,6 +406,12 @@ func initFlags() []cli.Flag {
 			EnvVars:     []string{"VGW_IAM_LDAP_GROUP_ID_ATR"},
 			Destination: &ldapGroupIdAtr,
 		},
+		&cli.StringFlag{
+			Name:        "iam-ldap-project-id-atr",
+			Usage:       "ldap server user project id attribute name",
+			EnvVars:     []string{"VGW_IAM_LDAP_PROJECT_ID_ATR"},
+			Destination: &ldapProjectIdAtr,
+		},
 		&cli.BoolFlag{
 			Name:        "iam-ldap-tls-skip-verify",
 			Usage:       "disable TLS certificate verification for LDAP connections (insecure, for self-signed certificates)",
@@ -699,6 +706,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		LDAPRoleAtr:                 ldapRoleAtr,
 		LDAPUserIdAtr:               ldapUserIdAtr,
 		LDAPGroupIdAtr:              ldapGroupIdAtr,
+		LDAPProjectIdAtr:            ldapProjectIdAtr,
 		LDAPTLSSkipVerify:           ldapTLSSkipVerify,
 		VaultEndpointURL:            vaultEndpointURL,
 		VaultNamespace:              vaultNamespace,


### PR DESCRIPTION
Closes #1621

These changes introduce the `projectID` field in IAM user accounts. The field has been added across all IAM systems: internal, IPA, LDAP, Vault, and S3 object. Support has also been added to the admin CLI commands to create, update, and list users with the `projectID` included.