### PR TITLE
fix(azure): avoid nil pointer panic on CompleteMultipartUpload part with empty ETag

### DIFF
--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -1873,7 +1873,7 @@ func (az *Azure) CompleteMultipartUpload(ctx context.Context, input *s3.Complete
 			return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
 
-		if *part.ETag != *block.Name {
+		if getString(part.ETag) != backend.GetStringFromPtr(block.Name) {
 			return res, "", s3err.GetAPIError(s3err.ErrInvalidPart)
 		}
 		// all parts except the last need to be greater, than


### PR DESCRIPTION
Fixes #2120

`CompleteMultipartUpload` on the Azure backend dereferenced `part.ETag` directly (`*part.ETag != *block.Name`). When a request body part has an empty/missing `<ETag>` element, `part.ETag` is nil and the gateway panics, returning `InternalError` to the client.

This mirrors the existing zero-byte-part branch, which already uses the nil-safe `getString(part.ETag)`. The mismatched ETag now correctly returns `InvalidPart` instead of crashing. Also guards `block.Name` via `backend.GetStringFromPtr`.

### Test plan
- `go build ./backend/azure/` passes.
- Reproducer from the issue (`create-multipart-upload` then `complete-multipart-upload` with a part missing `ETag`) now returns `InvalidPart` instead of a 500 panic.
