### PR TITLE
feat(helm): Make it possible to specify deployment strategy

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: versitygw
 description: A Helm chart for deploying the Versity S3 Gateway on Kubernetes
 type: application
-version: 0.3.1
+version: 0.3.2
 sources:
   - https://github.com/versity/versitygw
 icon: https://raw.githubusercontent.com/versity/versitygw/main/webui/web/assets/images/Versity-logo-blue-horizontal.png

--- a/chart/README.md
+++ b/chart/README.md
@@ -105,6 +105,12 @@ When scaling `versitygw` horizontally by setting `replicaCount` greater than 1, 
     - Using **ReadWriteMany (RWX)**: Replicas can be distributed across **multiple nodes** in the cluster. This is the recommended approach for true horizontal scaling and high availability. When using RWX, it is also recommended to use pod anti-affinity (via `affinity` in `values.yaml`) to ensure pods are distributed across nodes/zones.
 - **Stateless Backends (S3, Azure)**: If you are using a stateless storage backend (e.g. proxying to another S3 store) **and** you are either not using IAM or using an external IAM provider (e.g. LDAP, Vault), persistence can be safely disabled by setting `persistence.enabled=false`.
 
+### Deployment Strategy
+
+By default, the `RollingUpdate` [strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) is used.
+If **ReadWriteOnce (RWO)** volumes are used and pods may be scheduled onto different nodes, rollouts may become 
+stuck because the replacement pod cannot start. Consider setting `strategy.type=Recreate` in this case.
+
 ## Configuration
 
 See [`values.yaml`](./values.yaml) for the full list of parameters and their defaults.

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
   selector:
     matchLabels:
       {{- include "versitygw.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,11 @@ fullnameOverride: ""
 # you can only increase the number of replicas if you have a "ReadWriteMany" volume!
 replicaCount: 1
 
+# Specifies the strategy used to replace old Pods by new ones. strategy.type can be
+# "Recreate" or "RollingUpdate". "RollingUpdate" is the default value.
+# Using "Recreate" is often useful when using a "ReadWriteOnce" volume.
+strategy: {}
+
 # This section defines which image to use and how to pull it.
 # Find all available tags / releases at: https://github.com/versity/versitygw/pkgs/container/versitygw
 image:


### PR DESCRIPTION
This adds support to specify [Deployment Strategy](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy) inside the helm chart.