### PR TITLE
fix: fixes if-none-match precondition header logic in object write operations

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -594,6 +594,38 @@ func EvaluateMatchPreconditions(etag string, ifMatch, ifNoneMatch *string) error
 	return nil
 }
 
+// EvaluateObjectPutPreconditions evaluates if-match and if-none-match preconditions
+// for object PUT(PutObject, CompleteMultipartUpload) actions
+func EvaluateObjectPutPreconditions(etag string, ifMatch, ifNoneMatch *string, objExists bool) error {
+	if ifMatch == nil && ifNoneMatch == nil {
+		return nil
+	}
+
+	if ifNoneMatch != nil && *ifNoneMatch != "*" {
+		return s3err.GetAPIError(s3err.ErrNotImplemented)
+	}
+
+	if ifNoneMatch != nil && ifMatch != nil {
+		return s3err.GetAPIError(s3err.ErrNotImplemented)
+	}
+
+	if ifNoneMatch != nil && objExists {
+		return s3err.GetAPIError(s3err.ErrPreconditionFailed)
+	}
+
+	if ifMatch != nil && !objExists {
+		return s3err.GetAPIError(s3err.ErrNoSuchKey)
+	}
+
+	etag = strings.Trim(etag, `"`)
+
+	if ifMatch != nil && *ifMatch != etag {
+		return s3err.GetAPIError(s3err.ErrPreconditionFailed)
+	}
+
+	return nil
+}
+
 type ObjectDeletePreconditions struct {
 	IfMatch            *string
 	IfMatchLastModTime *time.Time

--- a/tests/integration/CompleteMultipartUpload.go
+++ b/tests/integration/CompleteMultipartUpload.go
@@ -1378,6 +1378,7 @@ func CompleteMultipartUpload_conditional_writes(s *S3Conf) error {
 		incorrectEtag := getPtr("incorrect_etag")
 		errPrecond := s3err.GetAPIError(s3err.ErrPreconditionFailed)
 		errNoSuchKey := s3err.GetAPIError(s3err.ErrNoSuchKey)
+		errNotImplemented := s3err.GetAPIError(s3err.ErrNotImplemented)
 
 		for i, test := range []struct {
 			obj         string
@@ -1386,28 +1387,33 @@ func CompleteMultipartUpload_conditional_writes(s *S3Conf) error {
 			err         error
 		}{
 			{obj, etag, nil, nil},
-			{obj, etag, etag, errPrecond},
-			{obj, etag, incorrectEtag, nil},
-			{obj, incorrectEtag, incorrectEtag, errPrecond},
-			{obj, incorrectEtag, etag, errPrecond},
+			{obj, etag, etag, errNotImplemented},
+			{obj, etag, incorrectEtag, errNotImplemented},
+			{obj, incorrectEtag, incorrectEtag, errNotImplemented},
+			{obj, incorrectEtag, etag, errNotImplemented},
 			{obj, incorrectEtag, nil, errPrecond},
-			{obj, nil, incorrectEtag, nil},
-			{obj, nil, etag, errPrecond},
+			{obj, nil, incorrectEtag, errNotImplemented},
+			{obj, nil, etag, errNotImplemented},
+			{obj, nil, getPtr("*"), errPrecond},
+			{obj, etag, getPtr("*"), errNotImplemented},
 			{obj, nil, nil, nil},
-			// should return NoSuchKey error, if any precondition
-			// header is present, but object doesn't exist
-			{"obj-1", incorrectEtag, etag, errNoSuchKey},
-			{"obj-2", etag, etag, errNoSuchKey},
-			{"obj-3", etag, incorrectEtag, errNoSuchKey},
-			{"obj-4", incorrectEtag, nil, errNoSuchKey},
-			{"obj-5", nil, etag, errNoSuchKey},
 
-			// precondtion headers without quotes
+			// precondition headers without quotes
 			{obj, &etagTrimmed, nil, nil},
-			{obj, &etagTrimmed, &etagTrimmed, errPrecond},
-			{obj, &etagTrimmed, incorrectEtag, nil},
-			{obj, incorrectEtag, &etagTrimmed, errPrecond},
-			{obj, nil, &etagTrimmed, errPrecond},
+			{obj, &etagTrimmed, &etagTrimmed, errNotImplemented},
+			{obj, &etagTrimmed, incorrectEtag, errNotImplemented},
+			{obj, incorrectEtag, &etagTrimmed, errNotImplemented},
+			{obj, nil, &etagTrimmed, errNotImplemented},
+
+			// object deson't exist tests
+			{"obj-1", incorrectEtag, etag, errNotImplemented},
+			{"obj-2", etag, etag, errNotImplemented},
+			{"obj-3", etag, nil, errNoSuchKey},
+			{"obj-4", etag, incorrectEtag, errNotImplemented},
+			{"obj-5", incorrectEtag, nil, errNoSuchKey},
+			{"obj-6", nil, etag, errNotImplemented},
+			{"obj-7", nil, getPtr("*"), nil},
+			{"obj-8", etag, getPtr("*"), errNotImplemented},
 		} {
 			res, err := putObjectWithData(0, &s3.PutObjectInput{
 				Bucket: &bucket,


### PR DESCRIPTION
Fixes #1708

This PR focuses on evaluating the `x-amz-if-none-match` precondition header for object PUT operations. If any value other than `*` is provided, a `NotImplemented` error is returned. If `If-Match` is used together with `If-None-Match`, regardless of the value combination, a `NotImplemented` error is returned. When only `If-None-Match: *` is specified, a `PreconditionFailed` error is returned if the object already exists in `PutObject` or `CompleteMultipartUpload`; if the object does not exist, object creation is allowed.