### PR TITLE
fix: prevent nil pointer panic in webhook sendLog

### DIFF
--- a/s3log/webhook.go
+++ b/s3log/webhook.go
@@ -131,11 +131,13 @@ func (wl *WebhookLogger) sendLog(lf LogFields) {
 	jsonLog, err := json.Marshal(lf)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to parse the log data: %v\n", err.Error())
+		return
 	}
 
 	req, err := http.NewRequest(http.MethodPost, wl.url, bytes.NewReader(jsonLog))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
+		return
 	}
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 

--- a/s3log/webhook_test.go
+++ b/s3log/webhook_test.go
@@ -1,0 +1,24 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package s3log
+
+import "testing"
+
+func TestSendLog_InvalidURL_NoPanic(t *testing.T) {
+	wl := &WebhookLogger{url: "://invalid"}
+	// sendLog must not panic when http.NewRequest fails due to
+	// an invalid URL. Before the fix, the nil req was dereferenced.
+	wl.sendLog(LogFields{})
+}


### PR DESCRIPTION
## Summary

Add missing `return` statements after error checks in `WebhookLogger.sendLog`, preventing a nil pointer panic when `http.NewRequest` fails.

## Problem

In `s3log/webhook.go`, the `sendLog` method checks errors from `json.Marshal` and `http.NewRequest` but does not return after logging them. When `http.NewRequest` fails (e.g., due to a malformed URL), `req` is nil and line 140 dereferences it with `req.Header.Set(...)`, crashing the server with a nil pointer panic.

**Call chain:** `WebhookLogger.Log` -> `sendLog` -> nil `req` dereference at `req.Header.Set`.

**Trigger condition:** Any invalid or unreachable webhook URL that causes `http.NewRequest` to return an error. While `InitWebhookLogger` validates the URL at startup, `sendLog` constructs a new request per log entry. The `sendLog` error path was never guarded.

**Observable failure:**
```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine N [running]:
github.com/versity/versitygw/s3log.(*WebhookLogger).sendLog(...)
    s3log/webhook.go:140
```

This bug was introduced in PR #129 (2023-07-14) and has been present for nearly 3 years.

## Changes

| File | Change |
|------|--------|
| `s3log/webhook.go` | Added `return` after both error checks in `sendLog` |
| `s3log/webhook_test.go` | Added regression test confirming no panic on invalid URL |

## Validation

Red-green verification:
- **Red step (without fix):** `panic: runtime error: invalid memory address or nil pointer dereference` at `webhook.go:140`
- **Green step (with fix):** `PASS`
