### PR TITLE
fix: request checksum calculation only when required in proxy mode

### DIFF
--- a/backend/s3proxy/client.go
+++ b/backend/s3proxy/client.go
@@ -69,6 +69,7 @@ func (s *S3Proxy) getConfig(ctx context.Context, access, secret string) (aws.Con
 		config.WithRegion(s.awsRegion),
 		config.WithCredentialsProvider(creds),
 		config.WithHTTPClient(client),
+		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 	}
 
 	if s.disableChecksum {


### PR DESCRIPTION
Set RequestChecksumCalculationWhenRequired so checksums are only
sent when explicitly requested by the caller or required by the API.
    
Fixes #1867