### PR TITLE
fix: fixes missing bucket object lock config error

### DIFF
--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -138,7 +138,8 @@ const (
 	ErrInvalidURI
 	ErrObjectLockConfigurationNotFound
 	ErrNoSuchObjectLockConfiguration
-	ErrInvalidBucketObjectLockConfiguration
+	ErrMissingObjectLockConfiguration
+	ErrMissingObjectLockConfigurationNoSpaces
 	ErrObjectLockConfigurationNotAllowed
 	ErrObjectLocked
 	ErrInvalidRetainUntilDate
@@ -600,9 +601,14 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "The specified object does not have a ObjectLock configuration.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrInvalidBucketObjectLockConfiguration: {
+	ErrMissingObjectLockConfiguration: {
 		Code:           "InvalidRequest",
-		Description:    "Bucket is missing Object Lock Configuration.",
+		Description:    "Bucket is missing Object Lock Configuration",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrMissingObjectLockConfigurationNoSpaces: {
+		Code:           "InvalidRequest",
+		Description:    "Bucket is missing ObjectLockConfiguration",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrObjectLockConfigurationNotAllowed: {

--- a/tests/integration/GetObjectLegalHold.go
+++ b/tests/integration/GetObjectLegalHold.go
@@ -72,7 +72,7 @@ func GetObjectLegalHold_disabled_lock(s *S3Conf) error {
 			Key:    &key,
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidBucketObjectLockConfiguration)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMissingObjectLockConfiguration)); err != nil {
 			return err
 		}
 

--- a/tests/integration/GetObjectRetention.go
+++ b/tests/integration/GetObjectRetention.go
@@ -73,7 +73,7 @@ func GetObjectRetention_disabled_lock(s *S3Conf) error {
 			Key:    &key,
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidBucketObjectLockConfiguration)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMissingObjectLockConfiguration)); err != nil {
 			return err
 		}
 

--- a/tests/integration/PutObjectLegalHold.go
+++ b/tests/integration/PutObjectLegalHold.go
@@ -115,7 +115,7 @@ func PutObjectLegalHold_unset_bucket_object_lock_config(s *S3Conf) error {
 			},
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidBucketObjectLockConfiguration)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMissingObjectLockConfiguration)); err != nil {
 			return err
 		}
 

--- a/tests/integration/PutObjectRetention.go
+++ b/tests/integration/PutObjectRetention.go
@@ -84,7 +84,7 @@ func PutObjectRetention_unset_bucket_object_lock_config(s *S3Conf) error {
 			},
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidBucketObjectLockConfiguration)); err != nil {
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMissingObjectLockConfiguration)); err != nil {
 			return err
 		}
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -163,6 +163,7 @@ func TestPutObject(ts *TestState) {
 	ts.Run(PutObject_tagging)
 	ts.Run(PutObject_missing_object_lock_retention_config)
 	ts.Run(PutObject_with_object_lock)
+	ts.Run(PutObject_missing_bucket_lock)
 	ts.Run(PutObject_invalid_legal_hold)
 	ts.Run(PutObject_invalid_object_lock_mode)
 	ts.Run(PutObject_past_retain_until_date)
@@ -328,6 +329,7 @@ func TestCopyObject(ts *TestState) {
 	ts.Run(CopyObject_non_existing_dir_object)
 	ts.Run(CopyObject_should_copy_meta_props)
 	ts.Run(CopyObject_should_replace_meta_props)
+	ts.Run(CopyObject_missing_bucket_lock)
 	ts.Run(CopyObject_invalid_legal_hold)
 	ts.Run(CopyObject_invalid_object_lock_mode)
 	ts.Run(CopyObject_with_legal_hold)
@@ -1201,6 +1203,7 @@ func GetIntTests() IntTests {
 		"PutObject_missing_object_lock_retention_config":                           PutObject_missing_object_lock_retention_config,
 		"PutObject_name_too_long":                                                  PutObject_name_too_long,
 		"PutObject_with_object_lock":                                               PutObject_with_object_lock,
+		"PutObject_missing_bucket_lock":                                            PutObject_missing_bucket_lock,
 		"PutObject_invalid_legal_hold":                                             PutObject_invalid_legal_hold,
 		"PutObject_invalid_object_lock_mode":                                       PutObject_invalid_object_lock_mode,
 		"PutObject_past_retain_until_date":                                         PutObject_past_retain_until_date,
@@ -1373,6 +1376,7 @@ func GetIntTests() IntTests {
 		"CopyObject_non_existing_dir_object":                                       CopyObject_non_existing_dir_object,
 		"CopyObject_should_copy_meta_props":                                        CopyObject_should_copy_meta_props,
 		"CopyObject_should_replace_meta_props":                                     CopyObject_should_replace_meta_props,
+		"CopyObject_missing_bucket_lock":                                           CopyObject_missing_bucket_lock,
 		"CopyObject_invalid_legal_hold":                                            CopyObject_invalid_legal_hold,
 		"CopyObject_invalid_object_lock_mode":                                      CopyObject_invalid_object_lock_mode,
 		"CopyObject_with_legal_hold":                                               CopyObject_with_legal_hold,


### PR DESCRIPTION
Fixes #1751

When an object lock–related operation is performed on an object in a bucket where Object Lock is not enabled, an `InvalidRequest` error is returned; however, the error message differs for some actions. This PR introduces a new error, `ErrMissingObjectLockConfigurationNoSpaces`, for `PutObject`, `CopyObject`, and `CreateMultipartUpload` to maintain compatibility with S3 in terms of the error message. It also adds the missing integration tests for these actions.