### PR TITLE
Update scoutfs glacier stage constants for ongoing requests

### DIFF
--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -114,8 +114,8 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 
 const (
 	stageComplete      = "ongoing-request=\"false\", expiry-date=\"Fri, 2 Dec 2050 00:00:00 GMT\""
-	stageInProgress    = "true"
-	stageNotInProgress = "false"
+	stageInProgress    = "ongoing-request=\"true\""
+	stageNotInProgress = "ongoing-request=\"false\""
 )
 
 const (


### PR DESCRIPTION
Fix issue with incompatible S3 response for offline and staging status.

Resolves issue with MinIO SDK returning "unexpected restore header" and causing restore requests to fail.