### PR TITLE
fix: prevent index-out-of-range panic in s3proxy GetBucketOwnershipControls

### DIFF
--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -258,6 +258,9 @@ func (s *S3Proxy) GetBucketOwnershipControls(ctx context.Context, bucket string)
 	if err != nil {
 		return ownship, handleError(err)
 	}
+	if resp.OwnershipControls == nil || len(resp.OwnershipControls.Rules) == 0 {
+		return ownship, s3err.GetBucketErr(s3err.ErrOwnershipControlsNotFound, bucket)
+	}
 	return resp.OwnershipControls.Rules[0].ObjectOwnership, nil
 }
 func (s *S3Proxy) DeleteBucketOwnershipControls(ctx context.Context, bucket string) error {


### PR DESCRIPTION
## Summary

Prevent an index-out-of-range panic in the s3proxy backend's `GetBucketOwnershipControls` method.

## Problem

When the upstream S3 backend returns a response with nil `OwnershipControls` or an empty `Rules` slice, the server panics at `backend/s3proxy/s3.go:261`:

```
resp.OwnershipControls.Rules[0].ObjectOwnership
```

**Call chain:** `S3ApiController.GetBucketOwnershipControls` (bucket-get.go:107) calls `S3Proxy.GetBucketOwnershipControls` (s3.go:250), which indexes into the response without any guard.

**Trigger:** An upstream S3-compatible backend that has no ownership controls configured for a bucket returns a valid (non-error) response with nil or empty `OwnershipControls.Rules`.

**Observable failure:** The gateway crashes with a runtime panic, terminating the request and potentially the process.

## Change

Add nil and length checks before accessing `Rules[0]`. If the response has nil `OwnershipControls` or empty `Rules`, return `OwnershipControlsNotFoundError` (HTTP 404). This matches the behavior of the posix backend (posix.go:708) and the azure backend (azure.go:340).

## Bug origin

Introduced in commit 7545e623 (2024-06-28, PR #659) when bucket ownership controls were first implemented. Present for nearly 2 years.

## Related

- PR #2154 fixed a similar empty-rules panic in the PUT handler (controller layer); this fix covers the GET path (backend layer)
- PR #2170 and PR #2173 fixed the same class of nil/bounds-check panics in other code paths
