### PR TITLE
fix: CopyObject with URL-encoded special chars

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -247,6 +247,17 @@ func ParseCopySource(copySourceHeader string) (string, string, string, error) {
 		return "", "", "", s3err.GetAPIError(s3err.ErrInvalidCopySourceBucket)
 	}
 
+	var err error
+	// URL-decode the bucket and object names to handle special characters
+	srcBucket, err = url.QueryUnescape(srcBucket)
+	if err != nil {
+		return "", "", "", s3err.GetAPIError(s3err.ErrInvalidCopySourceEncoding)
+	}
+	srcObject, err = url.QueryUnescape(srcObject)
+	if err != nil {
+		return "", "", "", s3err.GetAPIError(s3err.ErrInvalidCopySourceEncoding)
+	}
+
 	return srcBucket, srcObject, versionId, nil
 }
 

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -1,0 +1,150 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package backend
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/versity/versitygw/s3err"
+)
+
+func TestParseCopySource(t *testing.T) {
+	tests := []struct {
+		name             string
+		copySourceHeader string
+		wantBucket       string
+		wantObject       string
+		wantVersionId    string
+		wantErr          bool
+		wantErrCode      s3err.ErrorCode
+	}{
+		{
+			name:             "simple path",
+			copySourceHeader: "mybucket/myobject",
+			wantBucket:       "mybucket",
+			wantObject:       "myobject",
+			wantVersionId:    "",
+			wantErr:          false,
+		},
+		{
+			name:             "path with leading slash",
+			copySourceHeader: "/mybucket/myobject",
+			wantBucket:       "mybucket",
+			wantObject:       "myobject",
+			wantVersionId:    "",
+			wantErr:          false,
+		},
+		{
+			name:             "path with versionId",
+			copySourceHeader: "mybucket/myobject?versionId=abc123",
+			wantBucket:       "mybucket",
+			wantObject:       "myobject",
+			wantVersionId:    "abc123",
+			wantErr:          false,
+		},
+		{
+			name:             "URL-encoded curly braces",
+			copySourceHeader: "mybucket/myfolder/%7Be14c392b-09ad-4188-85f4-b779af00fb88%7D/testfile",
+			wantBucket:       "mybucket",
+			wantObject:       "myfolder/{e14c392b-09ad-4188-85f4-b779af00fb88}/testfile",
+			wantVersionId:    "",
+			wantErr:          false,
+		},
+		{
+			name:             "URL-encoded space",
+			copySourceHeader: "mybucket/my%20object",
+			wantBucket:       "mybucket",
+			wantObject:       "my object",
+			wantVersionId:    "",
+			wantErr:          false,
+		},
+		{
+			name:             "URL-encoded special chars",
+			copySourceHeader: "mybucket/obj%23%24%25%26",
+			wantBucket:       "mybucket",
+			wantObject:       "obj#$%&",
+			wantVersionId:    "",
+			wantErr:          false,
+		},
+		{
+			name:             "URL-encoded path with versionId",
+			copySourceHeader: "mybucket/my%20folder/my%20object?versionId=xyz789",
+			wantBucket:       "mybucket",
+			wantObject:       "my folder/my object",
+			wantVersionId:    "xyz789",
+			wantErr:          false,
+		},
+		{
+			name:             "invalid URL encoding - incomplete escape",
+			copySourceHeader: "mybucket/object%",
+			wantBucket:       "",
+			wantObject:       "",
+			wantVersionId:    "",
+			wantErr:          true,
+			wantErrCode:      s3err.ErrInvalidCopySourceEncoding,
+		},
+		{
+			name:             "invalid URL encoding - invalid hex",
+			copySourceHeader: "mybucket/object%ZZ",
+			wantBucket:       "",
+			wantObject:       "",
+			wantVersionId:    "",
+			wantErr:          true,
+			wantErrCode:      s3err.ErrInvalidCopySourceEncoding,
+		},
+		{
+			name:             "missing object",
+			copySourceHeader: "mybucket",
+			wantBucket:       "",
+			wantObject:       "",
+			wantVersionId:    "",
+			wantErr:          true,
+			wantErrCode:      s3err.ErrInvalidCopySourceBucket,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBucket, gotObject, gotVersionId, err := ParseCopySource(tt.copySourceHeader)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("ParseCopySource() error = nil, wantErr %v", tt.wantErr)
+					return
+				}
+				if !errors.Is(err, s3err.GetAPIError(tt.wantErrCode)) {
+					t.Errorf("ParseCopySource() error = %v, want error code %v", err, tt.wantErrCode)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("ParseCopySource() unexpected error = %v", err)
+				return
+			}
+
+			if gotBucket != tt.wantBucket {
+				t.Errorf("ParseCopySource() gotBucket = %v, want %v", gotBucket, tt.wantBucket)
+			}
+			if gotObject != tt.wantObject {
+				t.Errorf("ParseCopySource() gotObject = %v, want %v", gotObject, tt.wantObject)
+			}
+			if gotVersionId != tt.wantVersionId {
+				t.Errorf("ParseCopySource() gotVersionId = %v, want %v", gotVersionId, tt.wantVersionId)
+			}
+		})
+	}
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -347,6 +347,7 @@ func TestCopyObject(ts *TestState) {
 		// azure doesn't support these metadata characters
 		ts.Run(CopyObject_with_metadata)
 	}
+	ts.Run(CopyObject_with_special_characters)
 	ts.Run(CopyObject_success)
 }
 
@@ -1404,6 +1405,7 @@ func GetIntTests() IntTests {
 		"CopyObject_should_copy_the_existing_checksum":                             CopyObject_should_copy_the_existing_checksum,
 		"CopyObject_should_replace_the_existing_checksum":                          CopyObject_should_replace_the_existing_checksum,
 		"CopyObject_to_itself_by_replacing_the_checksum":                           CopyObject_to_itself_by_replacing_the_checksum,
+		"CopyObject_with_special_characters":                                       CopyObject_with_special_characters,
 		"CopyObject_success":                                                       CopyObject_success,
 		"PutObjectTagging_non_existing_object":                                     PutObjectTagging_non_existing_object,
 		"PutObjectTagging_long_tags":                                               PutObjectTagging_long_tags,


### PR DESCRIPTION
CopyObject was failing with NoSuchKey when source keys contained special characters like {} or spaces. The X-Amz-Copy-Source header is URL-encoded by clients, but ParseCopySource wasn't decoding before filesystem access.

Added url.QueryUnescape() to properly decode bucket and object names, fixing copy operations for keys with special characters.

Fixing this also uncovered an errors with azure blob url encoding with similar special character handling. Added this fix in for the integration tests to pass.

Fixes #1832
Fixes #1637