### PR TITLE
fix: fixes list-limiters parsing and validation

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1298,7 +1298,7 @@ func (az *Azure) ListParts(ctx context.Context, input *s3.ListPartsInput) (s3res
 	if *input.PartNumberMarker != "" {
 		partNumberMarker, err = strconv.Atoi(*input.PartNumberMarker)
 		if err != nil {
-			return s3response.ListPartsResult{}, s3err.GetAPIError(s3err.ErrInvalidPartNumberMarker)
+			return s3response.ListPartsResult{}, s3err.GetInvalidMaxLimiterErr("part-number-marker")
 		}
 	}
 	if input.MaxParts != nil {

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -2325,7 +2325,7 @@ func (p *Posix) ListParts(ctx context.Context, input *s3.ListPartsInput) (s3resp
 		var err error
 		partNumberMarker, err = strconv.Atoi(stringMarker)
 		if err != nil {
-			return lpr, s3err.GetAPIError(s3err.ErrInvalidPartNumberMarker)
+			return lpr, s3err.GetInvalidMaxLimiterErr("part-number-marker")
 		}
 	}
 

--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -47,10 +47,9 @@ const (
 	iso8601TimeFormatExtended = "Mon Jan _2 15:04:05 2006"
 	timefmt                   = "Mon, 02 Jan 2006 15:04:05 GMT"
 
-	maxXMLBodyLen     = 4 * 1024 * 1024
-	minPartNumber     = 1
-	maxPartNumber     = 10000
-	defaultMaxBuckets = int32(10000)
+	maxXMLBodyLen = 4 * 1024 * 1024
+	minPartNumber = 1
+	maxPartNumber = 10000
 
 	defaultRegion = "us-east-1"
 )

--- a/s3api/controllers/bucket-get.go
+++ b/s3api/controllers/bucket-get.go
@@ -21,9 +21,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gofiber/fiber/v2"
 	"github.com/versity/versitygw/auth"
-	"github.com/versity/versitygw/debuglogger"
 	"github.com/versity/versitygw/s3api/utils"
-	"github.com/versity/versitygw/s3err"
 	"github.com/versity/versitygw/s3response"
 )
 
@@ -324,15 +322,13 @@ func (c S3ApiController) ListObjectVersions(ctx *fiber.Ctx) (*Response, error) {
 		}, err
 	}
 
-	maxkeys, err := utils.ParseUint(maxkeysStr)
+	maxkeys, err := utils.ParseMaxLimiter(maxkeysStr, utils.LimiterTypeVersionsMaxKeys)
 	if err != nil {
-		debuglogger.Logf("error parsing max keys %q: %v",
-			maxkeysStr, err)
 		return &Response{
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,
 			},
-		}, s3err.GetAPIError(s3err.ErrInvalidMaxKeys)
+		}, err
 	}
 
 	data, err := c.be.ListObjectVersions(ctx.Context(),
@@ -474,15 +470,13 @@ func (c S3ApiController) ListMultipartUploads(ctx *fiber.Ctx) (*Response, error)
 			},
 		}, err
 	}
-	maxUploads, err := utils.ParseUint(maxUploadsStr)
+	maxUploads, err := utils.ParseMaxLimiter(maxUploadsStr, utils.LimiterTypeMaxUploads)
 	if err != nil {
-		debuglogger.Logf("error parsing max uploads %q: %v",
-			maxUploadsStr, err)
 		return &Response{
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,
 			},
-		}, s3err.GetAPIError(s3err.ErrInvalidMaxUploads)
+		}, err
 	}
 	res, err := c.be.ListMultipartUploads(ctx.Context(),
 		&s3.ListMultipartUploadsInput{
@@ -533,15 +527,13 @@ func (c S3ApiController) ListObjectsV2(ctx *fiber.Ctx) (*Response, error) {
 			},
 		}, err
 	}
-	maxkeys, err := utils.ParseUint(maxkeysStr)
+	maxkeys, err := utils.ParseMaxLimiter(maxkeysStr, utils.LimiterTypeMaxKeys)
 	if err != nil {
-		debuglogger.Logf("error parsing max keys %q: %v",
-			maxkeysStr, err)
 		return &Response{
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,
 			},
-		}, s3err.GetAPIError(s3err.ErrInvalidMaxKeys)
+		}, err
 	}
 
 	res, err := c.be.ListObjectsV2(ctx.Context(),
@@ -593,15 +585,13 @@ func (c S3ApiController) ListObjects(ctx *fiber.Ctx) (*Response, error) {
 		}, err
 	}
 
