### PR TITLE
chore: fix sidecar flag in runtests to correctly pass test option

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -57,7 +57,7 @@ fi
 
 # run tests
 # full flow tests
-if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7070 full-flow --parallel $$SIDECAR_TEST_FLAG; then
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7070 full-flow --parallel $SIDECAR_TEST_FLAG; then
 	echo "full flow tests failed"
 	kill $GW_PID
 	exit 1
@@ -94,7 +94,7 @@ fi
 
 # run tests
 # full flow tests
-if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7071 full-flow --parallel $$SIDECAR_TEST_FLAG; then
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7071 full-flow --parallel $SIDECAR_TEST_FLAG; then
 	echo "full flow tests failed"
 	kill $GW_HTTPS_PID
 	exit 1
@@ -131,7 +131,7 @@ fi
 
 # run tests
 # full flow tests
-if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7072 full-flow -vs --parallel $$SIDECAR_TEST_FLAG; then
+if ! ./versitygw test -a user -s pass -e http://127.0.0.1:7072 full-flow -vs --parallel $SIDECAR_TEST_FLAG; then
 	echo "versioning-enabled full-flow tests failed"
 	kill $GW_VS_PID
 	exit 1
@@ -163,7 +163,7 @@ fi
 
 # run tests
 # full flow tests
-if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7073 full-flow -vs --parallel $$SIDECAR_TEST_FLAG; then
+if ! ./versitygw test --allow-insecure -a user -s pass -e https://127.0.0.1:7073 full-flow -vs --parallel $SIDECAR_TEST_FLAG; then
 	echo "versioning-enabled full-flow tests failed"
 	kill $GW_VS_HTTPS_PID
 	exit 1


### PR DESCRIPTION
There was a typo in the runtests script that was preventing passing the correct sidecar option to the tests.