### PR TITLE
fix: decode URL hash in webui before parsing bucket/prefix

### DIFF
--- a/webui/web/explorer.html
+++ b/webui/web/explorer.html
@@ -1156,7 +1156,9 @@ under the License.
 
     async function init() {
       // Check URL hash for bucket/prefix
-      const hash = window.location.hash.slice(1);
+      // decodeURIComponent is needed because browsers percent-encode characters
+      // like spaces when storing the hash
+      const hash = decodeURIComponent(window.location.hash.slice(1));
       if (hash) {
         const parts = hash.split('/');
         const bucketName = parts[0];


### PR DESCRIPTION
window.location.hash returns the hash percent-encoded by the browser, so a prefix like "X Y/" is read back as "X%20Y/" (literal %20). Without decoding, all subsequent operations (list, upload, create folder) used the encoded string, causing the server to look for a directory named "X%20Y/" instead of "X Y/" — resulting in empty listings and uploads landing in a newly created "X%20Y/" directory.

Fix by calling decodeURIComponent() on the hash before splitting into bucket and prefix parts.

Fixes #2098