### PR TITLE
fix: update deprecated StandardOutput/StandardError type

### DIFF
--- a/extra/versitygw@.service
+++ b/extra/versitygw@.service
@@ -8,8 +8,8 @@ AssertPathExists=/etc/versitygw.d/%i.conf
 
 [Service]
 WorkingDirectory=/root
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=versitygw-%i
 
 User=root


### PR DESCRIPTION
Fix warnings from newer systemd:
Standard output type syslog is obsolete,
 automatically updating to journal.

This updates the stdout/stderr to journal output type which is what is getting set anyways after the syslog type has been deprecated.

No expected behavior change with this other than quieting warnings.