### PR TITLE
fix: allow Helm chart users to use their own, existing PVC

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: versitygw
 description: A Helm chart for deploying the Versity S3 Gateway on Kubernetes
 type: application
-version: 0.2.1
+version: 0.3.0
 sources:
   - https://github.com/versity/versitygw
 icon: https://raw.githubusercontent.com/versity/versitygw/main/webui/web/assets/images/Versity-logo-blue-horizontal.png

--- a/chart/README.md
+++ b/chart/README.md
@@ -59,6 +59,8 @@ helm upgrade my-versitygw oci://ghcr.io/versity/versitygw/charts/versitygw \
   --version 0.2.0
 ```
 
+You can find the list of available Helm chart versions in the [GitHub packages page](https://github.com/versity/versitygw/pkgs/container/versitygw%2Fcharts%2Fversitygw/versions?filters%5Bversion_type%5D=tagged).
+
 ## Backend Storage
 
 The `gateway.backend.type` value selects the storage backend. Use `gateway.backend.args` to pass backend-specific arguments.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -79,7 +79,11 @@ Returns empty string if persistence is disabled.
 */}}
 {{- define "versitygw.pvcName" -}}
 {{- if .Values.persistence.enabled }}
-{{- default (printf "%s-data" (include "versitygw.fullname" .)) .Values.persistence.claimName }}
+{{- if .Values.persistence.claimName }}
+{{- .Values.persistence.claimName }}
+{{- else }}
+{{- printf "%s-data" (include "versitygw.fullname" .) }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -4,6 +4,9 @@
     {{- fail "Multiple replicas with POSIX backend or Internal IAM require persistence.enabled=true to prevent data loss and inconsistency across pods. If using a stateless backend (e.g. S3, Azure) and external IAM, set persistence.enabled=false." }}
   {{- end }}
 {{- end }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.create) (not .Values.persistence.claimName) }}
+  {{- fail "persistence.claimName is required when persistence.create is false" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled -}}
+{{- if and .Values.persistence.enabled .Values.persistence.create -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -282,7 +282,9 @@ persistence:
   # If disabled, an emptyDir (ephemeral!) will be used instead of a PVC.
   # NOTE: Data will be lost on pod restart if persistence is disabled.
   enabled: true
-  # Use an existing PVC instead of creating a new one.
+  # Whether to create a new PVC. If false, persistence.claimName must be provided.
+  create: true
+  # The name of the PVC that should be created or used (if persistence.create=false)
   claimName: ""
   size: 10Gi
   storageClassName: ""


### PR DESCRIPTION
closes https://github.com/versity/versitygw/issues/1957

the following configurations are now possible:
```
# create a PVC with the Helm chart name
persistence:
  enabled: true # default: true
  create: true # default: true


# create a PVC with a custom name
persistence:
  enabled: true
  create: true
  claimName: foobar


# re-use an existing PVC
persistence:
  enabled: true
  create: false
  claimName: foobar


# do not use a PVC at all
persistence:
  enabled: false
```