### PR TITLE
fix: removes object metadata loading from posix ListParts

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2462,10 +2462,6 @@ func (p *Posix) ListParts(ctx context.Context, input *s3.ListPartsInput) (s3resp
 		nextpart = parts[len(parts)-1].PartNumber
 	}
 
-	userMetaData := make(map[string]string)
-	upiddir := filepath.Join(objdir, uploadID)
-	p.loadObjectMetaData(nil, bucket, upiddir, nil, userMetaData)
-
 	return s3response.ListPartsResult{
 		Bucket:               bucket,
 		IsTruncated:          oldLen != newLen,


### PR DESCRIPTION
In the POSIX `ListParts` implementation, there was a code snippet that loaded the object metadata, even though it wasn’t needed and never used in the response. This redundant code has now been removed.