### PR TITLE
fix: return null in GetBucketLocation for us-east-1

### DIFF
--- a/s3api/controllers/bucket-get.go
+++ b/s3api/controllers/bucket-get.go
@@ -658,10 +658,14 @@ func (c S3ApiController) GetBucketLocation(ctx *fiber.Ctx) (*Response, error) {
 
 	// pick up configured region from locals (set by router middleware)
 	region, _ := ctx.Locals("region").(string)
+	value := &region
+	if region == "us-east-1" {
+		value = nil
+	}
 
 	return &Response{
 		Data: s3response.LocationConstraint{
-			Value: region,
+			Value: value,
 		},
 		MetaOpts: &MetaOptions{
 			BucketOwner: parsedAcl.Owner,

--- a/s3api/controllers/bucket-get_test.go
+++ b/s3api/controllers/bucket-get_test.go
@@ -1303,14 +1303,40 @@ func TestS3ApiController_GetBucketLocation(t *testing.T) {
 			},
 		},
 		{
-			name: "successful response",
+			name: "successful response us-east-1",
 			input: testInput{
 				locals: defaultLocals,
 			},
 			output: testOutput{
 				response: &Response{
 					Data: s3response.LocationConstraint{
-						Value: "us-east-1",
+						Value: nil,
+					},
+					MetaOpts: &MetaOptions{
+						BucketOwner: "root",
+					},
+				},
+			},
+		},
+		{
+			name: "successful response",
+			input: testInput{
+				locals: map[utils.ContextKey]any{
+					utils.ContextKeyIsRoot: true,
+					utils.ContextKeyParsedAcl: auth.ACL{
+						Owner: "root",
+					},
+					utils.ContextKeyAccount: auth.Account{
+						Access: "root",
+						Role:   auth.RoleAdmin,
+					},
+					utils.ContextKeyRegion: "us-east-2",
+				},
+			},
+			output: testOutput{
+				response: &Response{
+					Data: s3response.LocationConstraint{
+						Value: utils.GetStringPtr("us-east-2"),
 					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",

--- a/s3response/s3response.go
+++ b/s3response/s3response.go
@@ -726,7 +726,7 @@ type Checksum struct {
 // LocationConstraint represents the GetBucketLocation response
 type LocationConstraint struct {
 	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LocationConstraint"`
-	Value   string   `xml:",chardata"`
+	Value   *string  `xml:",chardata"`
 }
 
 type CreateBucketConfiguration struct {

--- a/tests/integration/GetBucketLocation.go
+++ b/tests/integration/GetBucketLocation.go
@@ -34,9 +34,14 @@ func GetBucketLocation_success(s *S3Conf) error {
 			return err
 		}
 
-		if string(resp.LocationConstraint) != s.awsRegion {
+		expectedLocConstraint := s.awsRegion
+		if s.awsRegion == "us-east-1" {
+			expectedLocConstraint = ""
+		}
+
+		if string(resp.LocationConstraint) != expectedLocConstraint {
 			return fmt.Errorf("expected bucket region to be %v, instead got %v",
-				s.awsRegion, resp.LocationConstraint)
+				expectedLocConstraint, resp.LocationConstraint)
 		}
 
 		return nil


### PR DESCRIPTION
Fixes #1643

`GetBucketLocation` in S3 returns empty `LocationConstraint` if the bucket is in the `us-east-1` region. This fix returns empty `LocationConstraint` if the gateway region is `us-east-1`.