### PR TITLE
fix: fixes the SignedStreamingPayloadTrailer_success test failure

### DIFF
--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -2221,7 +2221,7 @@ func testSignedStreamingObjectPut(s *S3Conf, bucket, object string, payload []by
 	}
 
 	signer := v4.NewSigner()
-	signingTime := time.Now()
+	signingTime := time.Now().UTC()
 
 	// sign the request
 	err = signer.SignHTTP(ctx, aws.Credentials{AccessKeyID: s.awsID, SecretAccessKey: s.awsSecret}, req, sha256Header, "s3", s.awsRegion, signingTime)
@@ -2458,7 +2458,7 @@ func getAWS4StreamingTrailer(
 	yearMonthDay := signingTime.Format("20060102")
 
 	// ISO8601 basic format: yyyyMMdd'T'HHmmss'Z'
-	currentDateTime := signingTime.UTC().Format("20060102T150405Z")
+	currentDateTime := signingTime.Format("20060102T150405Z")
 
 	// <date>/<region>/<service>/aws4_request
 	serviceString := fmt.Sprintf(


### PR DESCRIPTION
In the `SignedStreamingPayloadTrailer_success` integration test, the signing date was not using UTC. This caused an incorrect string-to-sign and signature calculation, because the timestamp used for `x-amz-date` (which is always UTC) differed from the timestamp used for streaming payload signature generation. The test now uses UTC, resolving the issue that occurred when the local time zone differed from UTC, specifically in terms of the `yyyymmdd` date component.