### PR TITLE
fix: webui pass correct arguments to request() in putBucketPolicy

### DIFF
--- a/webui/web/js/api.js
+++ b/webui/web/js/api.js
@@ -1846,9 +1846,7 @@ ${tagsXml}
    */
   async putBucketPolicy(bucket, policy) {
     const policyJson = JSON.stringify(policy);
-    await this.request('PUT', `/${bucket}`, { policy: '' }, policyJson, {
-      'Content-Type': 'application/json'
-    });
+    await this.request('PUT', `/${bucket}`, { policy: '' }, policyJson, false, 'application/json');
   }
 
   /**


### PR DESCRIPTION
The fifth parameter of request() is useAdminEndpoint (boolean), but putBucketPolicy was passing a Content-Type header object instead. This caused useAdminEndpoint to be truthy and contentType to default to 'application/xml' instead of 'application/json'.

Fixed by passing false for useAdminEndpoint and 'application/json' as the contentType argument.

Fixes #1928