### PR TITLE
fix: properly encode path and query parameters.

### DIFF
--- a/webui/web/js/api.js
+++ b/webui/web/js/api.js
@@ -109,7 +109,7 @@ const hasSubtleCrypto = typeof crypto !== 'undefined' && typeof crypto.subtle !=
  */
 function encodeS3Key(key) {
   if (!key) return '';
-  return key.split('/').map(segment => encodeURIComponent(segment)).join('/');
+  return key.split('/').map(segment => awsUriEncode(segment)).join('/');
 }
 
 class VersityAPI {
@@ -161,7 +161,7 @@ class VersityAPI {
     // Sort query params for canonical request
     const sortedParams = [...url.searchParams.entries()].sort((a, b) => a[0].localeCompare(b[0]));
     const canonicalQueryString = sortedParams
-      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+      .map(([k, v]) => `${awsUriEncode(k)}=${awsUriEncode(v)}`)
       .join('&');
 
     const canonicalHeaders = `host:${host}\n`;
@@ -526,7 +526,7 @@ class VersityAPI {
     // Sort query parameters
     const sortedParams = [...url.searchParams.entries()].sort((a, b) => a[0].localeCompare(b[0]));
     const canonicalQueryString = sortedParams.map(([k, v]) =>
-      `${encodeURIComponent(k)}=${encodeURIComponent(v)}`
+      `${awsUriEncode(k)}=${awsUriEncode(v)}`
     ).join('&');
 
     // Hash the payload
@@ -627,7 +627,7 @@ class VersityAPI {
     // Sort query parameters
     const sortedParams = [...url.searchParams.entries()].sort((a, b) => a[0].localeCompare(b[0]));
     const canonicalQueryString = sortedParams.map(([k, v]) =>
-      `${encodeURIComponent(k)}=${encodeURIComponent(v)}`
+      `${awsUriEncode(k)}=${awsUriEncode(v)}`
     ).join('&');
 
     // Hash the payload
@@ -1234,7 +1234,7 @@ class VersityAPI {
     // Sort query parameters
     const sortedParams = [...url.searchParams.entries()].sort((a, b) => a[0].localeCompare(b[0]));
     const canonicalQueryString = sortedParams.map(([k, v]) =>
-      `${encodeURIComponent(k)}=${encodeURIComponent(v)}`
+      `${awsUriEncode(k)}=${awsUriEncode(v)}`
     ).join('&');
 
     // Create canonical headers
@@ -2057,6 +2057,18 @@ ${tagsXml}
     }
     return result;
   }
+}
+
+/**
+ * Encode path and query params as defined as the AWS SigV4 specification: any
+ * character other than A-Za-z0-9-_. should be hex-encoded.
+ */
+function awsUriEncode(text) {
+  return encodeURIComponent(text)
+    .replace(
+      /['()*!]/g,
+      (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`,
+    );
 }
 
 // Create global API instance

--- a/webui/web/js/api.js
+++ b/webui/web/js/api.js
@@ -2060,10 +2060,14 @@ ${tagsXml}
 }
 
 /**
- * Encode path and query params as defined as the AWS SigV4 specification: any
- * character other than A-Za-z0-9-_. should be hex-encoded.
+ * URI-encode a string per the AWS SigV4 specification.
+ * All characters except the unreserved set (A-Za-z0-9 - _ . ~) are percent-encoded,
+ * with hexadecimal digits in uppercase (e.g. %2F, not %2f).
+ *
+ * @param {string} text - The string to encode.
+ * @returns {string} The percent-encoded string.
  */
-function awsUriEncode(text) {
+ function awsUriEncode(text) {
   return encodeURIComponent(text)
     .replace(
       /['()*!]/g,


### PR DESCRIPTION
Fixes #2060.

[AWS Signature V4](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html) defines that all characters except for `[A-Za-z0-9-_.~]` should be hex-encoded. The current use of `encodeURIComponent()` misses a few characters, which would make signatures for those prefixes invalid.

This PR extends that method with the proper encoding for the mising characters.

---

Excerpt from the documentation:

```
URI encode every byte. UriEncode() must enforce the following rules:

    URI encode every byte except the unreserved characters: 'A'-'Z', 'a'-'z', '0'-'9', '-', '.', '_', and '~'.

    The space character is a reserved character and must be encoded as "%20" (and not as "+").

    Each URI encoded byte is formed by a '%' and the two-digit hexadecimal value of the byte.

    Letters in the hexadecimal value must be uppercase, for example "%1A".

    Encode the forward slash character, '/', everywhere except in the object key name. For example, if the object key name is photos/Jan/sample.jpg, the forward slash in the key name is not encoded. 
```