### PR TITLE
fix: fixes CreateBucket LocationConstraint validation

### DIFF
--- a/s3api/controllers/bucket-put.go
+++ b/s3api/controllers/bucket-put.go
@@ -562,10 +562,10 @@ func (c S3ApiController) CreateBucket(ctx *fiber.Ctx) (*Response, error) {
 			}, s3err.GetAPIError(s3err.ErrMalformedXML)
 		}
 
-		if body.LocationConstraint != "" {
+		if body.LocationConstraint != nil {
 			region := utils.ContextKeyRegion.Get(ctx).(string)
-			if body.LocationConstraint != region {
-				debuglogger.Logf("invalid location constraint: %s", body.LocationConstraint)
+			if *body.LocationConstraint != region || *body.LocationConstraint == "us-east-1" {
+				debuglogger.Logf("invalid location constraint: %s", *body.LocationConstraint)
 				return &Response{
 					MetaOpts: &MetaOptions{
 						BucketOwner: acct.Access,

--- a/s3api/controllers/bucket-put_test.go
+++ b/s3api/controllers/bucket-put_test.go
@@ -700,7 +700,7 @@ func TestS3ApiController_CreateBucket(t *testing.T) {
 	}
 
 	invLocConstBody, err := xml.Marshal(s3response.CreateBucketConfiguration{
-		LocationConstraint: "us-west-1",
+		LocationConstraint: utils.GetStringPtr("us-west-1"),
 	})
 	assert.NoError(t, err)
 

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -730,6 +730,6 @@ type LocationConstraint struct {
 }
 
 type CreateBucketConfiguration struct {
-	LocationConstraint string
+	LocationConstraint *string
 	TagSet             []types.Tag `xml:"Tags>Tag"`
 }


### PR DESCRIPTION
Fixes #1654
Fixes #1644

CreateBucket `LocationConstraint` rejects empty values with an `InvalidLocationConstraint` error. The `us-east-1` `LocationConstraint` is considered invalid because it is the default value and must not be present in the `CreateBucketConfiguration` request body.

This PR fixes both issues by returning `InvalidLocationConstraint` in both cases.