### PR TITLE
fix: remove duplicate cors headers from options router

### DIFF
--- a/s3api/router.go
+++ b/s3api/router.go
@@ -1445,7 +1445,6 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 		middlewares.ApplyBucketCORSPreflightFallback(be, corsAllowOrigin),
 		controllers.ProcessHandlers(ctrl.CORSOptions, metrics.ActionOptions, services,
 			middlewares.BucketObjectNameValidator(),
-			middlewares.ApplyBucketCORS(be, corsAllowOrigin),
 			middlewares.ParseAcl(be),
 		),
 	)
@@ -1454,7 +1453,6 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 		middlewares.ApplyBucketCORSPreflightFallback(be, corsAllowOrigin),
 		controllers.ProcessHandlers(ctrl.CORSOptions, metrics.ActionOptions, services,
 			middlewares.BucketObjectNameValidator(),
-			middlewares.ApplyBucketCORS(be, corsAllowOrigin),
 			middlewares.ParseAcl(be),
 		),
 	)


### PR DESCRIPTION
In the refactor for being able to set global CORS headers, the options router was incorrectly set to use both CORS middlewares casuing duplicate headers to be set. The ApplyBucketCORS() middleware is not needed for options since this is already handled by the CORSOoptions controller.

Fixes #1819