### PR TITLE
fix: changes AuthorizationHeaderMalformed error status to 400

### DIFF
--- a/s3err/sigv4.go
+++ b/s3err/sigv4.go
@@ -24,7 +24,7 @@ func malformedAuthError(format string, args ...any) APIError {
 	return APIError{
 		Code:           "AuthorizationHeaderMalformed",
 		Description:    fmt.Sprintf("The authorization header is malformed; %s", fmt.Sprintf(format, args...)),
-		HTTPStatusCode: http.StatusForbidden,
+		HTTPStatusCode: http.StatusBadRequest,
 	}
 }
 


### PR DESCRIPTION
Fixes #1706

Changes the `AuthorizationHeaderMalformed` error http status code from `403` to `400`.