-	maxkeys, err := utils.ParseUint(maxkeysStr)
+	maxkeys, err := utils.ParseMaxLimiter(maxkeysStr, utils.LimiterTypeMaxKeys)
 	if err != nil {
-		debuglogger.Logf("error parsing max keys %q: %v",
-			maxkeysStr, err)
 		return &Response{
 			MetaOpts: &MetaOptions{
 				BucketOwner: parsedAcl.Owner,
 			},
-		}, s3err.GetAPIError(s3err.ErrInvalidMaxKeys)
+		}, err
 	}
 
 	res, err := c.be.ListObjects(ctx.Context(),

--- a/s3api/controllers/bucket-get_test.go
+++ b/s3api/controllers/bucket-get_test.go
@@ -654,7 +654,7 @@ func TestS3ApiController_ListObjectVersions(t *testing.T) {
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
-					"max-keys": "-1",
+					"max-keys": "invalid",
 				},
 			},
 			output: testOutput{
@@ -663,7 +663,7 @@ func TestS3ApiController_ListObjectVersions(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidMaxKeys),
+				err: s3err.GetInvalidMaxLimiterErr(utils.LimiterTypeMaxKeys),
 			},
 		},
 		{
@@ -979,7 +979,7 @@ func TestS3ApiController_ListMultipartUploads(t *testing.T) {
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
-					"max-uploads": "-1",
+					"max-uploads": "invalid",
 				},
 			},
 			output: testOutput{
@@ -988,7 +988,7 @@ func TestS3ApiController_ListMultipartUploads(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidMaxUploads),
+				err: s3err.GetInvalidMaxLimiterErr(utils.LimiterTypeMaxUploads),
 			},
 		},
 		{
@@ -1082,7 +1082,7 @@ func TestS3ApiController_ListObjectsV2(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid max keys",
+			name: "negative max keys",
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
@@ -1095,7 +1095,7 @@ func TestS3ApiController_ListObjectsV2(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidMaxKeys),
+				err: s3err.GetNegativeMaxLimiterErr(utils.LimiterTypeMaxKeys),
 			},
 		},
 		{
@@ -1193,7 +1193,7 @@ func TestS3ApiController_ListObjects(t *testing.T) {
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
-					"max-keys": "-1",
+					"max-keys": "bla",
 				},
 			},
 			output: testOutput{
@@ -1202,7 +1202,7 @@ func TestS3ApiController_ListObjects(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidMaxKeys),
+				err: s3err.GetInvalidMaxLimiterErr(utils.LimiterTypeMaxKeys),
 			},
 		},
 		{

--- a/s3api/controllers/bucket-list_test.go
+++ b/s3api/controllers/bucket-list_test.go
@@ -40,7 +40,7 @@ func TestS3ApiController_ListBuckets(t *testing.T) {
 		output testOutput
 	}{
 		{
-			name: "invalid max buckets",
+			name: "negative max buckets",
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
@@ -52,6 +52,51 @@ func TestS3ApiController_ListBuckets(t *testing.T) {
 					MetaOpts: &MetaOptions{},
 				},
 				err: s3err.GetAPIError(s3err.ErrInvalidMaxBuckets),
+			},
+		},
+		{
+			name: "max buckets exceeds upper limit",
+			input: testInput{
+				locals: defaultLocals,
+				queries: map[string]string{
+					"max-buckets": "10001",
+				},
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{},
+				},
+				err: s3err.GetAPIError(s3err.ErrInvalidMaxBuckets),
+			},
+		},
+		{
+			name: "max buckets 0",
+			input: testInput{
+				locals: defaultLocals,
+				queries: map[string]string{
+					"max-buckets": "0",
+				},
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{},
+				},
+				err: s3err.GetAPIError(s3err.ErrInvalidMaxBuckets),
+			},
+		},
+		{
+			name: "invalid max buckets",
+			input: testInput{
+				locals: defaultLocals,
+				queries: map[string]string{
+					"max-buckets": "bla",
+				},
+			},
+			output: testOutput{
+				response: &Response{
+					MetaOpts: &MetaOptions{},
+				},
+				err: s3err.GetInvalidMaxLimiterErr("max-buckets"),
 			},
 		},
 		{

--- a/s3api/controllers/object-get_test.go
+++ b/s3api/controllers/object-get_test.go
@@ -497,7 +497,7 @@ func TestS3ApiController_ListParts(t *testing.T) {
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
-					"part-number-marker": "-1",
+					"part-number-marker": "foo",
 				},
 			},
 			output: testOutput{
@@ -506,11 +506,11 @@ func TestS3ApiController_ListParts(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidPartNumberMarker),
+				err: s3err.GetInvalidMaxLimiterErr(utils.LimiterTypePartNumberMarker),
 			},
 		},
 		{
-			name: "invalid max parts",
+			name: "negative max parts",
 			input: testInput{
 				locals: defaultLocals,
 				queries: map[string]string{
@@ -523,7 +523,7 @@ func TestS3ApiController_ListParts(t *testing.T) {
 						BucketOwner: "root",
 					},
 				},
-				err: s3err.GetAPIError(s3err.ErrInvalidMaxParts),
+				err: s3err.GetNegativeMaxLimiterErr(utils.LimiterTypeMaxParts),
 			},
 		},
 		{
@@ -632,23 +632,6 @@ func TestS3ApiController_GetObjectAttributes(t *testing.T) {
 					},
 				},
 				err: s3err.GetAPIError(s3err.ErrInvalidVersionId),
