### PR TITLE
fix: correct HeadObject restore status for offline objects in scoutfs

### DIFF
--- a/backend/scoutfs/scoutfs_compat.go
+++ b/backend/scoutfs/scoutfs_compat.go
@@ -114,9 +114,8 @@ func New(rootdir string, opts ScoutfsOpts) (*ScoutFS, error) {
 }
 
 const (
-	stageComplete      = "ongoing-request=\"false\", expiry-date=\"Fri, 2 Dec 2050 00:00:00 GMT\""
-	stageInProgress    = "ongoing-request=\"true\""
-	stageNotInProgress = "ongoing-request=\"false\""
+	stageComplete   = "ongoing-request=\"false\", expiry-date=\"Fri, 2 Dec 2050 00:00:00 GMT\""
+	stageInProgress = "ongoing-request=\"true\""
 )
 
 const (
@@ -196,9 +195,7 @@ func (s *ScoutFS) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s
 		objPath := filepath.Join(*input.Bucket, *input.Key)
 
 		stclass := types.StorageClassStandard
-		requestOngoing := ""
-
-		requestOngoing = stageComplete
+		requestOngoing := stageComplete
 
 		// Check if there are any offline exents associated with this file.
 		// If so, we will set storage class to glacier.
@@ -211,7 +208,7 @@ func (s *ScoutFS) HeadObject(ctx context.Context, input *s3.HeadObjectInput) (*s
 		}
 		if st.Offline_blocks != 0 {
 			stclass = types.StorageClassGlacier
-			requestOngoing = stageNotInProgress
+			requestOngoing = ""
 
 			ok, err := isStaging(objPath)
 			if errors.Is(err, fs.ErrNotExist) {

--- a/extra/example.conf
+++ b/extra/example.conf
@@ -535,7 +535,7 @@ ROOT_SECRET_ACCESS_KEY=
 # GET object:  if file offline, return invalid object state
 # HEAD object: if file offline, set obj storage class to GLACIER
 #              if file offline and staging, x-amz-restore: ongoing-request="true"
-#              if file offline and not staging, x-amz-restore: ongoing-request="false"
+#              if file offline and not staging, omit x-amz-restore
 #              if file online, x-amz-restore: ongoing-request="false", expiry-date="Fri, 2 Dec 2050 00:00:00 GMT"
 #              note: this expiry-date is not used but provided for client glacier compatibility
 # ListObjects: if file offline, set obj storage class to GLACIER


### PR DESCRIPTION
Fixes #2030 

When an object has offline blocks, the restore status was incorrectly set to `ongoing-request="false"` instead of omitting the header entirely, which causes s3 clients fail on parsing the x-amz-restore header. Remove the incorrect `stageNotInProgress` constant and simplify the `requestOngoing` initialization to reflect the correct default.