### PR TITLE
fix: fixes PutBucketCors CORSRules validation

### DIFF
--- a/s3api/controllers/bucket-get_test.go
+++ b/s3api/controllers/bucket-get_test.go
@@ -319,7 +319,7 @@ func TestS3ApiController_GetBucketCors(t *testing.T) {
 	cors := &auth.CORSConfiguration{
 		Rules: []auth.CORSRule{
 			{
-				AllowedOrigins: []string{"origin"},
+				AllowedOrigins: []auth.CORSOrigin{"origin"},
 				AllowedMethods: []auth.CORSHTTPMethod{http.MethodPut},
 				AllowedHeaders: []auth.CORSHeader{"X-Amz-Date"},
 			},

--- a/s3api/controllers/bucket-put_test.go
+++ b/s3api/controllers/bucket-put_test.go
@@ -466,7 +466,7 @@ func TestS3ApiController_PutBucketCors(t *testing.T) {
 	validBody, err := xml.Marshal(auth.CORSConfiguration{
 		Rules: []auth.CORSRule{
 			{
-				AllowedOrigins: []string{"*"},
+				AllowedOrigins: []auth.CORSOrigin{"*"},
 				AllowedMethods: []auth.CORSHTTPMethod{http.MethodPost},
 			},
 		},
@@ -476,7 +476,7 @@ func TestS3ApiController_PutBucketCors(t *testing.T) {
 	invalidCors, err := xml.Marshal(auth.CORSConfiguration{
 		Rules: []auth.CORSRule{
 			{
-				AllowedOrigins: []string{"origin"},
+				AllowedOrigins: []auth.CORSOrigin{"origin"},
 				AllowedMethods: []auth.CORSHTTPMethod{"invalid_method"},
 			},
 		},

--- a/s3api/controllers/options_test.go
+++ b/s3api/controllers/options_test.go
@@ -33,7 +33,7 @@ func TestS3ApiController_CORSOptions(t *testing.T) {
 	cors, err := xml.Marshal(auth.CORSConfiguration{
 		Rules: []auth.CORSRule{
 			{
-				AllowedOrigins: []string{"example.com"},
+				AllowedOrigins: []auth.CORSOrigin{"example.com"},
 				AllowedMethods: []auth.CORSHTTPMethod{http.MethodGet, http.MethodPost},
 				AllowedHeaders: []auth.CORSHeader{"Content-Type", "Content-Disposition"},
 				ExposeHeaders:  []auth.CORSHeader{"Content-Encoding", "date"},

--- a/s3err/s3err.go
+++ b/s3err/s3err.go
@@ -1036,6 +1036,14 @@ func GetInvalidCORSRequestHeaderErr(header string) APIError {
 	}
 }
 
+func GetMultipleWildcardCORSOriginErr(origin string) APIError {
+	return APIError{
+		Code:           "InvalidRequest",
+		Description:    fmt.Sprintf(`AllowedOrigin "%s" can not have more than one wildcard.`, origin),
+		HTTPStatusCode: http.StatusBadRequest,
+	}
+}
+
 func GetUnsopportedCORSMethodErr(method string) APIError {
 	return APIError{
 		Code:           "InvalidRequest",

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -603,6 +603,7 @@ func TestDeleteBucketPolicy(ts *TestState) {
 func TestPutBucketCors(ts *TestState) {
 	ts.Run(PutBucketCors_non_existing_bucket)
 	ts.Run(PutBucketCors_empty_cors_rules)
+	ts.Run(PutBucketCors_invalid_allowed_origins)
 	ts.Run(PutBucketCors_invalid_method)
 	ts.Run(PutBucketCors_invalid_header)
 	ts.Run(PutBucketCors_md5)
@@ -1591,6 +1592,7 @@ func GetIntTests() IntTests {
 		"DeleteBucketPolicy_success":                                               DeleteBucketPolicy_success,
 		"PutBucketCors_non_existing_bucket":                                        PutBucketCors_non_existing_bucket,
 		"PutBucketCors_empty_cors_rules":                                           PutBucketCors_empty_cors_rules,
+		"PutBucketCors_invalid_allowed_origins":                                    PutBucketCors_invalid_allowed_origins,
 		"PutBucketCors_invalid_method":                                             PutBucketCors_invalid_method,
 		"PutBucketCors_invalid_header":                                             PutBucketCors_invalid_header,
 		"PutBucketCors_md5":                                                        PutBucketCors_md5,


### PR DESCRIPTION
Fixes #1870
Fixes #1863

A validation has been added to **PutBucketCors** for `CORSRule.AllowedOrigins`. The `AllowedOrigins` list can no longer be empty—otherwise a **MalformedXML** error is returned. Additionally, each origin is now validated to ensure it does not contain more than one wildcard.

A similar validation has been added for `AllowedMethods`. The list must not be empty, or a **MalformedXML** error is returned. Previously, empty method values (e.g., `[]string{""}`) were incorrectly treated as valid. This has been fixed, and an **UnsupportedCORSMethod** error is now returned.