### PR TITLE
fix: Checks that x-amz-decoded-content-length matches the actual payload in unsigned streaming upload

### DIFF
--- a/s3api/middlewares/public-bucket.go
+++ b/s3api/middlewares/public-bucket.go
@@ -79,6 +79,10 @@ func AuthorizePublicBucketAccess(be backend.Backend, s3action string, policyPerm
 
 		if streamBody {
 			if utils.IsUnsignedStreamingPayload(payloadHash) {
+				cLength, err := utils.ParseDecodedContentLength(ctx)
+				if err != nil {
+					return err
+				}
 				// stack an unsigned streaming payload reader
 				checksumType, err := utils.ExtractChecksumType(ctx)
 				if err != nil {
@@ -87,7 +91,7 @@ func AuthorizePublicBucketAccess(be backend.Backend, s3action string, policyPerm
 
 				wrapBodyReader(ctx, func(r io.Reader) io.Reader {
 					var cr io.Reader
-					cr, err = utils.NewUnsignedChunkReader(r, checksumType)
+					cr, err = utils.NewUnsignedChunkReader(r, checksumType, cLength)
 					return cr
 				})
 

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -121,6 +121,7 @@ const (
 	ErrInvalidSHA256Paylod
 	ErrUnsupportedAnonymousSignedStreaming
 	ErrMissingContentLength
+	ErrContentLengthMismatch
 	ErrInvalidAccessKeyID
 	ErrRequestNotReadyYet
 	ErrMissingDateHeader
@@ -519,6 +520,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "MissingContentLength",
 		Description:    "You must provide the Content-Length HTTP header.",
 		HTTPStatusCode: http.StatusLengthRequired,
+	},
+	ErrContentLengthMismatch: {
+		Code:           "IncompleteBody",
+		Description:    "You did not provide the number of bytes specified by the Content-Length HTTP header",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrMissingDateHeader: {
 		Code:           "AccessDenied",

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -1102,6 +1102,7 @@ func TestUnsignedStreaminPayloadTrailer(ts *TestState) {
 		ts.Run(UnsignedStreamingPayloadTrailer_sdk_algo_and_trailer_mismatch)
 		ts.Run(UnsignedStreamingPayloadTrailer_incomplete_body)
 		ts.Run(UnsignedStreamingPayloadTrailer_invalid_chunk_size)
+		ts.Run(UnsignedStreamingPayloadTrailer_content_length_payload_size_mismatch)
 		ts.Run(UnsignedStreamingPayloadTrailer_no_trailer_should_calculate_crc64nvme)
 		ts.Run(UnsignedStreamingPayloadTrailer_no_payload_trailer_only_headers)
 		ts.Run(UnsignedStreamingPayloadTrailer_success_both_sdk_algo_and_trailer)
@@ -1756,6 +1757,7 @@ func GetIntTests() IntTests {
 		"UnsignedStreamingPayloadTrailer_sdk_algo_and_trailer_mismatch":            UnsignedStreamingPayloadTrailer_sdk_algo_and_trailer_mismatch,
 		"UnsignedStreamingPayloadTrailer_incomplete_body":                          UnsignedStreamingPayloadTrailer_incomplete_body,
 		"UnsignedStreamingPayloadTrailer_invalid_chunk_size":                       UnsignedStreamingPayloadTrailer_invalid_chunk_size,
+		"UnsignedStreamingPayloadTrailer_content_length_payload_size_mismatch":     UnsignedStreamingPayloadTrailer_content_length_payload_size_mismatch,
 		"UnsignedStreamingPayloadTrailer_no_trailer_should_calculate_crc64nvme":    UnsignedStreamingPayloadTrailer_no_trailer_should_calculate_crc64nvme,
 		"UnsignedStreamingPayloadTrailer_no_payload_trailer_only_headers":          UnsignedStreamingPayloadTrailer_no_payload_trailer_only_headers,
 		"UnsignedStreamingPayloadTrailer_success_both_sdk_algo_and_trailer":        UnsignedStreamingPayloadTrailer_success_both_sdk_algo_and_trailer,


### PR DESCRIPTION
Fixes #1676

`x-amz-decoded-content-length` in streaming uploads specifies the number of actual data-payload bytes, with encoding characters removed. If the value does not match the actual payload after decoding, now an `IncompleteBody` error is returned.