### PR TITLE
fix(chart): correct cosign-installer tag, revert path filter

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "chart/Chart.yaml"
 
 jobs:
   release:
@@ -44,7 +42,7 @@ jobs:
 
       - name: Install cosign
         if: steps.check.outputs.new == 'true'
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.0.0
 
       - name: Sign chart with cosign
         if: steps.check.outputs.new == 'true'


### PR DESCRIPTION
https://github.com/versity/versitygw/actions/runs/22793758976
The cosign-installer action doesn't have a major version tag for v4. There is one for v3 but [they recommend upgrading](https://github.com/sigstore/cosign-installer/releases/tag/v3.10.1) and I think they stopped updating the v3 tag, [it points to v3.9.1 from June](https://github.com/sigstore/cosign-installer/tags).

I also reverted the path filter. I don't think it makes a ton of sense to have it run each push to main but with the version check it's harmless and it's the original behavior here.

thanks!