### PR TITLE
fix(azure): return error on nil part ETag in CompleteMultipartUpload

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1873,7 +1873,7 @@ func (az *Azure) CompleteMultipartUpload(ctx context.Context, input *s3.Complete
 			return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
 
-		if *part.ETag != *block.Name {
+		if part.ETag == nil || *part.ETag != *block.Name {
 			return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
 		// all parts except the last need to be greater, than


### PR DESCRIPTION
Closes #2120.

The Azure backend's `CompleteMultipartUpload` unconditionally dereferences `*part.ETag` when comparing against the uncommitted block name, panicking when a client submits a part entry without an `ETag` field (e.g. `{"PartNumber": 1}`). The posix backend at `backend/posix/posix.go:1957` already guards this with `parts[i].ETag == nil` and returns `ErrInvalidPart`; this aligns the Azure path with the same behavior so the gateway returns `InvalidPart` to the client instead of crashing.