### PR TITLE
feat: history back/forward actions on explorer and modals.

### DIFF
--- a/webui/web/buckets.html
+++ b/webui/web/buckets.html
@@ -221,7 +221,7 @@ under the License.
   </div>
 
   <!-- Change Owner Modal -->
-  <div id="owner-modal" class="hidden fixed inset-0 z-50">
+  <div id="owner-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('owner-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -281,7 +281,7 @@ under the License.
   </div>
 
   <!-- Create Bucket Modal -->
-  <div id="create-bucket-modal" class="hidden fixed inset-0 z-50">
+  <div id="create-bucket-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('create-bucket-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -353,6 +353,15 @@ under the License.
     let allBuckets = [];
     let allUsers = [];
     let selectedBucket = null;
+    
+    // Catch the back button to close the open modal, if any is open.
+    window.addEventListener('popstate', (e) => {
+      Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
+        if (!modal.classList.contains('hidden')) {
+          closeModal(modal.getAttribute('id'), false);
+        }
+      })
+    });
 
     // ============================================
     // Custom Dropdown Functions

--- a/webui/web/buckets.html
+++ b/webui/web/buckets.html
@@ -354,15 +354,6 @@ under the License.
     let allUsers = [];
     let selectedBucket = null;
     
-    // Catch the back button to close the open modal, if any is open.
-    window.addEventListener('popstate', (e) => {
-      Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
-        if (!modal.classList.contains('hidden')) {
-          closeModal(modal.getAttribute('id'), false);
-        }
-      })
-    });
-
     // ============================================
     // Custom Dropdown Functions
     // ============================================

--- a/webui/web/explorer.html
+++ b/webui/web/explorer.html
@@ -999,7 +999,7 @@ under the License.
       // Will redirect to login
     } else {
       // Clear history state on startup (can happen when reloading with popup open)
-      if (history.state) history.back();
+      if (history.state?.modal) history.back();
       
       initSidebarWithRole();
       updateUserInfo();
@@ -1037,15 +1037,6 @@ under the License.
       await init();
     });
     
-    // Catch the back button to close the open modal, if any is open.
-    window.addEventListener('popstate', (e) => {
-      Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
-        if (!modal.classList.contains('hidden')) {
-          closeModal(modal.getAttribute('id'), false);
-        }
-      })
-    });
-
     // ============================================
     // Logout
     // ============================================

--- a/webui/web/explorer.html
+++ b/webui/web/explorer.html
@@ -272,7 +272,7 @@ under the License.
   </div>
 
   <!-- Object Info Modal -->
-  <div id="info-modal" class="hidden fixed inset-0 z-50">
+  <div id="info-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('info-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-3xl relative max-h-[90vh] flex flex-col">
@@ -372,7 +372,7 @@ under the License.
   <input type="file" id="file-input" class="hidden" multiple onchange="handleFileSelect(event)">
 
   <!-- Object Versions Modal -->
-  <div id="versions-modal" class="hidden fixed inset-0 z-50">
+  <div id="versions-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('versions-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-4xl relative max-h-[90vh] flex flex-col">
@@ -406,7 +406,7 @@ under the License.
   </div>
 
   <!-- Delete Confirmation Modal -->
-  <div id="delete-modal" class="hidden fixed inset-0 z-50">
+  <div id="delete-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('delete-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -432,7 +432,7 @@ under the License.
   </div>
 
   <!-- Create Folder Modal -->
-  <div id="create-folder-modal" class="hidden fixed inset-0 z-50">
+  <div id="create-folder-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('create-folder-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -462,7 +462,7 @@ under the License.
   </div>
 
   <!-- Create Bucket Modal -->
-  <div id="create-bucket-modal" class="hidden fixed inset-0 z-50">
+  <div id="create-bucket-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('create-bucket-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -492,7 +492,7 @@ under the License.
   </div>
 
   <!-- Delete Bucket Modal -->
-  <div id="delete-bucket-modal" class="hidden fixed inset-0 z-50">
+  <div id="delete-bucket-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('delete-bucket-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -526,7 +526,7 @@ under the License.
   </div>
 
   <!-- Bucket Info Modal -->
-  <div id="bucket-info-modal" class="hidden fixed inset-0 z-50">
+  <div id="bucket-info-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('bucket-info-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-2xl relative max-h-[90vh] overflow-y-auto">
@@ -600,7 +600,7 @@ under the License.
   </div>
 
   <!-- Versioning Modal -->
-  <div id="versioning-modal" class="hidden fixed inset-0 z-50">
+  <div id="versioning-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('versioning-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -642,7 +642,7 @@ under the License.
   </div>
 
   <!-- Object Lock Modal -->
-  <div id="object-lock-modal" class="hidden fixed inset-0 z-50">
+  <div id="object-lock-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('object-lock-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -706,7 +706,7 @@ under the License.
   </div>
 
   <!-- Bucket Policy Modal -->
-  <div id="bucket-policy-modal" class="hidden fixed inset-0 z-50">
+  <div id="bucket-policy-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('bucket-policy-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-5xl relative max-h-[90vh] flex flex-col">
@@ -878,7 +878,7 @@ under the License.
   </div>
 
   <!-- Multipart Uploads Modal -->
