### PR TITLE
fix: fix the concurrency issue in integration tests bucket name generation

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -66,8 +66,8 @@ type user struct {
 }
 
 func getBucketName() string {
-	bcktCount.Add(1)
-	return fmt.Sprintf("test-bucket-%v", bcktCount.Load())
+	val := bcktCount.Add(1)
+	return fmt.Sprintf("test-bucket-%v", val)
 }
 
 func getUser(role string) user {


### PR DESCRIPTION
`getBucketName` in the integration test utilities is responsible for generating unique bucket names using the `test-bucket-` prefix and an atomic integer. The previous implementation performed an atomic `Add` followed by a `Load`, which does not guarantee uniqueness and could result in duplicate bucket names. This has been fixed by removing the `Load` call and relying solely on the return value of the `Add` operation, which provides the updated integer value.