### PR TITLE
fix: close temp file before rename in sidecar StoreAttribute

### DIFF
--- a/backend/meta/sidecar.go
+++ b/backend/meta/sidecar.go
@@ -80,11 +80,17 @@ func (s SideCar) StoreAttribute(_ *os.File, bucket, object, attribute string, va
 		return fmt.Errorf("failed to create temporary file: %v", err)
 	}
 	defer os.Remove(tempfile.Name())
-	defer tempfile.Close()
 
 	_, err = tempfile.Write(value)
 	if err != nil {
+		tempfile.Close()
 		return fmt.Errorf("failed to write attribute: %v", err)
+	}
+
+	// Close explicitly before rename to prevent error on Windows:
+	// The process cannot access the file because it is being used by another process.
+	if err = tempfile.Close(); err != nil {
+		return fmt.Errorf("failed to close temporary file: %v", err)
 	}
 
 	err = os.Rename(tempfile.Name(), attr)


### PR DESCRIPTION
On Windows, a file apparently cannot be renamed while an open handle to it exists.
The previous code used defer tempfile.Close(), which meant the handle was still open when os.Rename was called, producing:

  failed to rename temporary file: The process cannot access
  the file because it is being used by another process.

Fix by closing the file explicitly before the rename.

Fixes #2021