-  <div id="multipart-uploads-modal" class="hidden fixed inset-0 z-50">
+  <div id="multipart-uploads-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('multipart-uploads-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-4xl relative max-h-[90vh] flex flex-col">
@@ -998,6 +998,9 @@ under the License.
     if (!requireAuth()) {
       // Will redirect to login
     } else {
+      // Clear history state on startup (can happen when reloading with popup open)
+      if (history.state) history.back();
+      
       initSidebarWithRole();
       updateUserInfo();
       init();
@@ -1021,10 +1024,27 @@ under the License.
             currentPrefix += '/';
           }
         }
+      } else {
+        currentBucket = "";
+        currentPrefix = "";
       }
 
       await loadBuckets();
     }
+    
+    // Rerun init() on hash change to allow for back/forward when browsing a bucket.
+    window.addEventListener('hashchange', async () => {
+      await init();
+    });
+    
+    // Catch the back button to close the open modal, if any is open.
+    window.addEventListener('popstate', (e) => {
+      Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
+        if (!modal.classList.contains('hidden')) {
+          closeModal(modal.getAttribute('id'), false);
+        }
+      })
+    });
 
     // ============================================
     // Logout

--- a/webui/web/js/app.js
+++ b/webui/web/js/app.js
@@ -135,6 +135,8 @@ function openModal(modalId) {
   }
 }
 
+let navigatingBack = false
+
 // Close the currently opened modal, manually popping the modal
 // history state if the modal was closed manually (default). In the
 // case where the modal was closed due to navigating back, the state
@@ -143,7 +145,8 @@ function closeModal(modalId, popState = true) {
   const modal = document.getElementById(modalId);
   if (modal) {
     modal.classList.add('hidden');
-    if (popState) {
+    if (popState && history.state?.modal) {
+      navigatingBack = true;
       history.back();
     }
   }
@@ -154,6 +157,24 @@ function closeAllModals() {
     modal.classList.add('hidden');
   });
 }
+
+function closeModalsOnNavigation() {
+  Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
+    if (!modal.classList.contains('hidden')) {
+      closeModal(modal.getAttribute('id'), false);
+    }
+  })
+}
+
+// Catch the back button to close the open modal, if any is open.
+window.addEventListener('popstate', (e) => {
+  if (navigatingBack) {
+    navigatingBack = false;
+    return;
+  }
+  
+  closeModalsOnNavigation();
+});
 
 // Close modals on Escape key
 document.addEventListener('keydown', (e) => {

--- a/webui/web/js/app.js
+++ b/webui/web/js/app.js
@@ -129,13 +129,23 @@ function openModal(modalId) {
     // Focus first input
     const firstInput = modal.querySelector('input:not([readonly]), select');
     if (firstInput) setTimeout(() => firstInput.focus(), 100);
+    
+    // Push to history state so the back button can close the modal
+    history.pushState({ modal: true }, '');
   }
 }
 
-function closeModal(modalId) {
+// Close the currently opened modal, manually popping the modal
+// history state if the modal was closed manually (default). In the
+// case where the modal was closed due to navigating back, the state
+// is already popped and we can skip it.
+function closeModal(modalId, popState = true) {
   const modal = document.getElementById(modalId);
   if (modal) {
     modal.classList.add('hidden');
+    if (popState) {
+      history.back();
+    }
   }
 }
 

--- a/webui/web/users.html
+++ b/webui/web/users.html
@@ -325,15 +325,6 @@ under the License.
     let allUsers = [];
     let userToDelete = null;
     
-    // Catch the back button to close the open modal, if any is open.
-    window.addEventListener('popstate', (e) => {
-      Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
-        if (!modal.classList.contains('hidden')) {
-          closeModal(modal.getAttribute('id'), false);
-        }
-      })
-    });
-
     // ============================================
     // Custom Dropdown Functions
     // ============================================

--- a/webui/web/users.html
+++ b/webui/web/users.html
@@ -209,7 +209,7 @@ under the License.
   </div>
 
   <!-- Create/Edit User Modal -->
-  <div id="user-modal" class="hidden fixed inset-0 z-50">
+  <div id="user-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('user-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-lg relative">
@@ -298,7 +298,7 @@ under the License.
   </div>
 
   <!-- Delete Confirmation Modal -->
-  <div id="delete-modal" class="hidden fixed inset-0 z-50">
+  <div id="delete-modal" class="modal hidden fixed inset-0 z-50">
     <div class="modal-backdrop absolute inset-0" onclick="closeModal('delete-modal')"></div>
     <div class="absolute inset-0 flex items-center justify-center p-4">
       <div class="bg-white rounded-xl shadow-2xl w-full max-w-md relative">
@@ -324,6 +324,15 @@ under the License.
   <script>
     let allUsers = [];
     let userToDelete = null;
+    
+    // Catch the back button to close the open modal, if any is open.
+    window.addEventListener('popstate', (e) => {
+      Array.from(document.getElementsByClassName('modal')).forEach((modal) => {
+        if (!modal.classList.contains('hidden')) {
+          closeModal(modal.getAttribute('id'), false);
+        }
+      })
+    });
 
     // ============================================
     // Custom Dropdown Functions


### PR DESCRIPTION
Most actions within each page is stateless (show modals) or change the URL hash. As it is, those are not tracked and using the back button has no effect.

This commits implements two things:

 - Tracking of the URL hash in the explorer to move from bucket/folders on history change.
 - Add a history state when a modal is open, so the back button closes the modal.

---

**Note:** The modal behavior, as implemented above, leaves behind an "empty" forward state when closing a modal (either through a button, or by using back). This means that, on modal close, the user is able to go one page forward, with no effect.

I did not find a way to prevent this, and figured it was still a good feature to have and what users expect.