### PR TITLE
test: disable mc client tests from test matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ Our multi-layered testing strategy includes:
 - **System Tests** - Protocol-level validation using industry-standard S3 clients:
   - AWS CLI - Official AWS command-line tools
   - s3cmd - Popular S3 client
-  - MinIO mc - Modern S3-compatible client
   - Direct REST API testing with curl for request/response validation
 - **Security Testing** - Both HTTP and HTTPS configurations tested. Vulnerability scanning with govulncheck. And regular dependency updates with dependabot.
 - **Compatibility Testing** - Multiple backends, versioning scenarios, static bucket modes, and various authentication methods.

--- a/tests/generate_matrix.sh
+++ b/tests/generate_matrix.sh
@@ -20,14 +20,35 @@ source ./tests/drivers/params.sh
 
 set -euo pipefail
 
+# Tests to exclude from the matrix (matched against file basename without extension)
+skip_list=(
+  "mc"
+  "mc_file_count"
+)
+
 files=()
 iam_types=()
 regions=()
 idx=0
 
+is_skipped() {
+  local basename="${1##*/}"
+  local name="${basename%.sh}"
+  name="${name#test_}"
+  for skip in "${skip_list[@]}"; do
+    if [[ "$name" == "$skip" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 check_for_and_load_test_file_and_params() {
   if ! check_param_count_v2 "file name" 1 $#; then
     exit 1
+  fi
+  if is_skipped "$1"; then
+    return 0
   fi
   if grep -q '@test' "$1"; then
     if [ $(( idx % 8 )) -eq 0 ]; then


### PR DESCRIPTION
The dl.min.io download site has been having stability issues possibly related to github action runners getting rate limited. Disable these for now until we can find a better place to host this client.