### PR TITLE
fix: cleanup file descriptor leaks with chown fails

### DIFF
--- a/backend/posix/with_otmpfile.go
+++ b/backend/posix/with_otmpfile.go
@@ -101,6 +101,7 @@ func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Accou
 	if doChown {
 		err := f.Chown(uid, gid)
 		if err != nil {
+			f.Close()
 			return nil, fmt.Errorf("set temp file ownership: %w", err)
 		}
 	}
@@ -141,6 +142,8 @@ func (p *Posix) openMkTemp(dir, bucket, obj string, size int64, dofalloc bool, u
 	if doChown {
 		err := f.Chown(uid, gid)
 		if err != nil {
+			f.Close()
+			os.Remove(f.Name())
 			return nil, fmt.Errorf("set temp file ownership: %w", err)
 		}
 	}

--- a/backend/posix/without_otmpfile.go
+++ b/backend/posix/without_otmpfile.go
@@ -61,6 +61,8 @@ func (p *Posix) openTmpFile(dir, bucket, obj string, size int64, acct auth.Accou
 	if doChown {
 		err := f.Chown(uid, gid)
 		if err != nil {
+			f.Close()
+			os.Remove(f.Name())
 			return nil, fmt.Errorf("set temp file ownership: %w", err)
 		}
 	}


### PR DESCRIPTION
We were missing a few cases of cleaning up temp files and file descriptors in the openTmpFile Chown() error cases.