### PR TITLE
feat: add option for default global cors allow origin headers

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -42,6 +42,7 @@ var (
 	rootUserAccess                         string
 	rootUserSecret                         string
 	region                                 string
+	corsAllowOrigin                        string
 	admCertFile, admKeyFile                string
 	certFile, keyFile                      string
 	kafkaURL, kafkaTopic, kafkaKey         string
@@ -187,6 +188,12 @@ func initFlags() []cli.Flag {
 			Value:       "us-east-1",
 			Destination: &region,
 			Aliases:     []string{"r"},
+		},
+		&cli.StringFlag{
+			Name:        "cors-allow-origin",
+			Usage:       "default CORS Access-Control-Allow-Origin value (applied when no bucket CORS configuration exists, and for admin APIs)",
+			EnvVars:     []string{"VGW_CORS_ALLOW_ORIGIN"},
+			Destination: &corsAllowOrigin,
 		},
 		&cli.StringFlag{
 			Name:        "cert",
@@ -649,6 +656,9 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 	}
 
 	var opts []s3api.Option
+	if corsAllowOrigin != "" {
+		opts = append(opts, s3api.WithCORSAllowOrigin(corsAllowOrigin))
+	}
 
 	if certFile != "" || keyFile != "" {
 		if certFile == "" {
@@ -786,6 +796,9 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 
 	if admPort != "" {
 		var opts []s3api.AdminOpt
+		if corsAllowOrigin != "" {
+			opts = append(opts, s3api.WithAdminCORSAllowOrigin(corsAllowOrigin))
+		}
 
 		if admCertFile != "" || admKeyFile != "" {
 			if admCertFile == "" {

--- a/s3api/admin-router.go
+++ b/s3api/admin-router.go
@@ -26,7 +26,7 @@ import (
 
 type S3AdminRouter struct{}
 
-func (ar *S3AdminRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMService, logger s3log.AuditLogger, root middlewares.RootUserConfig, region string, debug bool) {
+func (ar *S3AdminRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMService, logger s3log.AuditLogger, root middlewares.RootUserConfig, region string, debug bool, corsAllowOrigin string) {
 	ctrl := controllers.NewAdminController(iam, be, logger)
 	services := &controllers.Services{
 		Logger: logger,
@@ -37,40 +37,70 @@ func (ar *S3AdminRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMSe
 		controllers.ProcessHandlers(ctrl.CreateUser, metrics.ActionAdminCreateUser, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
 			middlewares.IsAdmin(metrics.ActionAdminCreateUser),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
+	app.Options("/create-user",
+		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),
+		middlewares.ApplyDefaultCORS(corsAllowOrigin),
+	)
 
 	// DeleteUsers admin api
 	app.Patch("/delete-user",
 		controllers.ProcessHandlers(ctrl.DeleteUser, metrics.ActionAdminDeleteUser, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
 			middlewares.IsAdmin(metrics.ActionAdminDeleteUser),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
+	app.Options("/delete-user",
+		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),
+		middlewares.ApplyDefaultCORS(corsAllowOrigin),
+	)
 
 	// UpdateUser admin api
 	app.Patch("/update-user",
 		controllers.ProcessHandlers(ctrl.UpdateUser, metrics.ActionAdminUpdateUser, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
 			middlewares.IsAdmin(metrics.ActionAdminUpdateUser),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
+	app.Options("/update-user",
+		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),
+		middlewares.ApplyDefaultCORS(corsAllowOrigin),
+	)
 
 	// ListUsers admin api
 	app.Patch("/list-users",
 		controllers.ProcessHandlers(ctrl.ListUsers, metrics.ActionAdminListUsers, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
 			middlewares.IsAdmin(metrics.ActionAdminListUsers),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
+	app.Options("/list-users",
+		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),
+		middlewares.ApplyDefaultCORS(corsAllowOrigin),
+	)
 
 	// ChangeBucketOwner admin api
 	app.Patch("/change-bucket-owner",
 		controllers.ProcessHandlers(ctrl.ChangeBucketOwner, metrics.ActionAdminChangeBucketOwner, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
 			middlewares.IsAdmin(metrics.ActionAdminChangeBucketOwner),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
+	app.Options("/change-bucket-owner",
+		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),
+		middlewares.ApplyDefaultCORS(corsAllowOrigin),
+	)
 
 	// ListBucketsAndOwners admin api
 	app.Patch("/list-buckets",
 		controllers.ProcessHandlers(ctrl.ListBuckets, metrics.ActionAdminListBuckets, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
 			middlewares.IsAdmin(metrics.ActionAdminListBuckets),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
+	app.Options("/list-buckets",
+		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),
+		middlewares.ApplyDefaultCORS(corsAllowOrigin),
+	)
 }

--- a/s3api/admin-server.go
+++ b/s3api/admin-server.go
@@ -28,13 +28,14 @@ import (
 )
 
 type S3AdminServer struct {
-	app     *fiber.App
-	backend backend.Backend
-	router  *S3AdminRouter
-	port    string
-	cert    *tls.Certificate
-	quiet   bool
-	debug   bool
+	app             *fiber.App
+	backend         backend.Backend
+	router          *S3AdminRouter
+	port            string
+	cert            *tls.Certificate
+	quiet           bool
+	debug           bool
+	corsAllowOrigin string
 }
 
 func NewAdminServer(be backend.Backend, root middlewares.RootUserConfig, port, region string, iam auth.IAMService, l s3log.AuditLogger, opts ...AdminOpt) *S3AdminServer {
@@ -73,7 +74,7 @@ func NewAdminServer(be backend.Backend, root middlewares.RootUserConfig, port, r
 	app.Use(controllers.WrapMiddleware(middlewares.DecodeURL, l, nil))
 	app.Use(middlewares.DebugLogger())
 
-	server.router.Init(app, be, iam, l, root, region, server.debug)
+	server.router.Init(app, be, iam, l, root, region, server.debug, server.corsAllowOrigin)
 
 	return server
 }
@@ -92,6 +93,12 @@ func WithAdminQuiet() AdminOpt {
 // WithAdminDebug enables the debug logging
 func WithAdminDebug() AdminOpt {
 	return func(s *S3AdminServer) { s.debug = true }
+}
+
+// WithAdminCORSAllowOrigin sets the default CORS Access-Control-Allow-Origin value
+// for the standalone admin server.
+func WithAdminCORSAllowOrigin(origin string) AdminOpt {
+	return func(s *S3AdminServer) { s.corsAllowOrigin = origin }
 }
 
 func (sa *S3AdminServer) Serve() (err error) {

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -237,6 +237,21 @@ func TestSetResponseHeaders(t *testing.T) {
 	}
 }
 
+func TestEnsureExposeMetaHeaders_AddsActualMetaHeaderNames(t *testing.T) {
+	app := fiber.New()
+	ctx := app.AcquireCtx(&fasthttp.RequestCtx{})
+
+	ctx.Response().Header.Add("Access-Control-Allow-Origin", "https://example.com")
+	ctx.Response().Header.Add("Access-Control-Expose-Headers", "ETag")
+	ctx.Response().Header.Set("x-amz-meta-foo", "bar")
+	ctx.Response().Header.Set("x-amz-meta-bar", "baz")
+
+	ensureExposeMetaHeaders(ctx)
+
+	got := string(ctx.Response().Header.Peek("Access-Control-Expose-Headers"))
+	assert.Equal(t, "ETag, X-Amz-Meta-Bar, X-Amz-Meta-Foo", got)
+}
+
 // mock the audit logger
 type mockAuditLogger struct {
 }

--- a/s3api/controllers/cors_default_origin_test.go
+++ b/s3api/controllers/cors_default_origin_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package controllers
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/s3api/middlewares"
+	"github.com/versity/versitygw/s3err"
+)
+
+func TestApplyBucketCORS_FallbackOrigin_NoBucketCors_NoRequestOrigin(t *testing.T) {
+	origin := "https://example.com"
+
+	mockedBackend := &BackendMock{
+		GetBucketCorsFunc: func(ctx context.Context, bucket string) ([]byte, error) {
+			return nil, s3err.GetAPIError(s3err.ErrNoSuchCORSConfiguration)
+		},
+	}
+
+	app := fiber.New()
+	app.Get("/:bucket/test",
+		middlewares.ApplyBucketCORS(mockedBackend, origin),
+		func(c *fiber.Ctx) error {
+			return c.SendStatus(http.StatusOK)
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "/mybucket/test", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin to be set to fallback, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Expose-Headers"); got != "ETag" {
+		t.Fatalf("expected Access-Control-Expose-Headers to include ETag, got %q", got)
+	}
+}
+
+func TestApplyBucketCORS_FallbackOrigin_NotAppliedWhenBucketCorsExists(t *testing.T) {
+	origin := "https://example.com"
+
+	mockedBackend := &BackendMock{
+		GetBucketCorsFunc: func(ctx context.Context, bucket string) ([]byte, error) {
+			return []byte("not-parsed"), nil
+		},
+	}
+
+	app := fiber.New()
+	app.Get("/:bucket/test",
+		middlewares.ApplyBucketCORS(mockedBackend, origin),
+		func(c *fiber.Ctx) error {
+			return c.SendStatus(http.StatusOK)
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "/mybucket/test", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("expected no Access-Control-Allow-Origin when bucket CORS exists, got %q", got)
+	}
+}

--- a/s3api/middlewares/apply-bucket-cors-preflight.go
+++ b/s3api/middlewares/apply-bucket-cors-preflight.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/s3err"
+)
+
+// ApplyBucketCORSPreflightFallback handles CORS preflight (OPTIONS) requests for S3 routes
+// when no per-bucket CORS configuration exists.
+//
+// If the bucket has no CORS configuration and fallbackOrigin is set, it responds with 204 and:
+// - Access-Control-Allow-Origin: fallbackOrigin
+// - Vary: Origin, Access-Control-Request-Headers, Access-Control-Request-Method
+// - Access-Control-Allow-Methods: mirrors Access-Control-Request-Method (if present)
+// - Access-Control-Allow-Headers: mirrors Access-Control-Request-Headers (if present)
+//
+// If the bucket has a CORS configuration (or fallbackOrigin is blank), it calls next so the
+// standard CORS OPTIONS handler can apply bucket-specific rules.
+func ApplyBucketCORSPreflightFallback(be backend.Backend, fallbackOrigin string) fiber.Handler {
+	fallbackOrigin = strings.TrimSpace(fallbackOrigin)
+	if fallbackOrigin == "" {
+		return func(ctx *fiber.Ctx) error { return ctx.Next() }
+	}
+
+	return func(ctx *fiber.Ctx) error {
+		bucket := ctx.Params("bucket")
+		_, err := be.GetBucketCors(ctx.Context(), bucket)
+		if err != nil {
+			if s3Err, ok := err.(s3err.APIError); ok && (s3Err.Code == "NoSuchCORSConfiguration" || s3Err.Code == "NoSuchBucket") {
+				if len(ctx.Response().Header.Peek("Access-Control-Allow-Origin")) == 0 {
+					ctx.Response().Header.Add("Access-Control-Allow-Origin", fallbackOrigin)
+				}
+				if len(ctx.Response().Header.Peek("Vary")) == 0 {
+					ctx.Response().Header.Add("Vary", VaryHdr)
+				}
+
+				if reqMethod := strings.TrimSpace(ctx.Get("Access-Control-Request-Method")); reqMethod != "" {
+					if len(ctx.Response().Header.Peek("Access-Control-Allow-Methods")) == 0 {
+						ctx.Response().Header.Add("Access-Control-Allow-Methods", reqMethod)
+					}
+				}
+
+				if reqHeaders := strings.TrimSpace(ctx.Get("Access-Control-Request-Headers")); reqHeaders != "" {
+					if len(ctx.Response().Header.Peek("Access-Control-Allow-Headers")) == 0 {
+						ctx.Response().Header.Add("Access-Control-Allow-Headers", reqHeaders)
+					}
+				}
+
+				ctx.Status(fiber.StatusNoContent)
+				return nil
+			}
+		}
+
+		return ctx.Next()
+	}
+}

--- a/s3api/middlewares/apply-bucket-cors-preflight_test.go
+++ b/s3api/middlewares/apply-bucket-cors-preflight_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/s3err"
+)
+
+type backendWithGetBucketCors struct {
+	backend.BackendUnsupported
+	getBucketCors func(ctx context.Context, bucket string) ([]byte, error)
+}
+
+func (b backendWithGetBucketCors) GetBucketCors(ctx context.Context, bucket string) ([]byte, error) {
+	return b.getBucketCors(ctx, bucket)
+}
+
+func TestApplyBucketCORSPreflightFallback_NoBucketCors_Responds204(t *testing.T) {
+	be := backendWithGetBucketCors{
+		getBucketCors: func(ctx context.Context, bucket string) ([]byte, error) {
+			return nil, s3err.GetAPIError(s3err.ErrNoSuchCORSConfiguration)
+		},
+	}
+
+	app := fiber.New()
+	app.Options("/:bucket",
+		ApplyBucketCORSPreflightFallback(be, "https://example.com"),
+		func(c *fiber.Ctx) error {
+			// Should not be reached if fallback triggers
+			return c.SendStatus(http.StatusTeapot)
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodOptions, "/testing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "https://request-origin.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("expected allow origin fallback, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Methods"); got != "GET" {
+		t.Fatalf("expected allow methods to mirror request, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Headers"); got != "content-type" {
+		t.Fatalf("expected allow headers to mirror request, got %q", got)
+	}
+}
+
+func TestApplyBucketCORSPreflightFallback_NoSuchBucket_Responds204(t *testing.T) {
+	be := backendWithGetBucketCors{
+		getBucketCors: func(ctx context.Context, bucket string) ([]byte, error) {
+			return nil, s3err.GetAPIError(s3err.ErrNoSuchBucket)
+		},
+	}
+
+	app := fiber.New()
+	app.Options("/:bucket",
+		ApplyBucketCORSPreflightFallback(be, "https://example.com"),
+		func(c *fiber.Ctx) error {
+			return c.SendStatus(http.StatusTeapot)
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodOptions, "/testing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "https://request-origin.example")
+	req.Header.Set("Access-Control-Request-Method", "PUT")
+	req.Header.Set("Access-Control-Request-Headers", "content-type")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://example.com" {
+		t.Fatalf("expected allow origin fallback, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Methods"); got != "PUT" {
+		t.Fatalf("expected allow methods to mirror request, got %q", got)
+	}
+}
+
+func TestApplyBucketCORSPreflightFallback_BucketHasCors_CallsNext(t *testing.T) {
+	be := backendWithGetBucketCors{
+		getBucketCors: func(ctx context.Context, bucket string) ([]byte, error) {
+			return []byte("dummy"), nil
+		},
+	}
+
+	app := fiber.New()
+	app.Options("/:bucket",
+		ApplyBucketCORSPreflightFallback(be, "https://example.com"),
+		func(c *fiber.Ctx) error {
+			return c.SendStatus(http.StatusOK)
+		},
+	)
+
+	req, err := http.NewRequest(http.MethodOptions, "/testing", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected status 200 from next handler, got %d", resp.StatusCode)
+	}
+}

--- a/s3api/middlewares/apply-default-cors-preflight.go
+++ b/s3api/middlewares/apply-default-cors-preflight.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// ApplyDefaultCORSPreflight responds to CORS preflight (OPTIONS) requests for routes
+// that don't have per-bucket CORS configuration (e.g. admin APIs).
+//
+// It uses the provided fallbackOrigin as the Access-Control-Allow-Origin value.
+// It mirrors Access-Control-Request-Method into Access-Control-Allow-Methods and
+// mirrors Access-Control-Request-Headers into Access-Control-Allow-Headers.
+func ApplyDefaultCORSPreflight(fallbackOrigin string) fiber.Handler {
+	fallbackOrigin = strings.TrimSpace(fallbackOrigin)
+	if fallbackOrigin == "" {
+		return func(ctx *fiber.Ctx) error { return nil }
+	}
+
+	return func(ctx *fiber.Ctx) error {
+		if len(ctx.Response().Header.Peek("Access-Control-Allow-Origin")) == 0 {
+			ctx.Response().Header.Add("Access-Control-Allow-Origin", fallbackOrigin)
+		}
+		if len(ctx.Response().Header.Peek("Vary")) == 0 {
+			ctx.Response().Header.Add("Vary", VaryHdr)
+		}
+
+		if reqMethod := strings.TrimSpace(ctx.Get("Access-Control-Request-Method")); reqMethod != "" {
+			if len(ctx.Response().Header.Peek("Access-Control-Allow-Methods")) == 0 {
+				ctx.Response().Header.Add("Access-Control-Allow-Methods", reqMethod)
+			}
+		}
+
+		if reqHeaders := strings.TrimSpace(ctx.Get("Access-Control-Request-Headers")); reqHeaders != "" {
+			if len(ctx.Response().Header.Peek("Access-Control-Allow-Headers")) == 0 {
+				ctx.Response().Header.Add("Access-Control-Allow-Headers", reqHeaders)
+			}
+		}
+
+		ctx.Status(fiber.StatusNoContent)
+		return nil
+	}
+}

--- a/s3api/middlewares/apply-default-cors-preflight_test.go
+++ b/s3api/middlewares/apply-default-cors-preflight_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestApplyDefaultCORSPreflight_OptionsSetsPreflightHeaders(t *testing.T) {
+	origin := "https://example.com"
+
+	app := fiber.New()
+	app.Options("/admin",
+		ApplyDefaultCORSPreflight(origin),
+		ApplyDefaultCORS(origin),
+		func(c *fiber.Ctx) error { return nil },
+	)
+
+	req, err := http.NewRequest(http.MethodOptions, "/admin", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "https://request-origin.example")
+	req.Header.Set("Access-Control-Request-Method", "PATCH")
+	req.Header.Set("Access-Control-Request-Headers", "content-type,authorization")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected allow origin fallback, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Methods"); got != "PATCH" {
+		t.Fatalf("expected allow methods to mirror request, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Headers"); got != "content-type,authorization" {
+		t.Fatalf("expected allow headers to mirror request, got %q", got)
+	}
+}

--- a/s3api/middlewares/apply-default-cors.go
+++ b/s3api/middlewares/apply-default-cors.go
@@ -1,0 +1,73 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"strings"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func ensureExposeETag(ctx *fiber.Ctx) {
+	existing := strings.TrimSpace(string(ctx.Response().Header.Peek("Access-Control-Expose-Headers")))
+	defaults := []string{"ETag"}
+	if existing == "" {
+		ctx.Response().Header.Add("Access-Control-Expose-Headers", strings.Join(defaults, ", "))
+		return
+	}
+
+	lowerExisting := map[string]struct{}{}
+	for _, part := range strings.Split(existing, ",") {
+		p := strings.ToLower(strings.TrimSpace(part))
+		if p != "" {
+			lowerExisting[p] = struct{}{}
+		}
+	}
+
+	updated := existing
+	for _, h := range defaults {
+		if _, ok := lowerExisting[strings.ToLower(h)]; ok {
+			continue
+		}
+		updated += ", " + h
+	}
+
+	if updated != existing {
+		ctx.Response().Header.Set("Access-Control-Expose-Headers", updated)
+	}
+}
+
+// ApplyDefaultCORS adds a default Access-Control-Allow-Origin header to responses
+// when the provided fallbackOrigin is non-empty.
+//
+// This is intended for routes that don't have per-bucket CORS configuration (e.g. admin APIs).
+// It will not override an existing Access-Control-Allow-Origin header.
+func ApplyDefaultCORS(fallbackOrigin string) fiber.Handler {
+	fallbackOrigin = strings.TrimSpace(fallbackOrigin)
+	if fallbackOrigin == "" {
+		return func(ctx *fiber.Ctx) error { return nil }
+	}
+
+	return func(ctx *fiber.Ctx) error {
+		if len(ctx.Response().Header.Peek("Access-Control-Allow-Origin")) == 0 {
+			ctx.Response().Header.Add("Access-Control-Allow-Origin", fallbackOrigin)
+		}
+		if len(ctx.Response().Header.Peek("Vary")) == 0 {
+			ctx.Response().Header.Add("Vary", VaryHdr)
+		}
+		ensureExposeETag(ctx)
+		return nil
+	}
+}

--- a/s3api/middlewares/apply-default-cors_test.go
+++ b/s3api/middlewares/apply-default-cors_test.go
@@ -1,0 +1,74 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func TestApplyDefaultCORS_AddsHeaderWhenOriginSet(t *testing.T) {
+	origin := "https://example.com"
+
+	app := fiber.New()
+	app.Get("/admin", ApplyDefaultCORS(origin), func(c *fiber.Ctx) error {
+		return c.SendStatus(http.StatusOK)
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/admin", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected fallback origin header, got %q", got)
+	}
+	if got := resp.Header.Get("Access-Control-Expose-Headers"); got != "ETag" {
+		t.Fatalf("expected expose headers to include ETag, got %q", got)
+	}
+}
+
+func TestApplyDefaultCORS_DoesNotOverrideExistingHeader(t *testing.T) {
+	origin := "https://example.com"
+
+	app := fiber.New()
+	app.Get("/admin", func(c *fiber.Ctx) error {
+		c.Response().Header.Add("Access-Control-Allow-Origin", "https://already-set.com")
+		return nil
+	}, ApplyDefaultCORS(origin), func(c *fiber.Ctx) error {
+		return c.SendStatus(http.StatusOK)
+	})
+
+	req, err := http.NewRequest(http.MethodGet, "/admin", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://already-set.com" {
+		t.Fatalf("expected existing header to remain, got %q", got)
+	}
+}

--- a/s3api/router_cors_test.go
+++ b/s3api/router_cors_test.go
@@ -1,0 +1,253 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package s3api
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/auth"
+	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/s3api/middlewares"
+	"github.com/versity/versitygw/s3err"
+)
+
+type backendWithCorsOnly struct {
+	backend.BackendUnsupported
+}
+
+func (b backendWithCorsOnly) GetBucketCors(ctx context.Context, bucket string) ([]byte, error) {
+	return nil, s3err.GetAPIError(s3err.ErrNoSuchCORSConfiguration)
+}
+
+func TestS3ApiRouter_ListBuckets_DefaultCORSAllowOrigin(t *testing.T) {
+	origin := "https://example.com"
+
+	app := fiber.New()
+	(&S3ApiRouter{}).Init(
+		app,
+		backend.BackendUnsupported{},
+		&auth.IAMServiceInternal{},
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"us-east-1",
+		"",
+		middlewares.RootUserConfig{},
+		origin,
+	)
+
+	req, err := http.NewRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+	if got := resp.Header.Get("Access-Control-Expose-Headers"); got == "" {
+		t.Fatalf("expected Access-Control-Expose-Headers to be set")
+	}
+}
+
+func TestS3ApiRouter_ListBuckets_OptionsPreflight_DefaultCORS(t *testing.T) {
+	origin := "https://example.com"
+
+	app := fiber.New()
+	(&S3ApiRouter{}).Init(
+		app,
+		backend.BackendUnsupported{},
+		&auth.IAMServiceInternal{},
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"us-east-1",
+		"",
+		middlewares.RootUserConfig{},
+		origin,
+	)
+
+	req, err := http.NewRequest(http.MethodOptions, "/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", "https://client.example")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Headers", "authorization")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected status %d, got %d", http.StatusNoContent, resp.StatusCode)
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+}
+
+func TestS3ApiRouter_PutBucketTagging_ErrorStillIncludesFallbackCORS(t *testing.T) {
+	origin := "http://127.0.0.1:9090"
+
+	app := fiber.New()
+	(&S3ApiRouter{}).Init(
+		app,
+		backendWithCorsOnly{},
+		&auth.IAMServiceInternal{},
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"us-east-1",
+		"",
+		middlewares.RootUserConfig{},
+		origin,
+	)
+
+	req, err := http.NewRequest(http.MethodPut, "/testing?tagging", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", origin)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+}
+
+func TestS3ApiRouter_PutObjectTagging_ErrorStillIncludesFallbackCORS(t *testing.T) {
+	origin := "http://127.0.0.1:9090"
+
+	app := fiber.New()
+	(&S3ApiRouter{}).Init(
+		app,
+		backendWithCorsOnly{},
+		&auth.IAMServiceInternal{},
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"us-east-1",
+		"",
+		middlewares.RootUserConfig{},
+		origin,
+	)
+
+	req, err := http.NewRequest(http.MethodPut, "/testing/myobj?tagging", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", origin)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+}
+
+func TestS3ApiRouter_CopyObject_ErrorStillIncludesFallbackCORS(t *testing.T) {
+	origin := "http://127.0.0.1:9090"
+
+	app := fiber.New()
+	(&S3ApiRouter{}).Init(
+		app,
+		backendWithCorsOnly{},
+		&auth.IAMServiceInternal{},
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"us-east-1",
+		"",
+		middlewares.RootUserConfig{},
+		origin,
+	)
+
+	req, err := http.NewRequest(http.MethodPut, "/testing/myobj", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", origin)
+	req.Header.Set("X-Amz-Copy-Source", "srcbucket/srckey")
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+}
+
+func TestS3ApiRouter_PutObject_ErrorStillIncludesFallbackCORS(t *testing.T) {
+	origin := "http://127.0.0.1:9090"
+
+	app := fiber.New()
+	(&S3ApiRouter{}).Init(
+		app,
+		backendWithCorsOnly{},
+		&auth.IAMServiceInternal{},
+		nil,
+		nil,
+		nil,
+		nil,
+		false,
+		"us-east-1",
+		"",
+		middlewares.RootUserConfig{},
+		origin,
+	)
+
+	req, err := http.NewRequest(http.MethodPut, "/testing/myobj", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Origin", origin)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatalf("app.Test: %v", err)
+	}
+
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != origin {
+		t.Fatalf("expected Access-Control-Allow-Origin %q, got %q", origin, got)
+	}
+}

--- a/s3api/router_test.go
+++ b/s3api/router_test.go
@@ -46,7 +46,7 @@ func TestS3ApiRouter_Init(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.sa.Init(tt.args.app, tt.args.be, tt.args.iam, nil, nil, nil, nil, false, "us-east-1", "", middlewares.RootUserConfig{})
+			tt.sa.Init(tt.args.app, tt.args.be, tt.args.iam, nil, nil, nil, nil, false, "us-east-1", "", middlewares.RootUserConfig{}, "")
 		})
 	}
 }

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -41,16 +41,17 @@ const (
 )
 
 type S3ApiServer struct {
-	app           *fiber.App
-	backend       backend.Backend
-	router        *S3ApiRouter
-	port          string
-	cert          *tls.Certificate
-	quiet         bool
-	readonly      bool
-	keepAlive     bool
-	health        string
-	virtualDomain string
+	app             *fiber.App
+	backend         backend.Backend
+	router          *S3ApiRouter
+	port            string
+	cert            *tls.Certificate
+	quiet           bool
+	readonly        bool
+	keepAlive       bool
+	health          string
+	virtualDomain   string
+	corsAllowOrigin string
 }
 
 func New(
@@ -123,7 +124,7 @@ func New(
 		app.Use(middlewares.DebugLogger())
 	}
 
-	server.router.Init(app, be, iam, l, adminLogger, evs, mm, server.readonly, region, server.virtualDomain, root)
+	server.router.Init(app, be, iam, l, adminLogger, evs, mm, server.readonly, region, server.virtualDomain, root, server.corsAllowOrigin)
 
 	return server, nil
 }
@@ -163,6 +164,12 @@ func WithHostStyle(virtualDomain string) Option {
 // WithKeepAlive enables the server keep alive
 func WithKeepAlive() Option {
 	return func(s *S3ApiServer) { s.keepAlive = true }
+}
+
+// WithCORSAllowOrigin sets the default CORS Access-Control-Allow-Origin value.
+// This is applied when no bucket CORS configuration exists, and for admin APIs.
+func WithCORSAllowOrigin(origin string) Option {
+	return func(s *S3ApiServer) { s.corsAllowOrigin = origin }
 }
 
 func (sa *S3ApiServer) Serve() (err error) {


### PR DESCRIPTION
There is some desire to have a web dashboard for the gateway. So that we dont have to proxy all requests through the webserver and expose credentials over the wire, the better approach would be to enable CORS headers to allow browser requests directly to the s3/admin service.

The default for these headers is off, so that they are only enabled for instances that specfically want to support this workload.