### PR TITLE
fix: adds an error route for object calls with ?uploads query arg

### DIFF
--- a/s3api/router.go
+++ b/s3api/router.go
@@ -1004,6 +1004,13 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 		))
 
 	// GET object operations
+
+	// object operation with '?uploads' is rejected with a specific error
+	objectRouter.Get("",
+		middlewares.MatchQueryArgs("uploads"),
+		controllers.ProcessHandlers(ctrl.HandleErrorRoute(s3err.GetAPIError(s3err.ErrGetUploadsWithKey)), metrics.ActionUndetected, services),
+	)
+
 	objectRouter.Get("",
 		middlewares.MatchQueryArgs("tagging"),
 		controllers.ProcessHandlers(

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -123,6 +123,7 @@ const (
 	ErrInvalidAccessKeyID
 	ErrRequestNotReadyYet
 	ErrMissingDateHeader
+	ErrGetUploadsWithKey
 	ErrInvalidRequest
 	ErrAuthNotSetup
 	ErrNotImplemented
@@ -513,6 +514,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrMissingDateHeader: {
 		Code:           "AccessDenied",
 		Description:    "AWS authentication requires a valid Date or x-amz-date header.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrGetUploadsWithKey: {
+		Code:           "InvalidRequest",
+		Description:    "Key is not expected for the GET method ?uploads subresource",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidRequest: {

--- a/tests/integration/general.go
+++ b/tests/integration/general.go
@@ -124,6 +124,23 @@ func RouterPUTObjectOnlyUploadId(s *S3Conf) error {
 	})
 }
 
+func RouterGetUploadsWithKey(s *S3Conf) error {
+	testName := "RouterGetUploadsWithKey"
+	return actionHandlerNoSetup(s, testName, func(s3client *s3.Client, bucket string) error {
+		req, err := http.NewRequest(http.MethodGet, s.endpoint+"/bucket/object?uploads", nil)
+		if err != nil {
+			return err
+		}
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		return checkHTTPResponseApiErr(resp, s3err.GetAPIError(s3err.ErrGetUploadsWithKey))
+	})
+}
+
 // CORS middleware tests
 func CORSMiddleware_invalid_method(s *S3Conf) error {
 	testName := "CORSMiddleware_invalid_method"

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -1085,6 +1085,8 @@ func TestRouter(ts *TestState) {
 	ts.Run(RouterPutPartNumberWithoutUploadId)
 	ts.Run(RouterPostRoot)
 	ts.Run(RouterPostObjectWithoutQuery)
+	ts.Run(RouterPUTObjectOnlyUploadId)
+	ts.Run(RouterGetUploadsWithKey)
 }
 
 type IntTest func(s3 *S3Conf) error
@@ -1721,5 +1723,6 @@ func GetIntTests() IntTests {
 		"RouterPostRoot":                                                          RouterPostRoot,
 		"RouterPostObjectWithoutQuery":                                            RouterPostObjectWithoutQuery,
 		"RouterPUTObjectOnlyUploadId":                                             RouterPUTObjectOnlyUploadId,
+		"RouterGetUploadsWithKey":                                                 RouterGetUploadsWithKey,
 	}
 }


### PR DESCRIPTION
Fixes #1597

S3 returns a specific error when calling an object GET operation (e.g., `bucket/object/key?uploads`) with the `?uploads` query parameter. It’s not the standard `MethodNotAllowed` error. This PR adds support for handling this specific error route.