### PR TITLE
fix: Makes precondition headers insensitive to whether the value is quoted

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -495,6 +495,8 @@ func EvaluatePreconditions(etag string, modTime time.Time, preconditions PreCond
 		return nil
 	}
 
+	etag = strings.Trim(etag, `"`)
+
 	// convert all conditions to *bool to evaluate the conditions
 	var ifMatch, ifNoneMatch, ifModSince, ifUnmodeSince *bool
 	if preconditions.IfMatch != nil {
@@ -581,6 +583,7 @@ func EvaluatePreconditions(etag string, modTime time.Time, preconditions PreCond
 
 // EvaluateMatchPreconditions evaluates if-match and if-none-match preconditions
 func EvaluateMatchPreconditions(etag string, ifMatch, ifNoneMatch *string) error {
+	etag = strings.Trim(etag, `"`)
 	if ifMatch != nil && *ifMatch != etag {
 		return errPreconditionFailed
 	}

--- a/s3api/utils/precondition.go
+++ b/s3api/utils/precondition.go
@@ -67,7 +67,10 @@ func ParsePreconditionMatchHeaders(ctx *fiber.Ctx, opts ...preconditionOpt) (*st
 	if cfg.withCopySource {
 		prefix = "X-Amz-Copy-Source-"
 	}
-	return GetStringPtr(ctx.Get(prefix + "If-Match")), GetStringPtr(ctx.Get(prefix + "If-None-Match"))
+
+	ifMatch := trimQuotes(ctx.Get(prefix + "If-Match"))
+	ifNoneMatch := trimQuotes(ctx.Get(prefix + "If-None-Match"))
+	return GetStringPtr(ifMatch), GetStringPtr(ifNoneMatch)
 }
 
 // ParsePreconditionDateHeaders parses the "If-Modified-Since" and "If-Unmodified-Since"
@@ -135,4 +138,16 @@ func ParseIfMatchSize(ctx *fiber.Ctx) *int64 {
 	}
 
 	return &ifMatchSize
+}
+
+func trimQuotes(str string) string {
+	if len(str) < 2 {
+		return str
+	}
+
+	if str[0] == str[len(str)-1] && str[0] == '"' {
+		return str[1 : len(str)-1]
+	}
+
+	return str
 }

--- a/tests/integration/CopyObject.go
+++ b/tests/integration/CopyObject.go
@@ -910,6 +910,7 @@ func CopyObject_conditional_reads(s *S3Conf) error {
 		before := time.Now().AddDate(0, 0, -3)
 		after := time.Now()
 		etag := obj.res.ETag
+		etagTrimmed := strings.Trim(*etag, `"`)
 
 		for i, test := range []struct {
 			ifmatch           *string
@@ -1008,6 +1009,47 @@ func CopyObject_conditional_reads(s *S3Conf) error {
 			{nil, nil, nil, &before, errCond},
 			{nil, nil, nil, &after, nil},
 			{nil, nil, nil, nil, nil},
+
+			// if-match, if-non-match without quotes
+			{&etagTrimmed, getPtr("invalid_etag"), &before, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &before, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &before, nil, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, nil, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, nil, nil},
+
+			{&etagTrimmed, &etagTrimmed, &before, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, &before, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, &before, nil, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, nil, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, nil, errMod},
+
+			{&etagTrimmed, nil, &before, &before, nil},
+			{&etagTrimmed, nil, &before, &after, nil},
+			{&etagTrimmed, nil, &before, nil, nil},
+			{&etagTrimmed, nil, &after, &before, errMod},
+			{&etagTrimmed, nil, &after, &after, errMod},
+			{&etagTrimmed, nil, &after, nil, errMod},
+			{&etagTrimmed, nil, nil, &before, nil},
+			{&etagTrimmed, nil, nil, &after, nil},
+			{&etagTrimmed, nil, nil, nil, nil},
+
+			{nil, &etagTrimmed, &before, &before, errCond},
+			{nil, &etagTrimmed, &before, &after, errMod},
+			{nil, &etagTrimmed, &before, nil, errMod},
+			{nil, &etagTrimmed, &after, &before, errCond},
+			{nil, &etagTrimmed, &after, &after, errMod},
+			{nil, &etagTrimmed, &after, nil, errMod},
+			{nil, &etagTrimmed, nil, &before, errCond},
+			{nil, &etagTrimmed, nil, &after, errMod},
+			{nil, &etagTrimmed, nil, nil, errMod},
 		} {
 			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 			_, err := s3client.CopyObject(ctx, &s3.CopyObjectInput{

--- a/tests/integration/GetObject.go
+++ b/tests/integration/GetObject.go
@@ -379,6 +379,7 @@ func GetObject_conditional_reads(s *S3Conf) error {
 		before := time.Now().AddDate(0, 0, -3)
 		after := time.Now()
 		etag := obj.res.ETag
+		etagTrimmed := strings.Trim(*etag, `"`)
 
 		for i, test := range []struct {
 			ifmatch           *string
@@ -477,6 +478,47 @@ func GetObject_conditional_reads(s *S3Conf) error {
 			{nil, nil, nil, &before, errCond},
 			{nil, nil, nil, &after, nil},
 			{nil, nil, nil, nil, nil},
+
+			// if-match, if-non-match without quotes
+			{&etagTrimmed, getPtr("invalid_etag"), &before, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &before, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &before, nil, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, nil, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, nil, nil},
+
+			{&etagTrimmed, &etagTrimmed, &before, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, &before, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, &before, nil, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, nil, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, nil, errMod},
+
+			{&etagTrimmed, nil, &before, &before, nil},
+			{&etagTrimmed, nil, &before, &after, nil},
+			{&etagTrimmed, nil, &before, nil, nil},
+			{&etagTrimmed, nil, &after, &before, errMod},
+			{&etagTrimmed, nil, &after, &after, errMod},
+			{&etagTrimmed, nil, &after, nil, errMod},
+			{&etagTrimmed, nil, nil, &before, nil},
+			{&etagTrimmed, nil, nil, &after, nil},
+			{&etagTrimmed, nil, nil, nil, nil},
+
+			{nil, &etagTrimmed, &before, &before, errCond},
+			{nil, &etagTrimmed, &before, &after, errMod},
+			{nil, &etagTrimmed, &before, nil, errMod},
+			{nil, &etagTrimmed, &after, &before, errCond},
+			{nil, &etagTrimmed, &after, &after, errMod},
+			{nil, &etagTrimmed, &after, nil, errMod},
+			{nil, &etagTrimmed, nil, &before, errCond},
+			{nil, &etagTrimmed, nil, &after, errMod},
+			{nil, &etagTrimmed, nil, nil, errMod},
 		} {
 			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 			_, err := s3client.GetObject(ctx, &s3.GetObjectInput{

--- a/tests/integration/HeadObject.go
+++ b/tests/integration/HeadObject.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -422,6 +423,7 @@ func HeadObject_conditional_reads(s *S3Conf) error {
 		before := time.Now().AddDate(0, 0, -3)
 		after := time.Now()
 		etag := obj.res.ETag
+		etagTrimmed := strings.Trim(*etag, `"`)
 
 		for i, test := range []struct {
 			ifmatch           *string
@@ -520,6 +522,47 @@ func HeadObject_conditional_reads(s *S3Conf) error {
 			{nil, nil, nil, &before, errCond},
 			{nil, nil, nil, &after, nil},
 			{nil, nil, nil, nil, nil},
+
+			// if-match, if-non-match without quotes
+			{&etagTrimmed, getPtr("invalid_etag"), &before, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &before, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &before, nil, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), &after, nil, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, &before, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, &after, nil},
+			{&etagTrimmed, getPtr("invalid_etag"), nil, nil, nil},
+
+			{&etagTrimmed, &etagTrimmed, &before, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, &before, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, &before, nil, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, &after, nil, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, &before, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, &after, errMod},
+			{&etagTrimmed, &etagTrimmed, nil, nil, errMod},
+
+			{&etagTrimmed, nil, &before, &before, nil},
+			{&etagTrimmed, nil, &before, &after, nil},
+			{&etagTrimmed, nil, &before, nil, nil},
+			{&etagTrimmed, nil, &after, &before, errMod},
+			{&etagTrimmed, nil, &after, &after, errMod},
+			{&etagTrimmed, nil, &after, nil, errMod},
+			{&etagTrimmed, nil, nil, &before, nil},
+			{&etagTrimmed, nil, nil, &after, nil},
+			{&etagTrimmed, nil, nil, nil, nil},
+
+			{nil, &etagTrimmed, &before, &before, errCond},
+			{nil, &etagTrimmed, &before, &after, errMod},
+			{nil, &etagTrimmed, &before, nil, errMod},
+			{nil, &etagTrimmed, &after, &before, errCond},
+			{nil, &etagTrimmed, &after, &after, errMod},
+			{nil, &etagTrimmed, &after, nil, errMod},
+			{nil, &etagTrimmed, nil, &before, errCond},
+			{nil, &etagTrimmed, nil, &after, errMod},
+			{nil, &etagTrimmed, nil, nil, errMod},
 		} {
 			ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 			_, err := s3client.HeadObject(ctx, &s3.HeadObjectInput{


### PR DESCRIPTION
Fixes #1710

The `If-Match` and `If-None-Match` precondition header values represent object ETags. ETags are generally quoted; however, S3 evaluates precondition headers equivalently whether the ETag is quoted or not, comparing only the underlying value and ignoring the quotes if present.

The new implementation trims quotes from the ETag in both the input precondition header and the object metadata, ensuring that comparisons are performed purely on the ETag value and are insensitive to quoting.