### PR TITLE
feat(chart): add cosign signing to chart OCI artifact

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
       packages: write
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,10 +25,19 @@ jobs:
 
       # https://github.com/marketplace/actions/helm-oci-charts-releaser
       - name: Run chart-releaser
+        id: releaser
         uses: bitdeps/helm-oci-charts-releaser@v0.1.5
         with:
-            oci_registry: ghcr.io/versity/versitygw/charts
-            oci_username: versity
-            oci_password: ${{ secrets.GITHUB_TOKEN }}
-            github_token: ${{ secrets.GITHUB_TOKEN }}
-            charts_dir: "."
+          oci_registry: ghcr.io/versity/versitygw/charts
+          oci_username: versity
+          oci_password: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: "."
+
+      - name: Install cosign
+        if: steps.releaser.outputs.changed_charts != ''
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Sign chart with cosign
+        if: steps.releaser.outputs.changed_charts != ''
+        run: cosign sign --yes ghcr.io/versity/versitygw/charts/versitygw:${{ steps.releaser.outputs.chart_version }}


### PR DESCRIPTION
Signs the chart with cosign keyless signing via GitHub Actions OIDC, allowing us to verify it was built and published by this repository. Once signed, the chart's origin can be verified as coming from this repo
```
cosign verify ghcr.io/versity/versitygw/charts/versitygw:0.1.1 \
  --certificate-identity-regexp="https://github.com/versity/versitygw/" \
  --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
```

Thanks!