### PR TITLE
fix: adds error routes to reject x-amz-copy-source for GET, POST, HEAD, DELETE requests

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -124,6 +124,7 @@ const (
 	ErrRequestNotReadyYet
 	ErrMissingDateHeader
 	ErrGetUploadsWithKey
+	ErrCopySourceNotAllowed
 	ErrInvalidRequest
 	ErrAuthNotSetup
 	ErrNotImplemented
@@ -519,6 +520,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrGetUploadsWithKey: {
 		Code:           "InvalidRequest",
 		Description:    "Key is not expected for the GET method ?uploads subresource",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrCopySourceNotAllowed: {
+		Code:           "InvalidArgument",
+		Description:    "You can only specify a copy source header for copy requests.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidRequest: {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -1087,6 +1087,7 @@ func TestRouter(ts *TestState) {
 	ts.Run(RouterPostObjectWithoutQuery)
 	ts.Run(RouterPUTObjectOnlyUploadId)
 	ts.Run(RouterGetUploadsWithKey)
+	ts.Run(RouterCopySourceNotAllowed)
 }
 
 type IntTest func(s3 *S3Conf) error
@@ -1724,5 +1725,6 @@ func GetIntTests() IntTests {
 		"RouterPostObjectWithoutQuery":                                            RouterPostObjectWithoutQuery,
 		"RouterPUTObjectOnlyUploadId":                                             RouterPUTObjectOnlyUploadId,
 		"RouterGetUploadsWithKey":                                                 RouterGetUploadsWithKey,
+		"RouterCopySourceNotAllowed":                                              RouterCopySourceNotAllowed,
 	}
 }


### PR DESCRIPTION
Fixes #1612

`x-amz-copy-source` is rejected with an **InvalidArgument** error in S3 for all HTTP methods other than **PUT** (i.e., **GET**, **POST**, **HEAD**, and **DELETE**). For **POST** requests, the behavior is slightly different: the error is returned only when the **uploadId** query parameter is present; otherwise, **MethodNotAllowed** is returned. This behavior applies to both bucket-level and object-level operations.