### PR TITLE
feat: add bucket metrics tag when request specifies a bucket

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -131,6 +131,12 @@ func (m *manager) Send(ctx *fiber.Ctx, err error, action string, count int64, st
 		{Key: "action", Value: a.Name},
 	}
 
+	// add tag bucket=<bucketname> if the request specifies a bucket
+	bucket := ctx.Params("bucket")
+	if bucket != "" {
+		reqTags = append(reqTags, Tag{Key: "bucket", Value: bucket})
+	}
+
 	reqStatus := status
 
 	if err != nil {


### PR DESCRIPTION
If the incoming request specifies a bucket name, add a tag bucket=<bucketname> to the metric.

Fixes #2103