### PR TITLE
fix: adds validation for chunk sizes in unsigned streaming trailer upload

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -180,6 +180,7 @@ const (
 	ErrInvalidLocationConstraint
 	ErrInvalidArgument
 	ErrMalformedTrailer
+	ErrInvalidChunkSize
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -802,6 +803,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 	ErrMalformedTrailer: {
 		Code:           "MalformedTrailerError",
 		Description:    "The request contained trailing data that was not well-formed or did not conform to our published schema.",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidChunkSize: {
+		Code:           "InvalidChunkSizeError",
+		Description:    "Only the last chunk is allowed to have a size less than 8192 bytes",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -1101,6 +1101,7 @@ func TestUnsignedStreaminPayloadTrailer(ts *TestState) {
 		ts.Run(UnsignedStreamingPayloadTrailer_multiple_checksum_headers)
 		ts.Run(UnsignedStreamingPayloadTrailer_sdk_algo_and_trailer_mismatch)
 		ts.Run(UnsignedStreamingPayloadTrailer_incomplete_body)
+		ts.Run(UnsignedStreamingPayloadTrailer_invalid_chunk_size)
 		ts.Run(UnsignedStreamingPayloadTrailer_no_trailer_should_calculate_crc64nvme)
 		ts.Run(UnsignedStreamingPayloadTrailer_no_payload_trailer_only_headers)
 		ts.Run(UnsignedStreamingPayloadTrailer_success_both_sdk_algo_and_trailer)
@@ -1754,6 +1755,7 @@ func GetIntTests() IntTests {
 		"UnsignedStreamingPayloadTrailer_multiple_checksum_headers":                UnsignedStreamingPayloadTrailer_multiple_checksum_headers,
 		"UnsignedStreamingPayloadTrailer_sdk_algo_and_trailer_mismatch":            UnsignedStreamingPayloadTrailer_sdk_algo_and_trailer_mismatch,
 		"UnsignedStreamingPayloadTrailer_incomplete_body":                          UnsignedStreamingPayloadTrailer_incomplete_body,
+		"UnsignedStreamingPayloadTrailer_invalid_chunk_size":                       UnsignedStreamingPayloadTrailer_invalid_chunk_size,
 		"UnsignedStreamingPayloadTrailer_no_trailer_should_calculate_crc64nvme":    UnsignedStreamingPayloadTrailer_no_trailer_should_calculate_crc64nvme,
 		"UnsignedStreamingPayloadTrailer_no_payload_trailer_only_headers":          UnsignedStreamingPayloadTrailer_no_payload_trailer_only_headers,
 		"UnsignedStreamingPayloadTrailer_success_both_sdk_algo_and_trailer":        UnsignedStreamingPayloadTrailer_success_both_sdk_algo_and_trailer,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2093,3 +2093,28 @@ func testUnsignedStreamingPayloadTrailerUploadPart(s *S3Conf, bucket, object str
 
 	return sendSignedRequest(s, req, cancel)
 }
+
+// constructUnsignedPaylod constructs an unsigned streaming upload payload
+// and returns the decoded content length and the payload
+func constructUnsignedPaylod(chunkSizes ...int64) (int64, []byte, error) {
+	var cLength int64
+	buffer := bytes.NewBuffer([]byte{})
+
+	for _, chunkSize := range chunkSizes {
+		cLength += chunkSize
+		_, err := buffer.WriteString(fmt.Sprintf("%x\r\n", chunkSize))
+		if err != nil {
+			return 0, nil, err
+		}
+		_, err = buffer.WriteString(strings.Repeat("a", int(chunkSize)))
+		if err != nil {
+			return 0, nil, err
+		}
+		_, err = buffer.WriteString("\r\n")
+		if err != nil {
+			return 0, nil, err
+		}
+	}
+
+	return cLength, buffer.Bytes(), nil
+}


### PR DESCRIPTION
Fixes #1665

S3 enforces a validation rule for unsigned streaming payload trailer uploads: all chunk sizes must be greater than 8192 bytes except for the final chunk. This fix adds a check in the unsigned chunk reader that validates chunk sizes by comparing each chunk size to the previous one.