### PR TITLE
feat: implements admin CreateBucket endpoint/cli command

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -246,7 +246,7 @@ func ParseACLOutput(data []byte, owner string) (GetBucketAclOutput, error) {
 	}, nil
 }
 
-func UpdateACL(input *PutBucketAclInput, acl ACL, iam IAMService, isAdmin bool) ([]byte, error) {
+func UpdateACL(input *PutBucketAclInput, acl ACL, iam IAMService) ([]byte, error) {
 	if input == nil {
 		return nil, s3err.GetAPIError(s3err.ErrInvalidRequest)
 	}

--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -157,7 +157,7 @@ func (az *Azure) CreateBucket(ctx context.Context, input *s3.CreateBucketInput, 
 		string(keyOwnership):  backend.GetPtrFromString(encodeBytes([]byte(input.ObjectOwnership))),
 	}
 
-	acct, ok := ctx.Value("account").(auth.Account)
+	acct, ok := ctx.Value("bucket-owner").(auth.Account)
 	if !ok {
 		acct = auth.Account{}
 	}

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -369,7 +369,7 @@ func (p *Posix) HeadBucket(_ context.Context, input *s3.HeadBucketInput) (*s3.He
 }
 
 func (p *Posix) CreateBucket(ctx context.Context, input *s3.CreateBucketInput, acl []byte) error {
-	acct, ok := ctx.Value("account").(auth.Account)
+	acct, ok := ctx.Value("bucket-owner").(auth.Account)
 	if !ok {
 		acct = auth.Account{}
 	}

--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -821,7 +821,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 			opts = append(opts, s3api.WithAdminDebug())
 		}
 
-		admSrv = s3api.NewAdminServer(be, middlewares.RootUserConfig{Access: rootUserAccess, Secret: rootUserSecret}, admPort, region, iam, loggers.AdminLogger, opts...)
+		admSrv = s3api.NewAdminServer(be, middlewares.RootUserConfig{Access: rootUserAccess, Secret: rootUserSecret}, admPort, region, iam, loggers.AdminLogger, srv.Router.Ctrl, opts...)
 	}
 
 	if !quiet {

--- a/metrics/actions.go
+++ b/metrics/actions.go
@@ -125,6 +125,7 @@ var (
 	ActionAdminChangeBucketOwner = "admin_ChangeBucketOwner"
 	ActionAdminListUsers         = "admin_ListUsers"
 	ActionAdminListBuckets       = "admin_ListBuckets"
+	ActionAdminCreateBucket      = "admin_CreateBucket"
 )
 
 func init() {

--- a/s3api/admin-server.go
+++ b/s3api/admin-server.go
@@ -38,11 +38,13 @@ type S3AdminServer struct {
 	corsAllowOrigin string
 }
 
-func NewAdminServer(be backend.Backend, root middlewares.RootUserConfig, port, region string, iam auth.IAMService, l s3log.AuditLogger, opts ...AdminOpt) *S3AdminServer {
+func NewAdminServer(be backend.Backend, root middlewares.RootUserConfig, port, region string, iam auth.IAMService, l s3log.AuditLogger, ctrl controllers.S3ApiController, opts ...AdminOpt) *S3AdminServer {
 	server := &S3AdminServer{
 		backend: be,
-		router:  new(S3AdminRouter),
-		port:    port,
+		router: &S3AdminRouter{
+			s3api: ctrl,
+		},
+		port: port,
 	}
 
 	for _, opt := range opts {

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -41,9 +41,9 @@ const (
 )
 
 type S3ApiServer struct {
+	Router          *S3ApiRouter
 	app             *fiber.App
 	backend         backend.Backend
-	router          *S3ApiRouter
 	port            string
 	cert            *tls.Certificate
 	quiet           bool
@@ -67,7 +67,7 @@ func New(
 ) (*S3ApiServer, error) {
 	server := &S3ApiServer{
 		backend: be,
-		router:  new(S3ApiRouter),
+		Router:  new(S3ApiRouter),
 		port:    port,
 	}
 
@@ -124,7 +124,7 @@ func New(
 		app.Use(middlewares.DebugLogger())
 	}
 
-	server.router.Init(app, be, iam, l, adminLogger, evs, mm, server.readonly, region, server.virtualDomain, root, server.corsAllowOrigin)
+	server.Router.Init(app, be, iam, l, adminLogger, evs, mm, server.readonly, region, server.virtualDomain, root, server.corsAllowOrigin)
 
 	return server, nil
 }
@@ -139,7 +139,7 @@ func WithTLS(cert tls.Certificate) Option {
 
 // WithAdminServer runs admin endpoints with the gateway in the same network
 func WithAdminServer() Option {
-	return func(s *S3ApiServer) { s.router.WithAdmSrv = true }
+	return func(s *S3ApiServer) { s.Router.WithAdmSrv = true }
 }
 
 // WithQuiet silences default logging output

--- a/s3api/server_test.go
+++ b/s3api/server_test.go
@@ -35,7 +35,7 @@ func TestS3ApiServer_Serve(t *testing.T) {
 				app:     fiber.New(),
 				backend: backend.BackendUnsupported{},
 				port:    "Invalid address",
-				router:  &S3ApiRouter{},
+				Router:  &S3ApiRouter{},
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestS3ApiServer_Serve(t *testing.T) {
 				app:     fiber.New(),
 				backend: backend.BackendUnsupported{},
 				port:    "Invalid address",
-				router:  &S3ApiRouter{},
+				Router:  &S3ApiRouter{},
 				cert:    &tls.Certificate{},
 			},
 		},

--- a/s3api/utils/context-keys.go
+++ b/s3api/utils/context-keys.go
@@ -36,6 +36,7 @@ const (
 	ContextKeyBodyReader     ContextKey = "body-reader"
 	ContextKeySkip           ContextKey = "__skip"
 	ContextKeyStack          ContextKey = "stack"
+	ContextKeyBucketOwner    ContextKey = "bucket-owner"
 )
 
 func (ck ContextKey) Values() []ContextKey {
@@ -50,6 +51,7 @@ func (ck ContextKey) Values() []ContextKey {
 		ContextKeyParsedAcl,
 		ContextKeySkipResBodyLog,
 		ContextKeyBodyReader,
+		ContextKeyBucketOwner,
 	}
 }
 

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -201,6 +201,7 @@ const (
 	ErrAdminInvalidUserRole
 	ErrAdminMissingUserAcess
 	ErrAdminMethodNotSupported
+	ErrAdminEmptyBucketOwnerHeader
 )
 
 var errorCodeResponse = map[ErrorCode]APIError{
@@ -897,6 +898,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "XAdminMethodNotSupported",
 		Description:    "The method is not supported in single root user mode.",
 		HTTPStatusCode: http.StatusNotImplemented,
+	},
+	ErrAdminEmptyBucketOwnerHeader: {
+		Code:           "XAdminInvalidRequest",
+		Description:    "The x-vgw-owner header specifying the new bucket owner access key id is either missing or empty",
+		HTTPStatusCode: http.StatusBadRequest,
 	},
 }
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -823,6 +823,7 @@ func TestFullFlow(ts *TestState) {
 	if ts.conf.versioningEnabled {
 		TestVersioning(ts)
 	}
+	TestIAM(ts)
 }
 
 func TestPosix(ts *TestState) {
@@ -945,7 +946,10 @@ func TestIAM(ts *TestState) {
 	ts.Run(IAM_userplus_CreateBucket)
 	ts.Run(IAM_admin_ChangeBucketOwner)
 	ts.Run(IAM_ChangeBucketOwner_back_to_root)
-	ts.Run(IAM_ListBuckets)
+	ts.Sync(IAM_ListBuckets)
+	ts.Run(IAM_CreateBucket_empty_owner_header)
+	ts.Run(IAM_CreateBucket_non_existing_user)
+	ts.Run(IAM_CreateBucket_success)
 }
 
 func TestAccessControl(ts *TestState) {
@@ -1672,6 +1676,10 @@ func GetIntTests() IntTests {
 		"IAM_userplus_CreateBucket":                                                IAM_userplus_CreateBucket,
 		"IAM_admin_ChangeBucketOwner":                                              IAM_admin_ChangeBucketOwner,
 		"IAM_ChangeBucketOwner_back_to_root":                                       IAM_ChangeBucketOwner_back_to_root,
+		"IAM_ListBuckets":                                                          IAM_ListBuckets,
+		"IAM_CreateBucket_empty_owner_header":                                      IAM_CreateBucket_empty_owner_header,
+		"IAM_CreateBucket_non_existing_user":                                       IAM_CreateBucket_non_existing_user,
+		"IAM_CreateBucket_success":                                                 IAM_CreateBucket_success,
 		"AccessControl_default_ACL_user_access_denied":                             AccessControl_default_ACL_user_access_denied,
 		"AccessControl_default_ACL_userplus_access_denied":                         AccessControl_default_ACL_userplus_access_denied,
 		"AccessControl_default_ACL_admin_successful_access":                        AccessControl_default_ACL_admin_successful_access,

--- a/tests/integration/iam.go
+++ b/tests/integration/iam.go
@@ -16,11 +16,16 @@ package integration
 
 import (
 	"context"
+	"encoding/xml"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/versity/versitygw/s3err"
+	"github.com/versity/versitygw/s3response"
 )
 
 func IAM_user_access_denied(s *S3Conf) error {
@@ -169,11 +174,191 @@ func IAM_ChangeBucketOwner_back_to_root(s *S3Conf) error {
 func IAM_ListBuckets(s *S3Conf) error {
 	testName := "IAM_ListBuckets"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
-		err := listBuckets(s)
+		return listBuckets(s)
+	})
+}
+
+func IAM_CreateBucket_empty_owner_header(s *S3Conf) error {
+	testName := "IAM_CreateBucket_empty_owner_header"
+	return actionHandlerNoSetup(s, testName, func(s3client *s3.Client, bucket string) error {
+		req, err := createSignedReq(
+			http.MethodPatch,
+			s.endpoint,
+			fmt.Sprintf("%s/create", bucket),
+			s.awsID,
+			s.awsSecret,
+			"s3",
+			s.awsRegion,
+			nil,
+			time.Now(),
+			nil,
+		)
 		if err != nil {
 			return err
 		}
 
-		return nil
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		return checkHTTPResponseApiErr(resp, s3err.GetAPIError(s3err.ErrAdminEmptyBucketOwnerHeader))
+	})
+}
+
+func IAM_CreateBucket_non_existing_user(s *S3Conf) error {
+	testName := "IAM_CreateBucket_non_existing_user"
+	return actionHandlerNoSetup(s, testName, func(s3client *s3.Client, bucket string) error {
+		req, err := createSignedReq(
+			http.MethodPatch,
+			s.endpoint,
+			fmt.Sprintf("%s/create", bucket),
+			s.awsID,
+			s.awsSecret,
+			"s3",
+			s.awsRegion,
+			nil,
+			time.Now(),
+			map[string]string{
+				"x-vgw-owner": "non-existing-user",
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		return checkHTTPResponseApiErr(resp, s3err.GetAPIError(s3err.ErrAdminUserNotFound))
+	})
+}
+
+func IAM_CreateBucket_success(s *S3Conf) error {
+	testName := "IAM_CreateBucket_success"
+	return actionHandlerNoSetup(s, testName, func(s3client *s3.Client, bucket string) error {
+		tagSet := []types.Tag{
+			{Key: getPtr("key"), Value: getPtr("value")},
+		}
+		body, err := xml.Marshal(s3response.CreateBucketConfiguration{
+			TagSet: tagSet,
+		})
+		if err != nil {
+			return err
+		}
+
+		testUser1, testUser2 := getUser("user"), getUser("user")
+		err = createUsers(s, []user{testUser1, testUser2})
+		if err != nil {
+			return err
+		}
+
+		req, err := createSignedReq(
+			http.MethodPatch,
+			s.endpoint,
+			fmt.Sprintf("%s/create", bucket),
+			s.awsID,
+			s.awsSecret,
+			"s3",
+			s.awsRegion,
+			body,
+			time.Now(),
+			map[string]string{
+				"x-amz-bucket-object-lock-enabled": "true",
+				"x-amz-object-ownership":           string(types.ObjectOwnershipBucketOwnerPreferred),
+				"x-amz-grant-read":                 testUser2.access,
+				"x-vgw-owner":                      testUser1.access,
+			},
+		)
+		if err != nil {
+			return err
+		}
+
+		resp, err := s.httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+
+		if resp.StatusCode != http.StatusCreated {
+			return fmt.Errorf("expected the response status code to be %v, instead got %v", http.StatusCreated, resp.StatusCode)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		tagging, err := s3client.GetBucketTagging(ctx, &s3.GetBucketTaggingInput{
+			Bucket: &bucket,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		if !areTagsSame(tagSet, tagging.TagSet) {
+			return fmt.Errorf("expected the bucket tagging to be %v, instead got %v", tagSet, tagging.TagSet)
+		}
+
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		ownership, err := s3client.GetBucketOwnershipControls(ctx, &s3.GetBucketOwnershipControlsInput{
+			Bucket: &bucket,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		var ownershipControls types.ObjectOwnership
+		if ownership.OwnershipControls != nil && len(ownership.OwnershipControls.Rules) == 1 {
+			ownershipControls = ownership.OwnershipControls.Rules[0].ObjectOwnership
+		}
+
+		if ownershipControls != types.ObjectOwnershipBucketOwnerPreferred {
+			return fmt.Errorf("expected the bucket ownership controls to be %s, instaed got %s", types.ObjectOwnershipBucketOwnerPreferred, ownershipControls)
+		}
+
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		acl, err := s3client.GetBucketAcl(ctx, &s3.GetBucketAclInput{
+			Bucket: &bucket,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		if len(acl.Grants) != 2 {
+			return fmt.Errorf("expected the length of acl grants to be 2, instead got %v", len(acl.Grants))
+		}
+
+		var granteeChecked bool
+		var ownerChecked bool
+		for _, grant := range acl.Grants {
+			// owner
+			if getString(grant.Grantee.ID) == testUser1.access {
+				ownerChecked = true
+				if grant.Permission != types.PermissionFullControl {
+					return fmt.Errorf("expected the owner '%s' to have %s permission, instead got %s", testUser1.access, types.PermissionFullControl, grant.Permission)
+				}
+
+				continue
+			}
+
+			if getString(grant.Grantee.ID) != testUser2.access {
+				return fmt.Errorf("expected the grantee ID to be %v, instaed got %v", testUser2.access, getString(grant.Grantee.ID))
+			}
+			if grant.Permission != types.PermissionRead {
+				return fmt.Errorf("expected the %v user permission to be %s, instead got %s", testUser2.access, types.PermissionRead, grant.Permission)
+			}
+
+			granteeChecked = true
+		}
+
+		if !ownerChecked {
+			return fmt.Errorf("missing the owner '%s' full control acl", testUser1.access)
+		}
+		if !granteeChecked {
+			return fmt.Errorf("missing the user %s in read grantees acl", testUser2.access)
+		}
+
+		return teardown(s, bucket)
 	})
 }


### PR DESCRIPTION
Closes #1731

Implements the admin `CreateBucket` (`PATCH /:bucket/create`) endpoint and CLI command, which create a new bucket with the provided owner access key ID. The endpoint internally calls the S3 `CreateBucket` API, storing the new owner information in the request context under the `bucket-owner` key. This value is then retrieved by the S3 API layer and the backends.

The endpoint uses the custom `x-vgw-owner` HTTP header to pass the bucket owner access key ID.

The admin CLI command mirrors `aws s3api create-bucket` and supports all flags implemented by the gateway (for example, `--create-bucket-configuration`, `--acl`, `--object-ownership`, etc.).