### PR TITLE
fix: fixes webserver network type

### DIFF
--- a/webui/webserver.go
+++ b/webui/webserver.go
@@ -61,6 +61,7 @@ func NewServer(cfg *ServerConfig, opts ...Option) *Server {
 		AppName:               "versitygw",
 		ServerHeader:          "VERSITYGW",
 		DisableStartupMessage: true,
+		Network:               fiber.NetworkTCP,
 	})
 
 	server := &Server{


### PR DESCRIPTION
Fixes #1917

When the `--webui` flag uses `localhost:<port>`, the hostname `localhost` resolves to both IPv6 and IPv4 addresses. Previously, the Fiber web server was initialized without an explicit network setting, and Fiber defaults to `tcp4` (IPv4-only). Because `tcp4` cannot bind to IPv6 addresses, any resolved IPv6 address (e.g., `::1`) was treated as invalid for the listener.

The network mode is now changed to `tcp`, which enables dual-stack behavior and allows binding to both IPv4 and IPv6 addresses.