### PR TITLE
fix: adds versionId in put/get/delete object tagging actions response.

### DIFF
--- a/s3api/controllers/object-delete.go
+++ b/s3api/controllers/object-delete.go
@@ -72,6 +72,9 @@ func (c S3ApiController) DeleteObjectTagging(ctx *fiber.Ctx) (*Response, error) 
 
 	err = c.be.DeleteObjectTagging(ctx.Context(), bucket, key, versionId)
 	return &Response{
+		Headers: map[string]*string{
+			"x-amz-version-id": &versionId,
+		},
 		MetaOpts: &MetaOptions{
 			Status:      http.StatusNoContent,
 			BucketOwner: parsedAcl.Owner,

--- a/s3api/controllers/object-delete_test.go
+++ b/s3api/controllers/object-delete_test.go
@@ -20,12 +20,14 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/oklog/ulid/v2"
 	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3err"
 	"github.com/versity/versitygw/s3event"
 )
 
 func TestS3ApiController_DeleteObjectTagging(t *testing.T) {
+	versionId := ulid.Make().String()
 	tests := []struct {
 		name   string
 		input  testInput
@@ -65,11 +67,17 @@ func TestS3ApiController_DeleteObjectTagging(t *testing.T) {
 		{
 			name: "backend returns error",
 			input: testInput{
+				queries: map[string]string{
+					"versionId": versionId,
+				},
 				locals: defaultLocals,
 				beErr:  s3err.GetAPIError(s3err.ErrInvalidRequest),
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"x-amz-version-id": &versionId,
+					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 						Status:      http.StatusNoContent,
@@ -83,9 +91,15 @@ func TestS3ApiController_DeleteObjectTagging(t *testing.T) {
 			name: "successful response",
 			input: testInput{
 				locals: defaultLocals,
+				queries: map[string]string{
+					"versionId": versionId,
+				},
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"x-amz-version-id": &versionId,
+					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 						Status:      http.StatusNoContent,

--- a/s3api/controllers/object-get.go
+++ b/s3api/controllers/object-get.go
@@ -93,6 +93,9 @@ func (c S3ApiController) GetObjectTagging(ctx *fiber.Ctx) (*Response, error) {
 
 	return &Response{
 		Data: tags,
+		Headers: map[string]*string{
+			"x-amz-version-id": &versionId,
+		},
 		MetaOpts: &MetaOptions{
 			BucketOwner: parsedAcl.Owner,
 		},

--- a/s3api/controllers/object-get_test.go
+++ b/s3api/controllers/object-get_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3err"
@@ -33,6 +34,7 @@ import (
 )
 
 func TestS3ApiController_GetObjectTagging(t *testing.T) {
+	versionId := ulid.Make().String()
 	tests := []struct {
 		name   string
 		input  testInput
@@ -88,6 +90,9 @@ func TestS3ApiController_GetObjectTagging(t *testing.T) {
 		{
 			name: "successful response",
 			input: testInput{
+				queries: map[string]string{
+					"versionId": versionId,
+				},
 				locals: defaultLocals,
 				beRes: map[string]string{
 					"key": "val",
@@ -95,6 +100,9 @@ func TestS3ApiController_GetObjectTagging(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"x-amz-version-id": utils.GetStringPtr(versionId),
+					},
 					Data: s3response.Tagging{
 						TagSet: s3response.TagSet{
 							Tags: []s3response.Tag{

--- a/s3api/controllers/object-put.go
+++ b/s3api/controllers/object-put.go
@@ -86,6 +86,9 @@ func (c S3ApiController) PutObjectTagging(ctx *fiber.Ctx) (*Response, error) {
 
 	err = c.be.PutObjectTagging(ctx.Context(), bucket, key, versionId, tagging)
 	return &Response{
+		Headers: map[string]*string{
+			"x-amz-version-id": &versionId,
+		},
 		MetaOpts: &MetaOptions{
 			BucketOwner: parsedAcl.Owner,
 			EventName:   s3event.EventObjectTaggingPut,

--- a/s3api/controllers/object-put_test.go
+++ b/s3api/controllers/object-put_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/oklog/ulid/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/s3api/utils"
@@ -44,6 +45,8 @@ func TestS3ApiController_PutObjectTagging(t *testing.T) {
 			},
 		})
 	assert.NoError(t, err)
+
+	versionId := ulid.Make().String()
 
 	tests := []struct {
 		name   string
@@ -102,9 +105,15 @@ func TestS3ApiController_PutObjectTagging(t *testing.T) {
 				locals: defaultLocals,
 				beErr:  s3err.GetAPIError(s3err.ErrNoSuchBucket),
 				body:   validTaggingBody,
+				queries: map[string]string{
+					"versionId": versionId,
+				},
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"x-amz-version-id": &versionId,
+					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 						EventName:   s3event.EventObjectTaggingPut,
@@ -118,9 +127,15 @@ func TestS3ApiController_PutObjectTagging(t *testing.T) {
 			input: testInput{
 				locals: defaultLocals,
 				body:   validTaggingBody,
+				queries: map[string]string{
+					"versionId": versionId,
+				},
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"x-amz-version-id": &versionId,
+					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 						EventName:   s3event.EventObjectTaggingPut,


### PR DESCRIPTION
Fixes #1693

`PutObjectTagging`, `GetObjectTagging` and `DeleteObjectTagging` return the `x-amz-version-id` in the response headers. The PR adds this header in the responses.