### PR TITLE
fix: skips object lock check in DeleteObject without versionId.

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -1076,6 +1076,9 @@ func TestVersioning(ts *TestState) {
 	ts.Run(Versioning_WORM_obj_version_locked_with_legal_hold)
 	ts.Run(Versioning_WORM_obj_version_locked_with_governance_retention)
 	ts.Run(Versioning_WORM_obj_version_locked_with_compliance_retention)
+	ts.Run(Versioning_WORM_delete_marker_locked_object_legal_hold)
+	ts.Run(Versioning_WORM_delete_marker_locked_object_governance_retention)
+	ts.Run(Versioning_WORM_delete_marker_locked_object_compliance_retention)
 	ts.Run(Versioning_WORM_PutObject_overwrite_locked_object)
 	ts.Run(Versioning_WORM_CopyObject_overwrite_locked_object)
 	ts.Run(Versioning_WORM_CompleteMultipartUpload_overwrite_locked_object)
@@ -1774,6 +1777,9 @@ func GetIntTests() IntTests {
 		"Versioning_WORM_obj_version_locked_with_legal_hold":                       Versioning_WORM_obj_version_locked_with_legal_hold,
 		"Versioning_WORM_obj_version_locked_with_governance_retention":             Versioning_WORM_obj_version_locked_with_governance_retention,
 		"Versioning_WORM_obj_version_locked_with_compliance_retention":             Versioning_WORM_obj_version_locked_with_compliance_retention,
+		"Versioning_WORM_delete_marker_locked_object_legal_hold":                   Versioning_WORM_delete_marker_locked_object_legal_hold,
+		"Versioning_WORM_delete_marker_locked_object_governance_retention":         Versioning_WORM_delete_marker_locked_object_governance_retention,
+		"Versioning_WORM_delete_marker_locked_object_compliance_retention":         Versioning_WORM_delete_marker_locked_object_compliance_retention,
 		"Versioning_WORM_PutObject_overwrite_locked_object":                        Versioning_WORM_PutObject_overwrite_locked_object,
 		"Versioning_WORM_CopyObject_overwrite_locked_object":                       Versioning_WORM_CopyObject_overwrite_locked_object,
 		"Versioning_WORM_CompleteMultipartUpload_overwrite_locked_object":          Versioning_WORM_CompleteMultipartUpload_overwrite_locked_object,


### PR DESCRIPTION
Fixes #1741

An object delete request without a `versionId` results in the creation of a new delete marker in versioning-enabled buckets. Even if the latest object version is locked, a new delete marker must still be created.

This implementation skips the object lock check for delete requests in versioning-enabled buckets when the `versionId` is missing, allowing the delete marker to be created as expected.

Additionally, it introduces a flag in the `createObjVersion` method in POSIX to remove unnecessary xattr attributes from an object after creating a new object version. A delete marker must not carry object-specific attributes such as tagging, legal hold, or retention. Currently, the cleanup is limited to legal hold and retention attributes, but this list will be expanded after fixing issue #1750.