### PR TITLE
fix(chart): fix multidoc separator when 2 routes are enabled

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: versitygw
 description: A Helm chart for deploying the Versity S3 Gateway on Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 sources:
   - https://github.com/versity/versitygw
 icon: https://raw.githubusercontent.com/versity/versitygw/main/webui/web/assets/images/Versity-logo-blue-horizontal.png

--- a/chart/templates/httproute.yaml
+++ b/chart/templates/httproute.yaml
@@ -25,8 +25,8 @@ spec:
           port: {{ .backendPort | default $.Values.gateway.port }}
     {{- end }}
 {{- end }}
+{{- if and .Values.admin.enabled .Values.admin.httpRoute.enabled }}
 ---
-{{- if and .Values.admin.enabled .Values.admin.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -53,8 +53,8 @@ spec:
           port: {{ $.Values.admin.port }}
     {{- end }}
 {{- end }}
+{{- if and .Values.webui.enabled .Values.webui.httpRoute.enabled }}
 ---
-{{- if and .Values.webui.enabled .Values.webui.httpRoute.enabled -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:


### PR DESCRIPTION
The multidoc separators were before the conditional, so when 2 routes were enabled it renders `---apiVersion`.

Sorry for missing this, I tested with 1 and all 3, not 2 😄