### PR TITLE
fix: fixes x-amz-if-match-size parsing

### DIFF
--- a/s3api/utils/precondition.go
+++ b/s3api/utils/precondition.go
@@ -128,6 +128,9 @@ func ParsePreconditionDateHeader(date string) *time.Time {
 // if parsing fails, returns nil
 func ParseIfMatchSize(ctx *fiber.Ctx) *int64 {
 	ifMatchSizeHdr := ctx.Get("x-amz-if-match-size")
+	if ifMatchSizeHdr == "" {
+		return nil
+	}
 	ifMatchSize, err := strconv.ParseInt(ifMatchSizeHdr, 10, 64)
 	if err != nil {
 		debuglogger.Logf("failed to parse 'x-amz-if-match-size': %s", ifMatchSizeHdr)


### PR DESCRIPTION
The `x-amz-if-match-size` parsing debug log used to appear for all `DeleteObject` calls when the header was missing. An empty-string check was missing, which led to attempting to parse an empty string into an `int64`, causing a failure and triggering the debug log. This check has now been added, and the debug log is emitted only when the header is present and contains an invalid `int64` value.