### PR TITLE
fix: correct private canned ACL behavior on bucket creation

### DIFF
--- a/auth/acl.go
+++ b/auth/acl.go
@@ -496,7 +496,7 @@ func UpdateBucketACLOwner(ctx context.Context, be backend.Backend, bucket, newOw
 }
 
 // ValidateCannedACL validates bucket canned acl value
-func ValidateCannedACL(acl string) error {
+func ValidateCannedACL(acl types.BucketCannedACL) error {
 	switch types.BucketCannedACL(acl) {
 	case types.BucketCannedACLPrivate, types.BucketCannedACLPublicRead, types.BucketCannedACLPublicReadWrite, "":
 		return nil

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -79,6 +79,8 @@ func TestCreateBucket(ts *TestState) {
 	ts.Run(CreateBucket_as_user)
 	ts.Run(CreateBucket_default_acl)
 	ts.Run(CreateBucket_non_default_acl)
+	ts.Run(CreateBucket_private_canned_acl)
+	ts.Run(CreateBucket_private_canned_acl_bucket_owner_enforced_ownership)
 	ts.Run(CreateDeleteBucket_success)
 	ts.Run(CreateBucket_default_object_lock)
 	ts.Run(CreateBucket_invalid_location_constraint)
@@ -1244,6 +1246,8 @@ func GetIntTests() IntTests {
 		"CreateDeleteBucket_success":                                               CreateDeleteBucket_success,
 		"CreateBucket_default_acl":                                                 CreateBucket_default_acl,
 		"CreateBucket_non_default_acl":                                             CreateBucket_non_default_acl,
+		"CreateBucket_private_canned_acl":                                          CreateBucket_private_canned_acl,
+		"CreateBucket_private_canned_acl_bucket_owner_enforced_ownership":          CreateBucket_private_canned_acl_bucket_owner_enforced_ownership,
 		"CreateBucket_default_object_lock":                                         CreateBucket_default_object_lock,
 		"CreateBucket_invalid_location_constraint":                                 CreateBucket_invalid_location_constraint,
 		"CreateBucket_long_tags":                                                   CreateBucket_long_tags,


### PR DESCRIPTION
Fixes #1869

Generally, when object ownership is not explicitly specified during bucket creation, it defaults to `BucketOwnerEnforced`. With `BucketOwnerEnforced`, ACLs are disabled and any attempt to set one results in an `InvalidBucketAclWithObjectOwnership` error.

However, there is an edge case. When the `private` canned ACL is used during bucket creation—which is effectively the default ACL for all buckets—`BucketOwnerEnforced` is still permitted. Moreover, if no explicit object ownership is specified together with the `private` canned ACL, the ownership defaults to `BucketOwnerPreferred`.

This fix also resolves the issue with rclone bucket creation, since rclone sends `x-amz-acl: private` by default:

```
rclone mkdir vgw:test
```