### PR TITLE
fix: md5 not a required header for PutObjectLockConfiguration

### DIFF
--- a/s3api/router.go
+++ b/s3api/router.go
@@ -216,7 +216,7 @@ func (sa *S3ApiRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMServ
 			middlewares.AuthorizePublicBucketAccess(be, metrics.ActionPutObjectLockConfiguration, auth.PutBucketObjectLockConfigurationAction, auth.PermissionWrite, region, false),
 			middlewares.VerifyPresignedV4Signature(root, iam, region, false),
 			middlewares.VerifyV4Signature(root, iam, region, false, true),
-			middlewares.VerifyChecksums(false, true, true),
+			middlewares.VerifyChecksums(false, true, false),
 			middlewares.ApplyBucketCORS(be, corsAllowOrigin),
 			middlewares.ParseAcl(be),
 		))


### PR DESCRIPTION
This was noticed from an error in the webgui. The md5 header is not required for PutObjectLockConfiguration according to AWS documentation. Fix this so that we do not return an error when the optional header is not provided.