### PR TITLE
feat: adds fiber max connections and in-flight requests limiter

### DIFF
--- a/cmd/versitygw/gateway_test.go
+++ b/cmd/versitygw/gateway_test.go
@@ -32,6 +32,8 @@ func initEnv(dir string) {
 	rootUserSecret = "pass"
 	iamDir = dir
 	port = "127.0.0.1:7070"
+	maxConnections = 250000
+	maxRequests = 100000
 
 	// client
 	awsID = "user"

--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -43,6 +43,8 @@ var (
 	rootUserAccess                         string
 	rootUserSecret                         string
 	region                                 string
+	maxConnections, maxRequests            int
+	adminMaxConnections, adminMaxRequests  int
 	corsAllowOrigin                        string
 	admCertFile, admKeyFile                string
 	certFile, keyFile                      string
@@ -217,6 +219,22 @@ func initFlags() []cli.Flag {
 			Destination: &region,
 			Aliases:     []string{"r"},
 		},
+		&cli.IntFlag{
+			Name:        "max-connections",
+			Usage:       "maximum number of concurrent connections s3 api server may serve",
+			EnvVars:     []string{"VGW_MAX_CONNECTIONS"},
+			Value:       250000,
+			Destination: &maxConnections,
+			Aliases:     []string{"mc"},
+		},
+		&cli.IntFlag{
+			Name:        "max-requests",
+			Usage:       "maximum number of in-flight requests s3 api server may serve",
+			EnvVars:     []string{"VGW_MAX_REQUESTS"},
+			Value:       100000,
+			Destination: &maxRequests,
+			Aliases:     []string{"mr"},
+		},
 		&cli.StringFlag{
 			Name:        "cors-allow-origin",
 			Usage:       "default CORS Access-Control-Allow-Origin value (applied when no bucket CORS configuration exists, and for admin APIs)",
@@ -241,6 +259,22 @@ func initFlags() []cli.Flag {
 			EnvVars:     []string{"VGW_ADMIN_PORT"},
 			Destination: &admPort,
 			Aliases:     []string{"ap"},
+		},
+		&cli.IntFlag{
+			Name:        "admin-max-connections",
+			Usage:       "maximum number of concurrent connections s3 admin server may handle",
+			EnvVars:     []string{"VGW_ADMIN_MAX_CONNECTIONS"},
+			Value:       250000,
+			Destination: &adminMaxConnections,
+			Aliases:     []string{"amc"},
+		},
+		&cli.IntFlag{
+			Name:        "admin-max-requests",
+			Usage:       "maximum number of in-flight requests s3 admin server may handle",
+			EnvVars:     []string{"VGW_ADMIN_MAX_REQUESTS"},
+			Value:       100000,
+			Destination: &adminMaxRequests,
+			Aliases:     []string{"amr"},
 		},
 		&cli.StringFlag{
 			Name:        "admin-cert",
@@ -673,6 +707,17 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		return fmt.Errorf("root user access and secret key must be provided")
 	}
 
+	if maxConnections < 1 {
+		log.Fatal("max-connections must be positive")
+	}
+	if maxRequests < 1 {
+		log.Fatal("max-requests must be positive")
+	}
+	if maxRequests > maxConnections {
+		log.Printf("WARNING: max-requests (%d) exceeds max-connections (%d) which could allow for gateway to panic before throttling requests",
+			maxRequests, maxConnections)
+	}
+
 	webuiAddr = strings.TrimSpace(webuiAddr)
 	if webuiAddr != "" && isAllDigits(webuiAddr) {
 		webuiAddr = ":" + webuiAddr
@@ -719,7 +764,9 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		}()
 	}
 
-	var opts []s3api.Option
+	opts := []s3api.Option{
+		s3api.WithConcurrencyLimiter(maxConnections, maxRequests),
+	}
 	if corsAllowOrigin != "" {
 		opts = append(opts, s3api.WithCORSAllowOrigin(corsAllowOrigin))
 	}
@@ -860,7 +907,20 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 	var admSrv *s3api.S3AdminServer
 
 	if admPort != "" {
-		var opts []s3api.AdminOpt
+		if adminMaxConnections < 1 {
+			log.Fatal("admin-max-connections must be positive")
+		}
+		if adminMaxRequests < 1 {
+			log.Fatal("admin-max-requests must be positive")
+		}
+		if adminMaxRequests > adminMaxConnections {
+			log.Printf("WARNING: admin-max-requests (%d) exceeds admin-max-connections (%d) which could allow for gateway to panic before throttling requests",
+				adminMaxRequests, adminMaxConnections)
+		}
+
+		opts := []s3api.AdminOpt{
+			s3api.WithAdminConcurrencyLimiter(adminMaxConnections, adminMaxRequests),
+		}
 		if corsAllowOrigin != "" {
 			opts = append(opts, s3api.WithAdminCORSAllowOrigin(corsAllowOrigin))
 		}

--- a/s3api/middlewares/rate-limiter.go
+++ b/s3api/middlewares/rate-limiter.go
@@ -1,0 +1,50 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package middlewares
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"github.com/versity/versitygw/metrics"
+	"github.com/versity/versitygw/s3err"
+	"github.com/versity/versitygw/s3log"
+	"golang.org/x/sync/semaphore"
+)
+
+// RateLimiter hard-limits the number of in-flight requests.
+// If the limit is reached, an immediate SlowDown error is returned
+func RateLimiter(limit int, mm metrics.Manager, logger s3log.AuditLogger) fiber.Handler {
+	sem := semaphore.NewWeighted(int64(limit))
+
+	return func(ctx *fiber.Ctx) error {
+		if !sem.TryAcquire(1) {
+			// limit reached
+			err := s3err.GetAPIError(s3err.ErrSlowDown)
+
+			if mm != nil {
+				mm.Send(ctx, err, metrics.ActionUndetected, 0, 0)
+			}
+			if logger != nil {
+				logger.Log(ctx, err, ctx.Body(), s3log.LogMeta{
+					Action: metrics.ActionUndetected,
+				})
+			}
+
+			ctx.Status(err.HTTPStatusCode)
+			return ctx.Send(s3err.GetAPIErrorResponse(err, "", "", ""))
+		}
+		defer sem.Release(1)
+		return ctx.Next()
+	}
+}

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -184,6 +184,7 @@ const (
 	ErrInvalidArgument
 	ErrMalformedTrailer
 	ErrInvalidChunkSize
+	ErrSlowDown
 
 	// Non-AWS errors
 	ErrExistingObjectIsDirectory
@@ -828,6 +829,11 @@ var errorCodeResponse = map[ErrorCode]APIError{
 		Code:           "InvalidChunkSizeError",
 		Description:    "Only the last chunk is allowed to have a size less than 8192 bytes",
 		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrSlowDown: {
+		Code:           "SlowDown",
+		Description:    "Please reduce your request rate.",
+		HTTPStatusCode: http.StatusServiceUnavailable,
 	},
 
 	// non aws errors


### PR DESCRIPTION
This is part of the thread exhaustion issue (#1815).

This PR introduces:

* A **maximum Fiber HTTP connections limit**
* A middleware that enforces a **hard limit on in-flight HTTP requests**

When the in-flight request limit is reached, the middleware returns an **S3-compatible `503 SlowDown`** error.

The same mechanism is implemented for the **admin server** (both max connections and max in-flight requests).

All limits are configurable via **CLI flags** and **environment variables**, for both the `s3api` server and the `admin` server.

---

| Setting         | CLI Flag            | Alias | Environment Variable  | Default |
| --------------- | ------------------- | ----- | --------------------- | ------- |
| Max Connections | `--max-connections` | `-mc` | `VGW_MAX_CONNECTIONS` | 250000  |
| Max Requests    | `--max-requests`    | `-mr` | `VGW_MAX_REQUESTS`    | 100000  |

---

| Setting         | CLI Flag                  | Alias  | Environment Variable        | Default |
| --------------- | ------------------------- | ------ | --------------------------- | ------- |
| Max Connections | `--admin-max-connections` | `-amc` | `VGW_ADMIN_MAX_CONNECTIONS` | 250000  |
| Max Requests    | `--admin-max-requests`    | `-amr` | `VGW_ADMIN_MAX_REQUESTS`    | 100000  |