### PR TITLE
fix: bracket IPv6 addresses in auto-detected webui gateway URLs

### DIFF
--- a/cmd/versitygw/main.go
+++ b/cmd/versitygw/main.go
@@ -1506,7 +1506,7 @@ func buildServiceURLs(spec string, ssl bool) ([]string, error) {
 	}
 	urls := make([]string, 0, len(interfaces))
 	for _, ip := range interfaces {
-		urls = append(urls, fmt.Sprintf("%s://%s:%s", scheme, ip, prt))
+		urls = append(urls, fmt.Sprintf("%s://%s", scheme, net.JoinHostPort(ip, prt)))
 	}
 	return urls, nil
 }


### PR DESCRIPTION
Use net.JoinHostPort instead of manual string formatting in buildServiceURLs so IPv6 addresses are properly wrapped in brackets. This fixes malformed URLs like "http://::1:7070" being presented as the default server URL in the WebUI login form when listening on an IPv6 address; they now correctly render as "http://[::1]:7070".

Fixes #1926