### PR TITLE
fix: POSIX support for prefix parts containing spaces

### DIFF
--- a/s3api/controllers/bucket-get.go
+++ b/s3api/controllers/bucket-get.go
@@ -15,6 +15,7 @@
 package controllers
 
 import (
+	"net/url"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -299,7 +300,7 @@ func (c S3ApiController) GetBucketPolicyStatus(ctx *fiber.Ctx) (*Response, error
 func (c S3ApiController) ListObjectVersions(ctx *fiber.Ctx) (*Response, error) {
 	// url values
 	bucket := ctx.Params("bucket")
-	prefix := ctx.Query("prefix")
+	prefix, _ := url.QueryUnescape(ctx.Query("prefix"))
 	delimiter := ctx.Query("delimiter")
 	maxkeysStr := ctx.Query("max-keys")
 	keyMarker := ctx.Query("key-marker")
@@ -451,7 +452,7 @@ func (c S3ApiController) GetBucketAcl(ctx *fiber.Ctx) (*Response, error) {
 func (c S3ApiController) ListMultipartUploads(ctx *fiber.Ctx) (*Response, error) {
 	// url values
 	bucket := ctx.Params("bucket")
-	prefix := ctx.Query("prefix")
+	prefix, _ := url.QueryUnescape(ctx.Query("prefix"))
 	delimiter := ctx.Query("delimiter")
 	keyMarker := ctx.Query("key-marker")
 	maxUploadsStr := ctx.Query("max-uploads")
@@ -508,7 +509,7 @@ func (c S3ApiController) ListMultipartUploads(ctx *fiber.Ctx) (*Response, error)
 func (c S3ApiController) ListObjectsV2(ctx *fiber.Ctx) (*Response, error) {
 	// url values
 	bucket := ctx.Params("bucket")
-	prefix := ctx.Query("prefix")
+	prefix, _ := url.QueryUnescape(ctx.Query("prefix"))
 	cToken := ctx.Query("continuation-token")
 	sAfter := ctx.Query("start-after")
 	delimiter := ctx.Query("delimiter")
@@ -583,7 +584,7 @@ func (c S3ApiController) ListObjectsV2(ctx *fiber.Ctx) (*Response, error) {
 func (c S3ApiController) ListObjects(ctx *fiber.Ctx) (*Response, error) {
 	// url values
 	bucket := ctx.Params("bucket")
-	prefix := ctx.Query("prefix")
+	prefix, _ := url.QueryUnescape(ctx.Query("prefix"))
 	marker := ctx.Query("marker")
 	delimiter := ctx.Query("delimiter")
 	maxkeysStr := ctx.Query("max-keys")

--- a/webui/web/explorer.html
+++ b/webui/web/explorer.html
@@ -1604,7 +1604,7 @@ under the License.
         objects = result.contents || [];
 
         // Filter out the current prefix itself (if it exists as an object)
-        objects = objects.filter(obj => obj.key !== currentPrefix);
+        objects = objects.filter(obj => obj.key !== decodeURIComponent(currentPrefix));
 
         // If versioning is enabled, fetch version counts for all objects
         objectVersionCounts = {};
@@ -2070,9 +2070,9 @@ under the License.
             </svg>
           `;
           if (isLast) {
-            html += `<span class="text-charcoal font-medium">${escapeHtml(part)}</span>`;
+            html += `<span class="text-charcoal font-medium">${escapeHtml(decodeURIComponent(part))}</span>`;
           } else {
-            html += `<button onclick="navigateToPrefix('${escapeHtml(path)}')" class="text-accent hover:text-accent-600">${escapeHtml(part)}</button>`;
+            html += `<button onclick="navigateToPrefix('${escapeHtml(path)}')" class="text-accent hover:text-accent-600">${escapeHtml(decodeURIComponent(part))}</button>`;
           }
         });
       }


### PR DESCRIPTION
Closes #2098.

This PR fixes invalid behavior when a prefix part contains spaces with the POSIX backend.

There was a mismatch between the encoding of the prefix in the query param (spaces encoded as `%20`) and lookups on the filesystem. It also fixes prefix display in the explorer breadcrumbs.

---

This PR is not done, there is still a weird behavior with those prefixes: "root" prefixes with spaces (but only those right under a bucket root) always contains a dummy object named after the prefix.

<img width="400" alt="image" src="https://github.com/user-attachments/assets/0f781542-4c2b-4de0-acec-5b8e8fec863a" />

I am not very familiar with the codebase yet and might need some help pinpointing where this is coming from.