### PR TITLE
fix: fixes non-existing object deletion with versionId

### DIFF
--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -1040,6 +1040,7 @@ func TestVersioning(ts *TestState) {
 	ts.Run(Versioning_DeleteObject_delete_a_delete_marker)
 	ts.Run(Versioning_Delete_null_versionId_object)
 	ts.Run(Versioning_DeleteObject_nested_dir_object)
+	ts.Run(Versioning_DeleteObject_non_existing_objects)
 	ts.Run(Versioning_DeleteObject_suspended)
 	ts.Run(Versioning_DeleteObjects_success)
 	ts.Run(Versioning_DeleteObjects_delete_deleteMarkers)
@@ -1749,6 +1750,7 @@ func GetIntTests() IntTests {
 		"Versioning_DeleteObject_delete_a_delete_marker":                           Versioning_DeleteObject_delete_a_delete_marker,
 		"Versioning_Delete_null_versionId_object":                                  Versioning_Delete_null_versionId_object,
 		"Versioning_DeleteObject_nested_dir_object":                                Versioning_DeleteObject_nested_dir_object,
+		"Versioning_DeleteObject_non_existing_objects":                             Versioning_DeleteObject_non_existing_objects,
 		"Versioning_DeleteObject_suspended":                                        Versioning_DeleteObject_suspended,
 		"Versioning_DeleteObjects_success":                                         Versioning_DeleteObjects_success,
 		"Versioning_DeleteObjects_delete_deleteMarkers":                            Versioning_DeleteObjects_delete_deleteMarkers,


### PR DESCRIPTION
Fixes #1757
Fixes #1758

When attempting to delete a non-existing object in a versioning-enabled bucket while specifying a `versionId`, VersityGW previously returned an internal error if the object had a parent file object, and an `InvalidArgument` error if the object did not exist. This PR fixes both behaviors and now returns a successful response that includes the `versionId`.