### PR TITLE
fix: adds application/xml Content-Type to error responses

### DIFF
--- a/s3api/controllers/base.go
+++ b/s3api/controllers/base.go
@@ -148,6 +148,8 @@ func WrapMiddleware(handler fiber.Handler, logger s3log.AuditLogger, mm metrics.
 				})
 			}
 
+			ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
+
 			serr, ok := err.(s3err.APIError)
 			if ok {
 				ctx.Status(serr.HTTPStatusCode)
@@ -197,6 +199,10 @@ func ProcessController(ctx *fiber.Ctx, controller Controller, s3action string, s
 				ObjectSize:  opts.ObjectSize,
 			})
 		}
+
+		// set content type to application/xml
+		ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
+
 		serr, ok := err.(s3err.APIError)
 		if ok {
 			ctx.Status(serr.HTTPStatusCode)
@@ -294,6 +300,9 @@ func ProcessController(ctx *fiber.Ctx, controller Controller, s3action string, s
 			})
 		}
 		ctx.Status(http.StatusInternalServerError)
+
+		// set content type to application/xml
+		ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
 
 		return ctx.Send(s3err.GetAPIErrorResponse(
 			s3err.GetAPIError(s3err.ErrInternalError), "", "", ""))

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -197,6 +197,9 @@ func stackTraceHandler(ctx *fiber.Ctx, e any) {
 // globalErrorHandler catches the errors before reaching to
 // the handlers and any system panics
 func globalErrorHandler(ctx *fiber.Ctx, er error) error {
+	// set content type to application/xml
+	ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
+
 	if utils.ContextKeyStack.IsSet(ctx) {
 		// if stack is set, it means the stack trace
 		// has caught a panic


### PR DESCRIPTION
Fixes #1852
Fixes #1821

Fiber used to return the `text/plain` default `Content-Type` for error responses, because it wasn't explicitly set. Now for all error responses the `application/xml` content type is set.