### PR TITLE
fix: fixes the panic in GetBucketVersioning in s3 proxy

### DIFF
--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -285,11 +285,14 @@ func (s *S3Proxy) GetBucketVersioning(ctx context.Context, bucket string) (s3res
 	out, err := s.client.GetBucketVersioning(ctx, &s3.GetBucketVersioningInput{
 		Bucket: &bucket,
 	})
+	if err != nil {
+		return s3response.GetBucketVersioningOutput{}, handleError(err)
+	}
 
 	return s3response.GetBucketVersioningOutput{
 		Status:    &out.Status,
 		MFADelete: &out.MFADelete,
-	}, handleError(err)
+	}, nil
 }
 
 func (s *S3Proxy) ListObjectVersions(ctx context.Context, input *s3.ListObjectVersionsInput) (s3response.ListVersionsResult, error) {


### PR DESCRIPTION
Fixes #1649

`GetBucketVersioning` used to be a cause of a panic in s3 proxy backend, because of an inproper error handling. Now the error returned from the sdk method is explitily checked, before returning the response.