### PR TITLE
feat: s3proxy default to credential chain with optional anonymous access

### DIFF
--- a/backend/s3proxy/client.go
+++ b/backend/s3proxy/client.go
@@ -52,12 +52,8 @@ func (s *S3Proxy) getConfig(ctx context.Context, access, secret string) (aws.Con
 	if (access != "" && secret == "") || (access == "" && secret != "") {
 		return aws.Config{}, fmt.Errorf("both access and secret must be set or none at all")
 	}
-
-	var creds aws.CredentialsProvider
-	if access != "" {
-		creds = credentials.NewStaticCredentialsProvider(access, secret, "")
-	} else {
-		creds = aws.AnonymousCredentials{}
+	if s.anonymousCredentials && access != "" {
+		return aws.Config{}, fmt.Errorf("anonymous credentials cannot be used with access and secret")
 	}
 
 	tr := &http.Transport{
@@ -67,8 +63,13 @@ func (s *S3Proxy) getConfig(ctx context.Context, access, secret string) (aws.Con
 
 	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(s.awsRegion),
-		config.WithCredentialsProvider(creds),
 		config.WithHTTPClient(client),
+	}
+
+	if access != "" {
+		opts = append(opts, config.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(access, secret, "")))
+	} else if s.anonymousCredentials {
+		opts = append(opts, config.WithCredentialsProvider(aws.AnonymousCredentials{}))
 	}
 
 	if s.disableChecksum {

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -49,6 +49,7 @@ type S3Proxy struct {
 
 	access                    string
 	secret                    string
+	anonymousCredentials      bool
 	endpoint                  string
 	awsRegion                 string
 	metaBucket                string
@@ -69,10 +70,11 @@ func NewWithClient(ctx context.Context, client *s3.Client, metaBucket string) (*
 	return s, s.validate(ctx)
 }
 
-func New(ctx context.Context, access, secret, endpoint, region, metaBucket string, disableChecksum, disableDataIntegrityCheck, sslSkipVerify, usePathStyle, debug bool) (*S3Proxy, error) {
+func New(ctx context.Context, access, secret, endpoint, region, metaBucket string, anonymousCredentials, disableChecksum, disableDataIntegrityCheck, sslSkipVerify, usePathStyle, debug bool) (*S3Proxy, error) {
 	s := &S3Proxy{
 		access:                    access,
 		secret:                    secret,
+		anonymousCredentials:      anonymousCredentials,
 		endpoint:                  endpoint,
 		awsRegion:                 region,
 		metaBucket:                metaBucket,

--- a/cmd/versitygw/s3.go
+++ b/cmd/versitygw/s3.go
@@ -27,6 +27,7 @@ var (
 	s3proxyEndpoint                  string
 	s3proxyRegion                    string
 	s3proxyMetaBucket                string
+	s3proxyAnonymousCredentials      bool
 	s3proxyDisableChecksum           bool
 	s3proxyDisableDataIntegrityCheck bool
 	s3proxySslSkipVerify             bool
@@ -79,6 +80,13 @@ to an s3 storage backend service.`,
 				Destination: &s3proxyMetaBucket,
 			},
 			&cli.BoolFlag{
+				Name:        "anonymous-credentials",
+				Usage:       "force anonymous credentials instead of AWS default credential chain",
+				Value:       false,
+				EnvVars:     []string{"VGW_S3_ANONYMOUS_CREDENTIALS"},
+				Destination: &s3proxyAnonymousCredentials,
+			},
+			&cli.BoolFlag{
 				Name:        "disable-checksum",
 				Usage:       "disable gateway to server object checksums",
 				Value:       false,
@@ -119,7 +127,7 @@ to an s3 storage backend service.`,
 
 func runS3(ctx *cli.Context) error {
 	be, err := s3proxy.New(ctx.Context, s3proxyAccess, s3proxySecret, s3proxyEndpoint, s3proxyRegion,
-		s3proxyMetaBucket, s3proxyDisableChecksum, s3proxyDisableDataIntegrityCheck, s3proxySslSkipVerify, s3proxyUsePathStyle, s3proxyDebug)
+		s3proxyMetaBucket, s3proxyAnonymousCredentials, s3proxyDisableChecksum, s3proxyDisableDataIntegrityCheck, s3proxySslSkipVerify, s3proxyUsePathStyle, s3proxyDebug)
 	if err != nil {
 		return fmt.Errorf("init s3 backend: %w", err)
 	}

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -571,27 +571,42 @@ ROOT_SECRET_ACCESS_KEY=
 # accounts while maintaining full control and a single account for the backend
 # S3 service.
 
-# When s3 backend selected, the VGW_S3_ACCESS_KEY and VGW_S3_SECRET_KEY must
-# be defined for an authorized access or both empty for an anonymous access.
+# When s3 backend selected, the VGW_S3_ACCESS_KEY and VGW_S3_SECRET_KEY can
+# be defined for an authorized access or both empty to use AWS environment.
 # The VGW_S3_REGION and VGW_S3_ENDPOINT are optional, and will default to
 # "us-east-1" and "https://s3.amazonaws.com" respectively.
-# VGW_S3_META_BUCKET specifies a bucket to store bucket ACL/policy metadata.
-# VGW_S3_DISABLE_CHECKSUM will disable the SHA256 checksum for unsigned payload.
-# VGW_S3_DISABLE_DATA_INTEGRITY_CHECK will disable data integrity checks on
-# requests by setting RequestChecksumCalculationWhenRequired, which only
-# calculates checksums when explicitly required (may improve performance).
-# VGW_S3_SSL_SKIP_VERIFY will skip SSL certificate verification.
-# VGW_S3_USE_PATH_STYLE will use path style addressing for the S3 proxy.
-# VGW_S3_DEBUG will enable debug logging for S3 requests.
 #VGW_S3_ACCESS_KEY=
 #VGW_S3_SECRET_KEY=
 #VGW_S3_REGION=
 #VGW_S3_ENDPOINT=
+
+# VGW_S3_ANONYMOUS_CREDENTIALS can be used when anonymous access to the
+# backend s3 service is desired.
+#VGW_S3_ANONYMOUS_CREDENTIALS=false
+
+# VGW_S3_META_BUCKET specifies a bucket to store bucket ACL/policy metadata.
+# This is required to be set in order to store versitygw metadata within the
+# backend s3 service.
 #VGW_S3_META_BUCKET=
+
+# VGW_S3_DISABLE_CHECKSUM will disable the SHA256 checksum for unsigned payload.
 #VGW_S3_DISABLE_CHECKSUM=false
+
+# VGW_S3_DISABLE_DATA_INTEGRITY_CHECK will disable data integrity checks on
+# requests by setting RequestChecksumCalculationWhenRequired, which only
+# calculates checksums when explicitly required. This is sometimes needed
+# for s3 services that do not support the AWS data integrity options.
 #VGW_S3_DISABLE_DATA_INTEGRITY_CHECK=false
+
+# VGW_S3_SSL_SKIP_VERIFY will skip SSL certificate verification. This is
+# usually required if the backend s3 service is using self signed certs.
 #VGW_S3_SSL_SKIP_VERIFY=false
+
+# VGW_S3_USE_PATH_STYLE will use path style addressing for the S3 backend
+# bucket access. The default is to use virtual host style bucket addressing.
 #VGW_S3_USE_PATH_STYLE=false
+
+# VGW_S3_DEBUG will enable debug logging for S3 requests.
 #VGW_S3_DEBUG=false
 
 ########


### PR DESCRIPTION
When access/secret are not provided, let AWS SDK v2 resolve credentials from the default provider chain (env vars, IRSA, ECS/EC2 roles, etc.) instead of forcing anonymous credentials.

Add an explicit anonymous credentials option for s3 proxy to force backend anonymous access.

Fixes #1955