### PR TITLE
fix: add x-amz-bucket-region to ListObjects(V2) response headers.

### DIFF
--- a/s3api/controllers/bucket-get.go
+++ b/s3api/controllers/bucket-get.go
@@ -519,6 +519,10 @@ func (c S3ApiController) ListObjectsV2(ctx *fiber.Ctx) (*Response, error) {
 	isRoot := utils.ContextKeyIsRoot.Get(ctx).(bool)
 	isPublicBucket := utils.ContextKeyPublicBucket.IsSet(ctx)
 	parsedAcl := utils.ContextKeyParsedAcl.Get(ctx).(auth.ACL)
+	region, ok := utils.ContextKeyRegion.Get(ctx).(string)
+	if !ok {
+		region = defaultRegion
+	}
 
 	err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 		Readonly:        c.readonly,
@@ -557,12 +561,23 @@ func (c S3ApiController) ListObjectsV2(ctx *fiber.Ctx) (*Response, error) {
 			StartAfter:        &sAfter,
 			FetchOwner:        &fetchOwner,
 		})
+	if err != nil {
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, err
+	}
+
 	return &Response{
+		Headers: map[string]*string{
+			"x-amz-bucket-region": &region,
+		},
 		Data: res,
 		MetaOpts: &MetaOptions{
 			BucketOwner: parsedAcl.Owner,
 		},
-	}, err
+	}, nil
 }
 
 func (c S3ApiController) ListObjects(ctx *fiber.Ctx) (*Response, error) {
@@ -577,6 +592,10 @@ func (c S3ApiController) ListObjects(ctx *fiber.Ctx) (*Response, error) {
 	isRoot := utils.ContextKeyIsRoot.Get(ctx).(bool)
 	isPublicBucket := utils.ContextKeyPublicBucket.IsSet(ctx)
 	parsedAcl := utils.ContextKeyParsedAcl.Get(ctx).(auth.ACL)
+	region, ok := utils.ContextKeyRegion.Get(ctx).(string)
+	if !ok {
+		region = defaultRegion
+	}
 
 	err := auth.VerifyAccess(ctx.Context(), c.be, auth.AccessOptions{
 		Readonly:        c.readonly,
@@ -614,12 +633,23 @@ func (c S3ApiController) ListObjects(ctx *fiber.Ctx) (*Response, error) {
 			Delimiter: &delimiter,
 			MaxKeys:   &maxkeys,
 		})
+	if err != nil {
+		return &Response{
+			MetaOpts: &MetaOptions{
+				BucketOwner: parsedAcl.Owner,
+			},
+		}, err
+	}
+
 	return &Response{
+		Headers: map[string]*string{
+			"x-amz-bucket-region": &region,
+		},
 		Data: res,
 		MetaOpts: &MetaOptions{
 			BucketOwner: parsedAcl.Owner,
 		},
-	}, err
+	}, nil
 }
 
 // GetBucketLocation handles GET /:bucket?location

--- a/s3api/controllers/bucket-get_test.go
+++ b/s3api/controllers/bucket-get_test.go
@@ -1107,7 +1107,6 @@ func TestS3ApiController_ListObjectsV2(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
-					Data: s3response.ListObjectsV2Result{},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 					},
@@ -1123,6 +1122,9 @@ func TestS3ApiController_ListObjectsV2(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
+					Headers: map[string]*string{
+						"x-amz-bucket-region": utils.GetStringPtr(defaultRegion),
+					},
 					Data: listV2Result,
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
@@ -1214,7 +1216,6 @@ func TestS3ApiController_ListObjects(t *testing.T) {
 			},
 			output: testOutput{
 				response: &Response{
-					Data: s3response.ListObjectsResult{},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 					},
@@ -1231,6 +1232,9 @@ func TestS3ApiController_ListObjects(t *testing.T) {
 			output: testOutput{
 				response: &Response{
 					Data: listResult,
+					Headers: map[string]*string{
+						"x-amz-bucket-region": utils.GetStringPtr(defaultRegion),
+					},
 					MetaOpts: &MetaOptions{
 						BucketOwner: "root",
 					},


### PR DESCRIPTION
Fixes #1814

The `x-amz-bucket-region` is not mentioned in AWS S3 documentation, however s3 sends it in all ListObjects(V2) successful responses. The header is now added.