### PR TITLE
fix: use encodeS3Key in webui instead of encodeURIComponent in createFolder

### DIFF
--- a/webui/web/js/api.js
+++ b/webui/web/js/api.js
@@ -1334,7 +1334,7 @@ class VersityAPI {
     // Ensure prefix ends with /
     const folderKey = prefix.endsWith('/') ? prefix : prefix + '/';
 
-    const fetchParams = await this.buildFetchParams('PUT', `/${bucket}/${encodeURIComponent(folderKey)}`, {}, '');
+    const fetchParams = await this.buildFetchParams('PUT', `/${bucket}/${encodeS3Key(folderKey)}`, {}, '');
 
     const response = await fetch(fetchParams.url, {
       method: 'PUT',


### PR DESCRIPTION
encodeURIComponent encodes the trailing slash as %2F, producing a path like /bucket/folder%2F. S3 servers (e.g. Ceph) reject this with a SignatureDoesNotMatch error because the canonical URI used for signing differs from what the server reconstructs.

encodeS3Key encodes each path segment individually, leaving slashes as literal /, which is consistent with all other object-key operations in the API client.

Fixes #2029