### PR TITLE
Do not expose directories that can't be buckets

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -365,6 +365,10 @@ func (p *Posix) ListBuckets(ctx context.Context, input s3response.ListBucketsInp
 			continue
 		}
 
+		if !utils.IsValidBucketName(fi.Name()) {
+			continue
+		}
+
 		if len(buckets) == int(input.MaxBuckets) {
 			cToken = buckets[len(buckets)-1].Name
 			break


### PR DESCRIPTION
If a directory name doesn't pass bucket name validation, don't bother returning it from ListBuckets.