### PR TITLE
feat: add cli options to specify webui gateway/admin listing

### DIFF
--- a/extra/example.conf
+++ b/extra/example.conf
@@ -245,6 +245,24 @@ ROOT_SECRET_ACCESS_KEY=
 # 'https://webui.example.com') to improve security.
 #VGW_CORS_ALLOW_ORIGIN=
 
+# The VGW_WEBUI_GATEWAYS option allows you to override the auto-detected S3
+# gateway URLs that are provided to the Web GUI. By default, the gateway
+# auto-detects URLs based on the configured VGW_PORT settings. Use this option
+# to specify custom URLs when the auto-detected values are incorrect (e.g., when
+# running behind a reverse proxy or load balancer). Multiple URLs can be
+# specified as a comma-separated list.
+# Example: VGW_WEBUI_GATEWAYS=https://s3.example.com,http://192.168.1.100:7070
+#VGW_WEBUI_GATEWAYS=
+
+# The VGW_WEBUI_ADMIN_GATEWAYS option allows you to override the auto-detected
+# admin gateway URLs that are provided to the Web GUI. By default, the gateway
+# auto-detects URLs based on the configured VGW_ADMIN_PORT settings (or uses the
+# same URLs as VGW_WEBUI_GATEWAYS if no admin ports are configured). Use this
+# option to specify custom admin URLs when the auto-detected values are incorrect.
+# Multiple URLs can be specified as a comma-separated list.
+# Example: VGW_WEBUI_ADMIN_GATEWAYS=https://admin.example.com,http://192.168.1.100:7080
+#VGW_WEBUI_ADMIN_GATEWAYS=
+
 #######################
 # Debug / Diagnostics #
 #######################


### PR DESCRIPTION
New cli options added:
webui-gateways - override auto-detected S3 gateway URLs for WebUI webui-admin-gateways - override auto-detected admin gateway URLs
 for WebUI

These also accept env vars VGW_WEBUI_GATEWAYS and
VGW_WEBUI_ADMIN_GATEWAYS for the options.

When setting these, this will override the url auto-detection for the webui service urls dropdown options. By default, the gateway auto-detects URLs based on the configured port settings. Use these options to specify custom URLs when the auto-detected values are incorrect (e.g., when running behind a reverse proxy or load balancer). Multiple URLs can be specified with repeated options or a comma-separated list with the environment variables. for example:
--webui-gateways https://s3.example.com \
--webui-gateways http://192.168.1.100:7070
or
VGW_WEBUI_GATEWAYS=https://s3.example.com,http://192.168.1.100:7070

The gateway will validate the provided URLs with warnings for any invalid URL specified. The gateway will terminate if these options are set but contain no valid URLs.

Also added sorting to the auto-detected URLs so that localhost URLs will be last in the list, since these will not likely work on remote systems. The specified lists when provided are left in the order they are specified to allow admins to determine dropdown list ordering.

Fixes #1851