### PR TITLE
fix(azure): return ErrInvalidPart on nil part ETag in CompleteMultipartUpload

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1854,12 +1854,16 @@ func (az *Azure) CompleteMultipartUpload(ctx context.Context, input *s3.Complete
 		}
 		partNumber = *part.PartNumber
 
+		if part.ETag == nil {
+			return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
+		}
+
 		block, ok := uncommittedBlocks[*part.PartNumber]
 		if !ok {
 			// Check if this is a tracked zero-byte part.
 			if zbPartsMap[*part.PartNumber] {
 				expectedETag := blockIDInt32ToBase64(*part.PartNumber)
-				if getString(part.ETag) != expectedETag {
+				if *part.ETag != expectedETag {
 					return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
 				}
 				// Non-last zero-byte parts violate the minimum part size.

--- a/tests/integration/CompleteMultipartUpload.go
+++ b/tests/integration/CompleteMultipartUpload.go
@@ -139,6 +139,52 @@ func CompleteMultipartUpload_invalid_ETag(s *S3Conf) error {
 		return nil
 	})
 }
+
+func CompleteMultipartUpload_nil_ETag(s *S3Conf) error {
+	testName := "CompleteMultipartUpload_nil_ETag"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		obj := "my-obj"
+		out, err := createMp(s3client, bucket, obj)
+		if err != nil {
+			return err
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		partNumber := int32(1)
+		_, err = s3client.UploadPart(ctx, &s3.UploadPartInput{
+			Bucket:     &bucket,
+			Key:        &obj,
+			UploadId:   out.UploadId,
+			PartNumber: &partNumber,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		// A part whose ETag is omitted (nil) must not crash the backend
+		// (regression: azure CompleteMultipartUpload previously panicked
+		// dereferencing a nil ETag pointer).
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+			Bucket:   &bucket,
+			Key:      &obj,
+			UploadId: out.UploadId,
+			MultipartUpload: &types.CompletedMultipartUpload{
+				Parts: []types.CompletedPart{
+					{
+						PartNumber: &partNumber,
+					},
+				},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrInvalidPart)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
 func CompleteMultipartUpload_invalid_checksum_type(s *S3Conf) error {
 	testName := "CompleteMultipartUpload_invalid_checksum_type"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -525,6 +525,7 @@ func TestCompleteMultipartUpload(ts *TestState) {
 	ts.Run(CompleteMultipartUpload_invalid_part_number)
 	ts.Run(CompleteMultipartUpload_default_content_type)
 	ts.Run(CompleteMultipartUpload_invalid_ETag)
+	ts.Run(CompleteMultipartUpload_nil_ETag)
 	ts.Run(CompleteMultipartUpload_small_upload_size)
 	ts.Run(CompleteMultipartUpload_empty_parts)
 	ts.Run(CompleteMultipartUpload_incorrect_parts_order)
@@ -965,6 +966,7 @@ func TestScoutfs(ts *TestState) {
 	ts.Run(CompleteMultipartUpload_incorrect_part_number)
 	ts.Run(CompleteMultipartUpload_invalid_part_number)
 	ts.Run(CompleteMultipartUpload_invalid_ETag)
+	ts.Run(CompleteMultipartUpload_nil_ETag)
 	ts.Run(CompleteMultipartUpload_small_upload_size)
 	ts.Run(CompleteMultipartUpload_empty_parts)
 	ts.Run(CompleteMultipartUpload_incorrect_parts_order)
@@ -1642,6 +1644,7 @@ func GetIntTests() IntTests {
 		"CompleteMultipartUpload_invalid_part_number":                              CompleteMultipartUpload_invalid_part_number,
 		"CompleteMultipartUpload_default_content_type":                             CompleteMultipartUpload_default_content_type,
 		"CompleteMultipartUpload_invalid_ETag":                                     CompleteMultipartUpload_invalid_ETag,
+		"CompleteMultipartUpload_nil_ETag":                                         CompleteMultipartUpload_nil_ETag,
 		"CompleteMultipartUpload_small_upload_size":                                CompleteMultipartUpload_small_upload_size,
 		"CompleteMultipartUpload_empty_parts":                                      CompleteMultipartUpload_empty_parts,
 		"CompleteMultipartUpload_incorrect_part_number":                            CompleteMultipartUpload_incorrect_part_number,


### PR DESCRIPTION
Closes #2120

When `CompleteMultipartUpload` is called against the Azure backend with one or more parts whose `ETag` field is nil (e.g. omitted from the request body), the gateway panics dereferencing the nil pointer at `*part.ETag`. The S3 client then sees an `InternalError` instead of a `MalformedXML` / `InvalidPart` response.

This adds an explicit nil check before either of the `*part.ETag` dereferences in the zero-byte-part and uncommitted-block branches, mirroring the posix backend's handling, and switches the existing zero-byte branch to use the now-checked pointer directly. The gateway returns `InvalidPart` instead of panicking.

A regression test `CompleteMultipartUpload_nil_ETag` is added alongside the existing `invalid_ETag` case and wired into both the standard and azure test groups.