### PR TITLE
fix: prevent panic in ParseCopySource on empty input

### DIFF
--- a/backend/common.go
+++ b/backend/common.go
@@ -230,6 +230,10 @@ func ParseCopySourceRange(size int64, acceptRange string) (int64, int64, error) 
 // ParseCopySource parses x-amz-copy-source header and returns source bucket,
 // source object, versionId, error respectively
 func ParseCopySource(copySourceHeader string) (string, string, string, error) {
+	if copySourceHeader == "" {
+		return "", "", "", s3err.GetInvalidArgumentErr(s3err.InvalidArgCopySourceBucket, copySourceHeader)
+	}
+
 	if copySourceHeader[0] == '/' {
 		copySourceHeader = copySourceHeader[1:]
 	}

--- a/backend/common_test.go
+++ b/backend/common_test.go
@@ -224,6 +224,15 @@ func TestParseCopySource(t *testing.T) {
 			wantErrValue:     s3err.GetInvalidArgumentErr(s3err.InvalidArgCopySourceEncoding, "mybucket/object%ZZ"),
 		},
 		{
+			name:             "empty string",
+			copySourceHeader: "",
+			wantBucket:       "",
+			wantObject:       "",
+			wantVersionId:    "",
+			wantErr:          true,
+			wantErrValue:     s3err.GetInvalidArgumentErr(s3err.InvalidArgCopySourceBucket, ""),
+		},
+		{
 			name:             "missing object",
 			copySourceHeader: "mybucket",
 			wantBucket:       "",


### PR DESCRIPTION
## Summary

`ParseCopySource` indexes into `copySourceHeader[0]` without checking
for an empty string, causing an index-out-of-range panic. All three backend
callers (azure, posix x2) pass the `x-amz-copy-source` header value
directly, so a malformed or missing header can propagate an empty string
and crash the gateway.

## Fix

Add an empty-string guard at the top of `ParseCopySource` that returns
an `InvalidArgCopySourceBucket` error, consistent with the existing
error returned when the source path has no bucket/object separator.

## Testing

- Added a table-driven test case that reproduces the panic without the
  fix and verifies the correct error with the fix.
- All 15 `TestParseCopySource` cases pass (14 existing + 1 new).
- `go vet ./backend/` and `go build ./backend/...` clean.