### PR TITLE
fix: retry link on ENOENT caused by racing DeleteObject

### DIFF
--- a/backend/posix/with_otmpfile.go
+++ b/backend/posix/with_otmpfile.go
@@ -159,6 +159,34 @@ func (tmp *tmpfile) falloc() error {
 	return nil
 }
 
+const maxLinkRetries = 3
+
+// linkatOTmpfile links the O_TMPFILE identified by procdir/fdName into dir/basename.
+// Handles EEXIST by linking to a temporary name and atomically renaming it into place.
+// Raw errors are returned unwrapped so callers can inspect errno values (e.g. ENOENT).
+func linkatOTmpfile(procdirFd, dirFd int, fdName, basename string) error {
+	err := unix.Linkat(procdirFd, fdName, dirFd, basename, unix.AT_SYMLINK_FOLLOW)
+	if !errors.Is(err, syscall.EEXIST) {
+		return err
+	}
+	// Linkat cannot overwrite an existing file; link to a temp name then rename atomically.
+	for retries := 1; ; retries++ {
+		tmpName := fmt.Sprintf(".%s.sgwtmp.%d", basename, time.Now().UnixNano())
+		err := unix.Linkat(procdirFd, fdName, dirFd, tmpName, unix.AT_SYMLINK_FOLLOW)
+		if errors.Is(err, syscall.EEXIST) && retries < maxLinkRetries {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("cannot find free temporary file: %w", err)
+		}
+		err = unix.Renameat(dirFd, tmpName, dirFd, basename)
+		if err != nil {
+			return fmt.Errorf("overwriting renameat failed: %w", err)
+		}
+		return nil
+	}
+}
+
 func (tmp *tmpfile) link() error {
 	// make sure this is cleaned up in all error cases
 	defer tmp.f.Close()
@@ -195,31 +223,24 @@ func (tmp *tmpfile) link() error {
 	}
 	defer dirf.Close()
 
-	err = unix.Linkat(int(procdir.Fd()), filepath.Base(tmp.f.Name()),
-		int(dirf.Fd()), filepath.Base(objPath), unix.AT_SYMLINK_FOLLOW)
-	if errors.Is(err, syscall.EEXIST) {
-		// Linkat cannot overwrite files; we will allocate a temporary file, Linkat to it and then Renameat it
-		// to avoid potential race condition
-		retries := 1
-		for {
-			tmpName := fmt.Sprintf(".%s.sgwtmp.%d", filepath.Base(objPath), time.Now().UnixNano())
-			err := unix.Linkat(int(procdir.Fd()), filepath.Base(tmp.f.Name()),
-				int(dirf.Fd()), tmpName, unix.AT_SYMLINK_FOLLOW)
-			if errors.Is(err, syscall.EEXIST) && retries < 3 {
-				retries += 1
-				continue
-			}
-			if err != nil {
-				return fmt.Errorf("cannot find free temporary file: %w", err)
-			}
-
-			err = unix.Renameat(int(dirf.Fd()), tmpName, int(dirf.Fd()), filepath.Base(objPath))
-			if err != nil {
-				return fmt.Errorf("overwriting renameat failed: %w", err)
-			}
-			break
+	err = linkatOTmpfile(int(procdir.Fd()), int(dirf.Fd()),
+		filepath.Base(tmp.f.Name()), filepath.Base(objPath))
+	if errors.Is(err, syscall.ENOENT) {
+		// The parent directory was concurrently removed (e.g. by a racing
+		// DeleteObject+removeParents). Recreate it and retry once.
+		dirf.Close()
+		if mkErr := backend.MkdirAll(dir, tmp.uid, tmp.gid, tmp.needsChown, tmp.newDirPerm); mkErr != nil {
+			return fmt.Errorf("recreate parent dir: %w", mkErr)
 		}
-	} else if err != nil {
+		dirf, err = os.Open(dir)
+		if err != nil {
+			return fmt.Errorf("open parent dir: %w", err)
+		}
+		defer dirf.Close()
+		err = linkatOTmpfile(int(procdir.Fd()), int(dirf.Fd()),
+			filepath.Base(tmp.f.Name()), filepath.Base(objPath))
+	}
+	if err != nil {
 		return fmt.Errorf("link tmpfile (fd %q as %q): %w",
 			filepath.Base(tmp.f.Name()), objPath, err)
 	}
@@ -245,6 +266,21 @@ func (tmp *tmpfile) fallbackLink() error {
 
 	objPath := filepath.Join(tmp.bucket, tmp.objname)
 	err = os.Rename(tempname, objPath)
+	if errors.Is(err, syscall.ENOENT) {
+		// The parent directory was concurrently removed; recreate and retry.
+		dir := filepath.Dir(objPath)
+		for {
+			mkErr := backend.MkdirAll(dir, tmp.uid, tmp.gid, tmp.needsChown, tmp.newDirPerm)
+			if mkErr != nil {
+				return fmt.Errorf("recreate parent dir: %w", mkErr)
+			}
+			err = os.Rename(tempname, objPath)
+			if errors.Is(err, syscall.ENOENT) {
+				continue
+			}
+			break
+		}
+	}
 	if err != nil {
 		// rename only works for files within the same filesystem
 		// if this fails fallback to copy

--- a/backend/posix/without_otmpfile.go
+++ b/backend/posix/without_otmpfile.go
@@ -88,7 +88,22 @@ func (tmp *tmpfile) link() error {
 		return fmt.Errorf("close tmpfile: %w", err)
 	}
 
-	return backend.MoveFile(tempname, objPath, defaultFilePerm)
+	err = backend.MoveFile(tempname, objPath, defaultFilePerm)
+	if errors.Is(err, syscall.ENOENT) {
+		// The parent directory may have been concurrently removed; recreate and retry.
+		for {
+			mkErr := os.MkdirAll(filepath.Dir(objPath), 0o755)
+			if mkErr != nil {
+				return fmt.Errorf("recreate parent dir: %w", mkErr)
+			}
+			err = backend.MoveFile(tempname, objPath, defaultFilePerm)
+			if errors.Is(err, syscall.ENOENT) {
+				continue
+			}
+			break
+		}
+	}
+	return err
 }
 
 func (tmp *tmpfile) Write(b []byte) (int, error) {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -867,6 +867,7 @@ func TestPosix(ts *TestState) {
 	ts.Run(CopyObject_overwrite_same_dir_object)
 	ts.Run(CopyObject_overwrite_same_file_object)
 	ts.Run(DeleteObject_directory_not_empty)
+	ts.Run(PutObject_race_with_delete)
 	// posix specific versioning tests
 	if !ts.conf.versioningEnabled {
 		TestVersioningDisabled(ts)
@@ -1744,6 +1745,7 @@ func GetIntTests() IntTests {
 		"PutObject_overwrite_file_obj_with_nested_obj":                             PutObject_overwrite_file_obj_with_nested_obj,
 		"PutObject_dir_obj_with_data":                                              PutObject_dir_obj_with_data,
 		"PutObject_with_slashes":                                                   PutObject_with_slashes,
+		"PutObject_race_with_delete":                                               PutObject_race_with_delete,
 		"CreateMultipartUpload_dir_obj":                                            CreateMultipartUpload_dir_obj,
 		"IAM_user_access_denied":                                                   IAM_user_access_denied,
 		"IAM_userplus_access_denied":                                               IAM_userplus_access_denied,

--- a/tests/integration/posix.go
+++ b/tests/integration/posix.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/versity/versitygw/s3err"
+	"golang.org/x/sync/errgroup"
 )
 
 func PutObject_overwrite_dir_obj(s *S3Conf) error {
@@ -216,5 +218,80 @@ func CopyObject_overwrite_same_file_object(s *S3Conf) error {
 		}
 
 		return nil
+	})
+}
+
+// PutObject_race_with_delete tests the race between PutObject and DeleteObject
+// in the same subdirectory.
+// One goroutine sequentially puts "race-dir/0.txt" … "race-dir/N-1.txt".
+// A second goroutine loops for the same number of iterations: it lists all
+// objects under "race-dir/" and bulk-deletes them.  When the batch delete
+// removes the last visible object in the directory, removeParents() rmdir's
+// "race-dir/", which can race with the uploader's final link() step.
+// The test asserts that no error is returned from either goroutine.
+func PutObject_race_with_delete(s *S3Conf) error {
+	testName := "PutObject_race_with_delete"
+	const iterations = 100
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		eg := errgroup.Group{}
+
+		// Upload goroutine: sequentially puts objects into race-dir/
+		eg.Go(func() error {
+			for i := range iterations {
+				key := fmt.Sprintf("race-dir/%d.txt", i)
+				ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+				_, err := s3client.PutObject(ctx, &s3.PutObjectInput{
+					Bucket: &bucket,
+					Key:    &key,
+				})
+				cancel()
+				if err != nil {
+					return fmt.Errorf("put %d: %w", i, err)
+				}
+			}
+			return nil
+		})
+
+		// Delete goroutine: repeatedly lists race-dir/ and bulk-deletes everything.
+		// When the last object is removed, removeParents() rmdir's the directory,
+		// racing with the concurrent link() call in the upload goroutine.
+		eg.Go(func() error {
+			for range iterations {
+				ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+				res, err := s3client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{
+					Bucket: &bucket,
+					Prefix: getPtr("race-dir/"),
+				})
+				cancel()
+				if err != nil {
+					return fmt.Errorf("list: %w", err)
+				}
+				if len(res.Contents) == 0 {
+					continue
+				}
+
+				objs := make([]types.ObjectIdentifier, 0, len(res.Contents))
+				for _, obj := range res.Contents {
+					objs = append(objs, types.ObjectIdentifier{Key: obj.Key})
+				}
+
+				ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+				out, err := s3client.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+					Bucket: &bucket,
+					Delete: &types.Delete{Objects: objs},
+				})
+				cancel()
+				if err != nil {
+					return fmt.Errorf("delete objects: %w", err)
+				}
+				if len(out.Errors) > 0 {
+					return fmt.Errorf("delete error: key=%v code=%v msg=%v",
+						*out.Errors[0].Key, *out.Errors[0].Code, *out.Errors[0].Message)
+				}
+			}
+			return nil
+		})
+
+		return eg.Wait()
 	})
 }


### PR DESCRIPTION
A concurrent PutObject and DeleteObject on the same prefix can race: PutObject opens an O_TMPFILE in MetaTmpDir (not yet visible in the fs) DeleteObject removes the last visible object in "x/" and calls removeParents(), which rmdir's the now-empty "x/"
PutObject's link() tries to link the fd into "x/obj" — ENOENT

Fix by detecting ENOENT in the final link step (Linkat, Rename, and MoveFile) and retrying once after recreating the parent directory.

Also extract linkatOTmpfile() to consolidate the Linkat+EEXIST→Renameat logic that was previously inline in link().

Fixes #1988