### PR TITLE
fix(s3api): reject CompleteMultipartUpload parts missing ETag or PartNumber as MalformedXML

### DIFF
--- a/s3api/controllers/object-post.go
+++ b/s3api/controllers/object-post.go
@@ -308,6 +308,20 @@ func (c S3ApiController) CompleteMultipartUpload(ctx *fiber.Ctx) (*Response, err
 		}, s3err.GetAPIError(s3err.ErrMalformedXML)
 	}
 
+	// Both ETag and PartNumber are required per the CompleteMultipartUpload
+	// schema; treat a missing field as malformed XML to match S3 behaviour
+	// and to avoid passing nil pointers down to backends.
+	for _, part := range body.Parts {
+		if part.ETag == nil || part.PartNumber == nil {
+			debuglogger.Logf("missing ETag or PartNumber in complete multipart upload part")
+			return &Response{
+				MetaOpts: &MetaOptions{
+					BucketOwner: parsedAcl.Owner,
+				},
+			}, s3err.GetAPIError(s3err.ErrMalformedXML)
+		}
+	}
+
 	var mpuObjectSize *int64
 	if mpuObjSizeHdr != "" {
 		val, err := strconv.ParseInt(mpuObjSizeHdr, 10, 64)

--- a/tests/integration/CompleteMultipartUpload.go
+++ b/tests/integration/CompleteMultipartUpload.go
@@ -1624,6 +1624,83 @@ func CompleteMultipartUpload_invalid_part_number(s *S3Conf) error {
 	})
 }
 
+func CompleteMultipartUpload_missing_ETag(s *S3Conf) error {
+	testName := "CompleteMultipartUpload_missing_ETag"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		obj := "my-obj"
+		out, err := createMp(s3client, bucket, obj)
+		if err != nil {
+			return err
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		partNumber := int32(1)
+		_, err = s3client.UploadPart(ctx, &s3.UploadPartInput{
+			Bucket:     &bucket,
+			Key:        &obj,
+			UploadId:   out.UploadId,
+			PartNumber: &partNumber,
+		})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		// Missing ETag in a CompletedPart must be rejected as MalformedXML.
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+			Bucket:   &bucket,
+			Key:      &obj,
+			UploadId: out.UploadId,
+			MultipartUpload: &types.CompletedMultipartUpload{
+				Parts: []types.CompletedPart{
+					{
+						PartNumber: &partNumber,
+					},
+				},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedXML)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func CompleteMultipartUpload_missing_PartNumber(s *S3Conf) error {
+	testName := "CompleteMultipartUpload_missing_PartNumber"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		obj := "my-obj"
+		out, err := createMp(s3client, bucket, obj)
+		if err != nil {
+			return err
+		}
+
+		// Missing PartNumber in a CompletedPart must be rejected as MalformedXML.
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		_, err = s3client.CompleteMultipartUpload(ctx, &s3.CompleteMultipartUploadInput{
+			Bucket:   &bucket,
+			Key:      &obj,
+			UploadId: out.UploadId,
+			MultipartUpload: &types.CompletedMultipartUpload{
+				Parts: []types.CompletedPart{
+					{
+						ETag: getPtr("e868e0f4719e394144ef36531ee6824c"),
+					},
+				},
+			},
+		})
+		cancel()
+		if err := checkApiErr(err, s3err.GetAPIError(s3err.ErrMalformedXML)); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
 func CompleteMultipartUpload_default_content_type(s *S3Conf) error {
 	testName := "CompleteMultipartUpload_default_content_type"
 	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -525,6 +525,8 @@ func TestCompleteMultipartUpload(ts *TestState) {
 	ts.Run(CompleteMultipartUpload_invalid_part_number)
 	ts.Run(CompleteMultipartUpload_default_content_type)
 	ts.Run(CompleteMultipartUpload_invalid_ETag)
+	ts.Run(CompleteMultipartUpload_missing_ETag)
+	ts.Run(CompleteMultipartUpload_missing_PartNumber)
 	ts.Run(CompleteMultipartUpload_small_upload_size)
 	ts.Run(CompleteMultipartUpload_empty_parts)
 	ts.Run(CompleteMultipartUpload_incorrect_parts_order)
@@ -965,6 +967,8 @@ func TestScoutfs(ts *TestState) {
 	ts.Run(CompleteMultipartUpload_incorrect_part_number)
 	ts.Run(CompleteMultipartUpload_invalid_part_number)
 	ts.Run(CompleteMultipartUpload_invalid_ETag)
+	ts.Run(CompleteMultipartUpload_missing_ETag)
+	ts.Run(CompleteMultipartUpload_missing_PartNumber)
 	ts.Run(CompleteMultipartUpload_small_upload_size)
 	ts.Run(CompleteMultipartUpload_empty_parts)
 	ts.Run(CompleteMultipartUpload_incorrect_parts_order)
@@ -1642,6 +1646,8 @@ func GetIntTests() IntTests {
 		"CompleteMultipartUpload_invalid_part_number":                              CompleteMultipartUpload_invalid_part_number,
 		"CompleteMultipartUpload_default_content_type":                             CompleteMultipartUpload_default_content_type,
 		"CompleteMultipartUpload_invalid_ETag":                                     CompleteMultipartUpload_invalid_ETag,
+		"CompleteMultipartUpload_missing_ETag":                                     CompleteMultipartUpload_missing_ETag,
+		"CompleteMultipartUpload_missing_PartNumber":                               CompleteMultipartUpload_missing_PartNumber,
 		"CompleteMultipartUpload_small_upload_size":                                CompleteMultipartUpload_small_upload_size,
 		"CompleteMultipartUpload_empty_parts":                                      CompleteMultipartUpload_empty_parts,
 		"CompleteMultipartUpload_incorrect_part_number":                            CompleteMultipartUpload_incorrect_part_number,


### PR DESCRIPTION
Closes #2111

The S3 `CompleteMultipartUpload` schema requires each `Part` element to carry both an `ETag` and a `PartNumber`. AWS S3 rejects a request that omits either field with `MalformedXML`; versitygw currently accepts the request, passes the partially-populated `CompletedPart` to the backend, and either returns the wrong `InvalidPart` error or — in the case of the azure backend — panics on the nil pointer (also tracked in #2120).

This adds an explicit validation pass in the controller, right after the XML body is unmarshalled, that returns `MalformedXML` if any part is missing `ETag` or `PartNumber`. Two regression tests (`missing_ETag` and `missing_PartNumber`) are added and wired into both the standard and azure test groups.