### PR TITLE
fix: return not implemented in object actions, if acl header is present

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -158,7 +158,16 @@ func (c S3ApiController) CreateMultipartUpload(ctx *fiber.Ctx) (*Response, error
 	isRoot := utils.ContextKeyIsRoot.Get(ctx).(bool)
 	parsedAcl := utils.ContextKeyParsedAcl.Get(ctx).(auth.ACL)
 
-	err := auth.VerifyAccess(ctx.Context(), c.be,
+	err := utils.ValidateNoACLHeaders(ctx)
+	if err != nil {
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, err
+	}
+
+	err = auth.VerifyAccess(ctx.Context(), c.be,
 		auth.AccessOptions{
 			Readonly:      c.readonly,
 			Acl:           parsedAcl,

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -188,6 +188,7 @@ func TestPutObject(ts *TestState) {
 	}
 	ts.Run(PutObject_invalid_credentials)
 	ts.Run(PutObject_invalid_object_names)
+	ts.Run(PutObject_object_acl_not_supported)
 }
 
 func TestHeadObject(ts *TestState) {
@@ -335,6 +336,7 @@ func TestCopyObject(ts *TestState) {
 	ts.Run(CopyObject_with_legal_hold)
 	ts.Run(CopyObject_with_retention_lock)
 	ts.Run(CopyObject_conditional_reads)
+	ts.Run(CopyObject_object_acl_not_supported)
 	//TODO: remove the condition after implementing checksums in azure
 	if !ts.conf.azureTests {
 		ts.Run(CopyObject_invalid_checksum_algorithm)
@@ -381,6 +383,7 @@ func TestCreateMultipartUpload(ts *TestState) {
 	ts.Run(CreateMultipartUpload_past_retain_until_date)
 	ts.Run(CreateMultipartUpload_invalid_legal_hold)
 	ts.Run(CreateMultipartUpload_invalid_object_lock_mode)
+	ts.Run(CreateMultipartUpload_object_acl_not_supported)
 	//TODO: remove the condition after implementing checksums in azure
 	if !ts.conf.azureTests {
 		ts.Run(CreateMultipartUpload_invalid_checksum_algorithm)
@@ -1283,6 +1286,7 @@ func GetIntTests() IntTests {
 		"PutObject_tagging":                                                        PutObject_tagging,
 		"PutObject_success":                                                        PutObject_success,
 		"PutObject_invalid_object_names":                                           PutObject_invalid_object_names,
+		"PutObject_object_acl_not_supported":                                       PutObject_object_acl_not_supported,
 		"PutObject_false_negative_object_names":                                    PutObject_false_negative_object_names,
 		"PutObject_racey_success":                                                  PutObject_racey_success,
 		"HeadObject_non_existing_object":                                           HeadObject_non_existing_object,
@@ -1387,6 +1391,7 @@ func GetIntTests() IntTests {
 		"CopyObject_with_legal_hold":                                               CopyObject_with_legal_hold,
 		"CopyObject_with_retention_lock":                                           CopyObject_with_retention_lock,
 		"CopyObject_conditional_reads":                                             CopyObject_conditional_reads,
+		"CopyObject_object_acl_not_supported":                                      CopyObject_object_acl_not_supported,
 		"CopyObject_with_metadata":                                                 CopyObject_with_metadata,
 		"CopyObject_invalid_checksum_algorithm":                                    CopyObject_invalid_checksum_algorithm,
 		"CopyObject_create_checksum_on_copy":                                       CopyObject_create_checksum_on_copy,
@@ -1417,6 +1422,7 @@ func GetIntTests() IntTests {
 		"CreateMultipartUpload_past_retain_until_date":                             CreateMultipartUpload_past_retain_until_date,
 		"CreateMultipartUpload_invalid_legal_hold":                                 CreateMultipartUpload_invalid_legal_hold,
 		"CreateMultipartUpload_invalid_object_lock_mode":                           CreateMultipartUpload_invalid_object_lock_mode,
+		"CreateMultipartUpload_object_acl_not_supported":                           CreateMultipartUpload_object_acl_not_supported,
 		"CreateMultipartUpload_invalid_checksum_algorithm":                         CreateMultipartUpload_invalid_checksum_algorithm,
 		"CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type":        CreateMultipartUpload_empty_checksum_algorithm_with_checksum_type,
 		"CreateMultipartUpload_type_algo_mismatch":                                 CreateMultipartUpload_type_algo_mismatch,

--- a/tests/integration/utils.go
+++ b/tests/integration/utils.go
@@ -551,7 +551,7 @@ type putObjectOutput struct {
 func putObjectWithData(lgth int64, input *s3.PutObjectInput, client *s3.Client) (*putObjectOutput, error) {
 	var csum [32]byte
 	var data []byte
-	if input.Body == nil {
+	if input.Body == nil && lgth != 0 {
 		data = make([]byte, lgth)
 		rand.Read(data)
 		csum = sha256.Sum256(data)


### PR DESCRIPTION
Fixes #1767
Fixes #1773

As object ACLs are not supported in the gateway, any attempt to set an ACL during object creation must return a NotImplemented error. A check has now been added to `PutObject`, `CopyObject`, and `CreateMultipartUpload` to detect any ACL-related headers and return a NotImplemented error accordingly.