### PR TITLE
fix: not return parent keys for ListObjectVersions

### DIFF
--- a/backend/walk.go
+++ b/backend/walk.go
@@ -389,6 +389,11 @@ func WalkVersions(ctx context.Context, fileSystem fs.FS, prefix, delimiter, keyM
 				return fs.SkipDir
 			}
 
+			// Skip parents of specified prefix
+			if len(path+"/") < len(prefix) {
+				return nil
+			}
+
 			res, err := getObj(path, versionIdMarker, &pastVersionIdMarker, max-len(objects)-len(delMarkers)-cpmap.Len(), d)
 			if err == ErrSkipObj {
 				return nil


### PR DESCRIPTION
Fix for ListObjectVersions. Function `WalkVersions` in `walk.go` now skips parent keys of specified prefix.

Fixes #1864 
