### PR TITLE
fix: fixes some write operations blocking in read-only mode

### DIFF
--- a/auth/access-control.go
+++ b/auth/access-control.go
@@ -82,14 +82,14 @@ type AccessOptions struct {
 }
 
 func VerifyAccess(ctx context.Context, be backend.Backend, opts AccessOptions) error {
-	// Skip the access check for public bucket requests
-	if opts.IsPublicRequest {
-		return nil
-	}
 	if opts.Readonly {
 		if opts.AclPermission == PermissionWrite || opts.AclPermission == PermissionWriteAcp {
 			return s3err.GetAPIError(s3err.ErrAccessDenied)
 		}
+	}
+	// Skip the access check for public bucket requests
+	if opts.IsPublicRequest {
+		return nil
 	}
 	if opts.IsRoot {
 		return nil

--- a/s3api/controllers/bucket-put.go
+++ b/s3api/controllers/bucket-put.go
@@ -492,6 +492,12 @@ func (c S3ApiController) CreateBucket(ctx *fiber.Ctx) (*Response, error) {
 		ctx.Get("X-Amz-Object-Ownership", string(types.ObjectOwnershipBucketOwnerEnforced)),
 	)
 
+	if c.readonly {
+		return &Response{
+			MetaOpts: &MetaOptions{},
+		}, s3err.GetAPIError(s3err.ErrAccessDenied)
+	}
+
 	creator := utils.ContextKeyAccount.Get(ctx).(auth.Account)
 	if !utils.ContextKeyBucketOwner.IsSet(ctx) {
 		utils.ContextKeyBucketOwner.Set(ctx, creator)


### PR DESCRIPTION
Fixes #1765
Fixes #1771

This PR addresses two issues:

1. CreateBucket was previously allowed when the gateway was running in read-only mode. It is now correctly blocked.
2. Write operations were permitted on public buckets in read-only mode because the public access checks in `auth.VerifyAccess` were evaluated before the read-only check. The read-only check now takes precedence, and all write operations on public buckets are blocked.