### PR TITLE
fix(chart): use docker login for helm and cosign

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -34,7 +34,11 @@ jobs:
 
       - name: Login to GHCR
         if: steps.check.outputs.new == 'true'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u versity --password-stdin
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: versity
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push chart
         if: steps.check.outputs.new == 'true'


### PR DESCRIPTION
Cosign does not take credentials from helm login but does from docker login, and helm does as well. Verified here https://github.com/aclerici38/pocket-id-operator/actions/runs/22818484620/job/66187482832

Sorry again for all the noise I've caused the last few days. This should have been a couple very simple additions to the new, great chart.

Thanks!!