### PR TITLE
Redirect to the page the unauthenticated user tried to access after login

### DIFF
--- a/webui/web/index.html
+++ b/webui/web/index.html
@@ -620,7 +620,25 @@ under the License.
         // Save gateway to recent list
         const rememberKey = document.getElementById('remember-access-key').checked;
         saveRecentGateway(s3Endpoint, region, accessKey, rememberKey);
-
+        
+        if (window.location.hash !== '') {
+          try {
+            const previousLocation = decodeURIComponent(window.location.hash.slice(1));
+            const url = new URL(previousLocation, window.location.origin)
+            
+            const ALLOWED_PAGES = ['/explorer.html', '/dashboard.html', '/buckets.html', '/users.html'];
+            
+            // Validate same origin and against an explicit page allowlist.
+            // Using URL() means javascript: URIs resolve with origin "null" and are rejected.
+            if (url.origin === window.location.origin && ALLOWED_PAGES.includes(url.pathname)) {
+              window.location.href = previousLocation;
+              return;
+            }
+          } catch (_) {
+              // Malformed URL — fall through to default role-based redirect below.
+          }
+        }
+        
         // Navigate based on role
         if (role === 'admin') {
           // Admin user - redirect to dashboard

--- a/webui/web/js/app.js
+++ b/webui/web/js/app.js
@@ -26,7 +26,9 @@
  */
 function requireAuth() {
   if (!api.loadCredentials()) {
-    window.location.href = 'index.html';
+    const previousLocation = encodeURIComponent(`${window.location.pathname}${window.location.hash}`);
+
+    window.location.href = `index.html#${previousLocation}`;
     return false;
   }
   api.loadUserContext();
@@ -40,7 +42,9 @@ function requireAuth() {
  */
 function requireAdmin() {
   if (!api.loadCredentials()) {
-    window.location.href = 'index.html';
+    const previousLocation = encodeURIComponent(`${window.location.pathname}${window.location.hash}`);
+
+    window.location.href = `index.html#${previousLocation}`;
     return false;
   }
   api.loadUserContext();


### PR DESCRIPTION
If an unauthenticated user tries to access a specific page (for example, a specific prefix in a bucket), they were redirected to the login page, and presented with either the dashboard or the explorer root after login.

This PR adds the page they tried to access before the login redirect to the URL hash on `index.html` and rediects to it after login.

On top of UX improvement, this adds the possibility to provide direct links to buckets or prefixes that work regardless of whether the user already has a "session" or not.