### PR TITLE
fix: apply CORS middleware to admin CreateBucket route

### DIFF
--- a/s3api/admin-router.go
+++ b/s3api/admin-router.go
@@ -110,6 +110,7 @@ func (ar *S3AdminRouter) Init(app *fiber.App, be backend.Backend, iam auth.IAMSe
 		controllers.ProcessHandlers(ctrl.CreateBucket, metrics.ActionAdminListBuckets, services,
 			middlewares.VerifyV4Signature(root, iam, region, false, true, false),
 			middlewares.IsAdmin(metrics.ActionAdminCreateBucket),
+			middlewares.ApplyDefaultCORS(corsAllowOrigin),
 		))
 	app.Options("/:bucket/create",
 		middlewares.ApplyDefaultCORSPreflight(corsAllowOrigin),


### PR DESCRIPTION
## Summary

Adds the missing `middlewares.ApplyDefaultCORS(corsAllowOrigin)` to the `PATCH /:bucket/create` admin route handler chain. Every other admin PATCH route in `s3api/admin-router.go` already applies it; this one was overlooked when the endpoint was added in #1739.

The OPTIONS preflight handler for the same path already sets CORS headers, so preflight succeeds — but the actual `PATCH` response was returned without `Access-Control-Allow-Origin`, causing browsers to block it with `ERR_FAILED` even though the gateway returned `201 Created`. This breaks bucket creation from the WebUI when it is served from a different origin than the admin API.

Fixes #2105.

## Test plan

Manual reproduction with `--cors-allow-origin "https://example.com"` on `:7071`:

Before:
```
$ awscurl --service s3 -X PATCH -H "Origin: https://example.com" \
    -H "X-Vgw-Owner: admin" -i http://127.0.0.1:7071/mybucket/create
# response has no Access-Control-Allow-Origin / Vary / Access-Control-Expose-Headers
```

After:
```
$ awscurl --service s3 -X PATCH -H "Origin: https://example.com" \
    -H "X-Vgw-Owner: admin" -i http://127.0.0.1:7071/mybucket/create
# Access-Control-Allow-Origin: https://example.com
# Vary: Origin, Access-Control-Request-Headers, Access-Control-Request-Method
# Access-Control-Expose-Headers: ETag
```

Sibling routes (e.g. `/list-buckets`) behave identically before and after, confirming no regression.

- [x] Verified buggy build returns no CORS headers on `/:bucket/create`
- [x] Verified fixed build returns the same CORS headers as sibling admin PATCH routes
- [x] `go build ./s3api/...` clean

---
*Investigation and fix assisted by Claude (Anthropic).*