### PR TITLE
chore: fix warning in system.yml github workflow

### DIFF
--- a/.github/workflows/system.yml
+++ b/.github/workflows/system.yml
@@ -131,16 +131,17 @@ jobs:
           fi
 
       - name: Ensure coverage file exists, and generate working name
+        id: prepare_coverage
         run: |
           touch coverage.log
           run_set="${{ matrix.RUN_SET }}"
           SAFE_RUN_SET="${run_set//\//-}"
-          echo "SAFE_RUN_SET=$SAFE_RUN_SET" >> $GITHUB_ENV
+          echo "safe_run_set=$SAFE_RUN_SET" >> $GITHUB_OUTPUT
 
       - name: Upload command coverage log
         uses: actions/upload-artifact@v6
         with:
-          name: coverage-${{ env.SAFE_RUN_SET }}-${{ matrix.RECREATE_BUCKETS }}
+          name: coverage-${{ steps.prepare_coverage.outputs.safe_run_set }}-${{ matrix.RECREATE_BUCKETS }}
           path: coverage.log
           retention-days: 1
 


### PR DESCRIPTION
The system.yml file was giving this warning:
Context access might be invalid: SAFE_RUN_SET

The warning occurs because this was trying to access env.SAFE_RUN_SET in a with: key of an action, but GitHub Actions has restrictions on where context variables can be accessed.

The env context isn't always guaranteed to be available in the with: key of actions, especially when it depends on runtime values set in previous steps.

The recommended fix is to change from $GITHUB_ENV to $GITHUB_OUTPUT for this case.