### PR TITLE
fix: removes Expect from sigv4 ignored headers list

### DIFF
--- a/aws/signer/internal/v4/headers.go
+++ b/aws/signer/internal/v4/headers.go
@@ -8,7 +8,8 @@ var IgnoredHeaders = Rules{
 			// some clients use user-agent in signed headers
 			// "User-Agent":      struct{}{},
 			"X-Amzn-Trace-Id": struct{}{},
-			"Expect":          struct{}{},
+			// Expect might appear in signed headers
+			// "Expect":          struct{}{},
 		},
 	},
 }

--- a/aws/signer/internal/v4/headers_test.go
+++ b/aws/signer/internal/v4/headers_test.go
@@ -41,7 +41,7 @@ func TestIgnoredHeaders(t *testing.T) {
 	}{
 		"expect": {
 			Header:        "Expect",
-			ExpectIgnored: true,
+			ExpectIgnored: false,
 		},
 		"authorization": {
 			Header:        "Authorization",

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -38,6 +38,7 @@ func TestAuthentication(ts *TestState) {
 	ts.Run(Authentication_invalid_sha256_payload_hash)
 	ts.Run(Authentication_md5)
 	ts.Run(Authentication_signature_error_incorrect_secret_key)
+	ts.Run(Authentication_with_expect_header)
 }
 
 func TestPresignedAuthentication(ts *TestState) {
@@ -1164,6 +1165,7 @@ func GetIntTests() IntTests {
 		"Authentication_invalid_sha256_payload_hash":                               Authentication_invalid_sha256_payload_hash,
 		"Authentication_md5":                                                       Authentication_md5,
 		"Authentication_signature_error_incorrect_secret_key":                      Authentication_signature_error_incorrect_secret_key,
+		"Authentication_with_expect_header":                                        Authentication_with_expect_header,
 		"PresignedAuth_security_token_not_supported":                               PresignedAuth_security_token_not_supported,
 		"PresignedAuth_unsupported_algorithm":                                      PresignedAuth_unsupported_algorithm,
 		"PresignedAuth_ECDSA_not_supported":                                        PresignedAuth_ECDSA_not_supported,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -286,11 +286,12 @@ type authConfig struct {
 	body     []byte
 	service  string
 	date     time.Time
+	headers  map[string]string
 }
 
 func authHandler(s *S3Conf, cfg *authConfig, handler func(req *http.Request) error) error {
 	runF(cfg.testName)
-	req, err := createSignedReq(cfg.method, s.endpoint, cfg.path, s.awsID, s.awsSecret, cfg.service, s.awsRegion, cfg.body, cfg.date, nil)
+	req, err := createSignedReq(cfg.method, s.endpoint, cfg.path, s.awsID, s.awsSecret, cfg.service, s.awsRegion, cfg.body, cfg.date, cfg.headers)
 	if err != nil {
 		failF("%v: %v", cfg.testName, err)
 		return fmt.Errorf("%v: %w", cfg.testName, err)


### PR DESCRIPTION
Fixes #1707

The `Expect` HTTP header is ignored by the AWS SDK SigV4 signer and is omitted during signature calculation. As a result, the signature is computed incorrectly when the `Expect` header is included in the signed headers. This PR removes the `Expect` header from the SigV4 ignored headers list in the SDK-derived source code.