### PR TITLE
fix: fixes DeleteObject if-match quoted comparison

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -634,6 +634,7 @@ type ObjectDeletePreconditions struct {
 
 // EvaluateObjectDeletePreconditions evaluates preconditions for DeleteObject
 func EvaluateObjectDeletePreconditions(etag string, modTime time.Time, size int64, preconditions ObjectDeletePreconditions) error {
+	etag = strings.Trim(etag, `"`)
 	ifMatch := preconditions.IfMatch
 	if ifMatch != nil && *ifMatch != etag {
 		return errPreconditionFailed

--- a/s3api/controllers/object-delete.go
+++ b/s3api/controllers/object-delete.go
@@ -133,7 +133,7 @@ func (c S3ApiController) DeleteObject(ctx *fiber.Ctx) (*Response, error) {
 	key := strings.TrimPrefix(ctx.Path(), fmt.Sprintf("/%s/", bucket))
 	versionId := ctx.Query("versionId")
 	bypass := strings.EqualFold(ctx.Get("X-Amz-Bypass-Governance-Retention"), "true")
-	ifMatch := utils.GetStringPtr(ctx.Get("If-Match"))
+	ifMatch := utils.GetStringPtr(utils.TrimQuotes(ctx.Get("If-Match")))
 	ifMatchLastModTime := utils.ParsePreconditionDateHeader(ctx.Get("X-Amz-If-Match-Last-Modified-Time"))
 	ifMatchSize := utils.ParseIfMatchSize(ctx)
 	// context locals

--- a/s3api/utils/precondition.go
+++ b/s3api/utils/precondition.go
@@ -68,8 +68,8 @@ func ParsePreconditionMatchHeaders(ctx *fiber.Ctx, opts ...preconditionOpt) (*st
 		prefix = "X-Amz-Copy-Source-"
 	}
 
-	ifMatch := trimQuotes(ctx.Get(prefix + "If-Match"))
-	ifNoneMatch := trimQuotes(ctx.Get(prefix + "If-None-Match"))
+	ifMatch := TrimQuotes(ctx.Get(prefix + "If-Match"))
+	ifNoneMatch := TrimQuotes(ctx.Get(prefix + "If-None-Match"))
 	return GetStringPtr(ifMatch), GetStringPtr(ifNoneMatch)
 }
 
@@ -143,7 +143,7 @@ func ParseIfMatchSize(ctx *fiber.Ctx) *int64 {
 	return &ifMatchSize
 }
 
-func trimQuotes(str string) string {
+func TrimQuotes(str string) string {
 	if len(str) < 2 {
 		return str
 	}


### PR DESCRIPTION
Fixes #1835

If-Match in DeleteObject is a precondition header that compares the client-provided ETag with the server-side ETag before deleting the object. Previously, the comparison failed when the client sent an unquoted ETag, because server ETags are stored with quotes. The implementation now trims quotes from both the input ETag and the server ETag before comparison to avoid mismatches. Both quoted and unquoted ETags are valid according to S3.