### PR TITLE
feat: add posix concurrency-limiter

### DIFF
--- a/cmd/versitygw/gateway_test.go
+++ b/cmd/versitygw/gateway_test.go
@@ -61,7 +61,8 @@ func initPosix(ctx context.Context) {
 	}
 
 	be, err := posix.New(tempdir, meta.XattrMeta{}, posix.PosixOpts{
-		NewDirPerm: 0755,
+		NewDirPerm:  0755,
+		Concurrency: 5000,
 	})
 	if err != nil {
 		log.Fatalf("init posix: %v", err)


### PR DESCRIPTION
Closes #1815

Implements posix actions concurrency limiter. Since posix actions perform filesystem-heavy syscalls, a semaphore-based limiter is introduced to cap the maximum number of concurrent posix actions. When the limit is reached, additional action calls block until a slot becomes available.

For internal posix calls, the `no_acquire_slot` context key is used to prevent acquiring the limiter multiple times within a single action (e.g., PutObject internally calling PutObjectLegalHold).

The posix concurrency limit can be configured via the gateway posix subcommand flag (--concurrency) or the environment variable `VGW_POSIX_CONCURRENCY`. The default value is `5000`.