### PR TITLE
Reload TLS certificates on SIGHUP

### DIFF
--- a/s3api/server_test.go
+++ b/s3api/server_test.go
@@ -15,11 +15,11 @@
 package s3api
 
 import (
-	"crypto/tls"
 	"testing"
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/versity/versitygw/backend"
+	"github.com/versity/versitygw/s3api/utils"
 )
 
 func TestS3ApiServer_Serve(t *testing.T) {
@@ -42,11 +42,11 @@ func TestS3ApiServer_Serve(t *testing.T) {
 			name:    "Serve-invalid-address-with-certificate",
 			wantErr: true,
 			sa: &S3ApiServer{
-				app:     fiber.New(),
-				backend: backend.BackendUnsupported{},
-				port:    "Invalid address",
-				Router:  &S3ApiRouter{},
-				cert:    &tls.Certificate{},
+				app:         fiber.New(),
+				backend:     backend.BackendUnsupported{},
+				port:        "Invalid address",
+				Router:      &S3ApiRouter{},
+				CertStorage: &utils.CertStorage{},
 			},
 		},
 	}


### PR DESCRIPTION
* Add utils.CertStorage for holding cert data that can be updated at runtime.
* Add utils.NewTLSListener() to have a central place to control e.g. TLS MinVersion across different servers.
* Move server option setting to after server.app is set so we can call app.SetTLSHandler() in the option code. This is handled by fiber when calling app.ListenTLSWithCertificate() but not when calling app.Listener() directly.
* Add WithTLS() to webserver code so it looks more like the other servers.

Fixes #1299

I have not used fiber before, so I am unsure if we actually want to call app.SetTLSHandler() as well as TLSHandler.GetClientInfo(info). Including those things was an attempt to not clobber the functionality setup when calling app.ListenTLSWithCertificate(), but it also looks a bit weird that the fiber handler writes to a field with no locking:
https://github.com/gofiber/fiber/blob/main/ctx.go#L85-L91

Also the recipe for autocert usage at https://github.com/gofiber/recipes/blob/master/autocert/main.go does not seem to deal with that either... So let me know if I should just drop that (i guess it depended on if calling fiber.Ctx.ClientHelloInfo() is important for this project or not).