### PR TITLE
fix: fix admin cli update user --project-id retrieval

### DIFF
--- a/cmd/versitygw/admin.go
+++ b/cmd/versitygw/admin.go
@@ -433,7 +433,7 @@ func updateUser(ctx *cli.Context) error {
 		ctx.String("secret"),
 		ctx.Int("user-id"),
 		ctx.Int("group-id"),
-		ctx.Int("projectID"),
+		ctx.Int("project-id"),
 		auth.Role(ctx.String("role"))
 
 	props := auth.MutableProps{}


### PR DESCRIPTION
The project id was misspelled(`projectID`) in the admin cli `update-user` command when retrieving the flag value. Now it's fixed to correct `project-id` to match the flag name.