### PR TITLE
fix: docker entrypoint move VGW_ARGS before backend subcommand

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -32,7 +32,15 @@ case "$backend" in
         ;;
 esac
 
-set -- "$backend"
+# Global flags must precede the backend subcommand.
+if [ -n "${VGW_ARGS:-}" ]; then
+    # shellcheck disable=SC2086
+    set -- ${VGW_ARGS}
+else
+    set --
+fi
+
+set -- "$@" "$backend"
 
 if [ -n "${VGW_BACKEND_ARG:-}" ]; then
     set -- "$@" "$VGW_BACKEND_ARG"
@@ -41,11 +49,6 @@ fi
 if [ -n "${VGW_BACKEND_ARGS:-}" ]; then
     # shellcheck disable=SC2086
     set -- "$@" ${VGW_BACKEND_ARGS}
-fi
-
-if [ -n "${VGW_ARGS:-}" ]; then
-    # shellcheck disable=SC2086
-    set -- "$@" ${VGW_ARGS}
 fi
 
 exec "$BIN" "$@"


### PR DESCRIPTION
Global flags must appear before the backend subcommand in the versitygw CLI. Previously VGW_ARGS was appended after the backend, causing global flags to be silently ignored.

Reorder argument assembly to: VGW_ARGS <backend> VGW_BACKEND_ARG VGW_BACKEND_ARGS

Fixes #2082