### PR TITLE
Fix ZFS xattr namespace usage on FreeBSD vs other platforms

### DIFF
--- a/backend/meta/xattr.go
+++ b/backend/meta/xattr.go
@@ -26,10 +26,6 @@ import (
 	"github.com/versity/versitygw/s3err"
 )
 
-const (
-	xattrPrefix = "user."
-)
-
 var (
 	// ErrNoSuchKey is returned when the key does not exist.
 	ErrNoSuchKey = errors.New("no such key")

--- a/backend/meta/xattr_freebsd.go
+++ b/backend/meta/xattr_freebsd.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build freebsd
+
+package meta
+
+const xattrPrefix = ""

--- a/backend/meta/xattr_other.go
+++ b/backend/meta/xattr_other.go
@@ -1,0 +1,19 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !freebsd
+
+package meta
+
+const xattrPrefix = "user."


### PR DESCRIPTION
Go's stdlib seems to handle the FreeBSD user. namespace directly, or FreeBSD itself doesn't require it. Make this a platform-specific feature.

Manually Tested:

- make & delete bucket
- create & delete files
- recursive copy file

```
 gmake test build
go test ./...
ok      github.com/versity/versitygw/auth       (cached)
?       github.com/versity/versitygw/aws/internal/awstesting/unit       [no test files]
ok      github.com/versity/versitygw/aws/signer/internal/v4     (cached)
ok      github.com/versity/versitygw/aws/signer/v4      (cached)
ok      github.com/versity/versitygw/backend    (cached)
?       github.com/versity/versitygw/backend/azure      [no test files]
?       github.com/versity/versitygw/backend/meta       [no test files]
?       github.com/versity/versitygw/backend/posix      [no test files]
?       github.com/versity/versitygw/backend/s3proxy    [no test files]
?       github.com/versity/versitygw/backend/scoutfs    [no test files]
ok      github.com/versity/versitygw/cmd/versitygw      (cached)
?       github.com/versity/versitygw/debuglogger        [no test files]
?       github.com/versity/versitygw/metrics    [no test files]
?       github.com/versity/versitygw/plugins    [no test files]
ok      github.com/versity/versitygw/s3api      (cached)
ok      github.com/versity/versitygw/s3api/controllers  (cached)
ok      github.com/versity/versitygw/s3api/middlewares  (cached)
ok      github.com/versity/versitygw/s3api/utils        (cached)
?       github.com/versity/versitygw/s3err      [no test files]
ok      github.com/versity/versitygw/s3event    (cached)
?       github.com/versity/versitygw/s3log      [no test files]
?       github.com/versity/versitygw/s3response [no test files]
?       github.com/versity/versitygw/s3select   [no test files]
?       github.com/versity/versitygw/tests/integration  [no test files]
?       github.com/versity/versitygw/tests/rest_scripts [no test files]
?       github.com/versity/versitygw/tests/rest_scripts/command [no test files]
?       github.com/versity/versitygw/tests/rest_scripts/config  [no test files]
?       github.com/versity/versitygw/tests/rest_scripts/logger  [no test files]
go build -ldflags "-X=main.Build=f4a951e -X=main.BuildTime=`date -u '+%Y-%m-%d_%I:%M:%S%p'` -X=main.Version=v1.0.20" -o versitygw cmd/versitygw/*.go
```

Fixes: #1745