-			},
-		},
-		{
-			name: "invalid max parts",
-			input: testInput{
-				locals: defaultLocals,
-				headers: map[string]string{
-					"X-Amz-Max-Parts": "-1",
-				},
-			},
-			output: testOutput{
-				response: &Response{
-					MetaOpts: &MetaOptions{
-						BucketOwner: "root",
-					},
-				},
-				err: s3err.GetAPIError(s3err.ErrInvalidMaxParts),
 			},
 		},
 		{

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -76,11 +76,8 @@ const (
 	ErrInvalidBucketName
 	ErrInvalidDigest
 	ErrBadDigest
-	ErrInvalidMaxKeys
 	ErrInvalidMaxBuckets
-	ErrInvalidMaxUploads
-	ErrInvalidMaxParts
-	ErrInvalidPartNumberMarker
+	ErrNegativeMaxKeys
 	ErrInvalidObjectAttributes
 	ErrInvalidPart
 	ErrInvalidPartNumber
@@ -287,24 +284,9 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Description:    "Argument max-buckets must be an integer between 1 and 10000.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
-	ErrInvalidMaxUploads: {
+	ErrNegativeMaxKeys: {
 		Code:           "InvalidArgument",
-		Description:    "Argument max-uploads must be an integer between 0 and 2147483647.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrInvalidMaxKeys: {
-		Code:           "InvalidArgument",
-		Description:    "Argument maxKeys must be an integer between 0 and 2147483647.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrInvalidMaxParts: {
-		Code:           "InvalidArgument",
-		Description:    "Argument max-parts must be an integer between 0 and 2147483647.",
-		HTTPStatusCode: http.StatusBadRequest,
-	},
-	ErrInvalidPartNumberMarker: {
-		Code:           "InvalidArgument",
-		Description:    "Argument part-number-marker must be an integer between 0 and 2147483647",
+		Description:    "max-keys cannot be negative",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	ErrInvalidObjectAttributes: {
@@ -1060,6 +1042,22 @@ func GetInvalidCORSMethodErr(method string) APIError {
 	return APIError{
 		Code:           "BadRequest",
 		Description:    fmt.Sprintf("Invalid Access-Control-Request-Method: %s", method),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+func GetInvalidMaxLimiterErr(limiter string) APIError {
+	return APIError{
+		Code:           "InvalidArgument",
+		Description:    fmt.Sprintf("Provided %s not an integer or within integer range", limiter),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
+func GetNegativeMaxLimiterErr(limiter string) APIError {
+	return APIError{
+		Code:           "InvalidArgument",
+		Description:    fmt.Sprintf("Argument %s must be an integer between 0 and 2147483647", limiter),
 		HTTPStatusCode: http.StatusBadRequest,
 	}
 }

--- a/tests/integration/ListMultipartUploads.go
+++ b/tests/integration/ListMultipartUploads.go
@@ -74,7 +74,7 @@ func ListMultipartUploads_invalid_max_uploads(s *S3Conf) error {
 			MaxUploads: &maxUploads,
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidMaxUploads)); err != nil {
+		if err := checkApiErr(err, s3err.GetNegativeMaxLimiterErr("max-uploads")); err != nil {
 			return err
 		}
 

--- a/tests/integration/ListObjectVersions.go
+++ b/tests/integration/ListObjectVersions.go
@@ -81,6 +81,19 @@ func ListObjectVersions_non_existing_bucket(s *S3Conf) error {
 	}, withVersioning(types.BucketVersioningStatusEnabled))
 }
 
+func ListObjectVersions_negative_max_keys(s *S3Conf) error {
+	testName := "ListObjectVersions_negative_max_keys"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err := s3client.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+			Bucket:  &bucket,
+			MaxKeys: getPtr(int32(-123)),
+		})
+		cancel()
+		return checkApiErr(err, s3err.GetAPIError(s3err.ErrNegativeMaxKeys))
+	}, withLock())
+}
+
 func ListObjectVersions_list_single_object_versions(s *S3Conf) error {
 	testName := "ListObjectVersions_list_single_object_versions"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {

--- a/tests/integration/ListObjects.go
+++ b/tests/integration/ListObjects.go
@@ -185,7 +185,7 @@ func ListObjects_invalid_max_keys(s *S3Conf) error {
 			MaxKeys: &maxKeys,
 		})
 		cancel()
-		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidMaxKeys)); err != nil {
+		if err := checkApiErr(err, s3err.GetNegativeMaxLimiterErr("max-keys")); err != nil {
 			return err
 		}
 

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -442,6 +442,7 @@ func TestListParts(ts *TestState) {
 	ts.Run(ListParts_incorrect_uploadId)
 	ts.Run(ListParts_incorrect_object_key)
 	ts.Run(ListParts_invalid_max_parts)
+	ts.Run(ListParts_invalid_part_number_marker)
 	ts.Run(ListParts_default_max_parts)
 	ts.Run(ListParts_exceeding_max_parts)
 	ts.Run(ListParts_truncated)
@@ -1054,6 +1055,7 @@ func TestVersioning(ts *TestState) {
 	ts.Run(Versioning_DeleteObjects_delete_deleteMarkers)
 	// ListObjectVersions
 	ts.Run(ListObjectVersions_non_existing_bucket)
+	ts.Run(ListObjectVersions_negative_max_keys)
 	ts.Run(ListObjectVersions_list_single_object_versions)
 	ts.Run(ListObjectVersions_list_multiple_object_versions)
 	ts.Run(ListObjectVersions_multiple_object_versions_truncated)
@@ -1467,6 +1469,7 @@ func GetIntTests() IntTests {
 		"ListParts_incorrect_uploadId":                                             ListParts_incorrect_uploadId,
 		"ListParts_incorrect_object_key":                                           ListParts_incorrect_object_key,
 		"ListParts_invalid_max_parts":                                              ListParts_invalid_max_parts,
+		"ListParts_invalid_part_number_marker":                                     ListParts_invalid_part_number_marker,
 		"ListParts_default_max_parts":                                              ListParts_default_max_parts,
 		"ListParts_truncated":                                                      ListParts_truncated,
 		"ListParts_with_checksums":                                                 ListParts_with_checksums,
@@ -1773,6 +1776,7 @@ func GetIntTests() IntTests {
 		"Versioning_DeleteObjects_success":                                         Versioning_DeleteObjects_success,
 		"Versioning_DeleteObjects_delete_deleteMarkers":                            Versioning_DeleteObjects_delete_deleteMarkers,
 		"ListObjectVersions_non_existing_bucket":                                   ListObjectVersions_non_existing_bucket,
+		"ListObjectVersions_negative_max_keys":                                     ListObjectVersions_negative_max_keys,
 		"ListObjectVersions_list_single_object_versions":                           ListObjectVersions_list_single_object_versions,
 		"ListObjectVersions_list_multiple_object_versions":                         ListObjectVersions_list_multiple_object_versions,
 		"ListObjectVersions_multiple_object_versions_truncated":                    ListObjectVersions_multiple_object_versions_truncated,


### PR DESCRIPTION
Fixes #1809
Fixes #1806
Fixes #1804
Fixes #1794

This PR focuses on correcting so-called "list-limiter" parsing and validation. The affected limiters include: `max-keys`, `max-uploads`, `max-parts`, `max-buckets`, `max-uploads` and `part-number-marker`. When a limiter value is outside the integer range, a specific `InvalidArgument` error is now returned. If the value is a valid integer but negative, a different `InvalidArgument` error is produced.

`max-buckets` has its own validation rules: completely invalid values and values outside the allowed range (`1 <= input <= 10000`) return distinct errors. For `ListObjectVersions`, negative `max-keys` values follow S3’s special-case behavior and return a different `InvalidArgument` error message.

Additionally, `GetObjectAttributes` now follows S3 semantics for `x-amz-max-parts`: S3 ignores invalid values, so the gateway now matches that behavior.