### PR TITLE
feat: update go version to `1.25.7`(latest stable)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/versity/versitygw
 
-go 1.24.0
+go 1.25.0
 
-toolchain go1.24.1
+toolchain go1.25.7
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0


### PR DESCRIPTION
Updates the go version from `1.24.1 -> 1.25.7`. It's good to stay up to date with the latest go versions(`1.25.7`, latest stable). It's necessary for fiber `v3` upgrade. Fiber `v3` requires go version `1.25+`.