### PR TITLE
fix: add timeout to FreeIPA http.Client to prevent server-side hangs

### DIFF
--- a/auth/iam_ipa.go
+++ b/auth/iam_ipa.go
@@ -76,7 +76,7 @@ func NewIpaIAMService(rootAcc Account, host, vaultName, username, password strin
 		TLSClientConfig: mTLSConfig,
 		Proxy:           http.ProxyFromEnvironment,
 	}
-	ipa.client = http.Client{Jar: jar, Transport: tr}
+	ipa.client = http.Client{Jar: jar, Transport: tr, Timeout: 30 * time.Second}
 
 	err = ipa.login()
 	if err != nil {


### PR DESCRIPTION
## Problem

The IPA IAM `http.Client` at `auth/iam_ipa.go:79` has no `Timeout` configured. If the FreeIPA server becomes unresponsive (accepts the TCP connection but never sends a response), every goroutine servicing an S3 request that requires IPA authentication hangs indefinitely in `ipa.client.Do()`.

Since `login()` is called before every `rpc()` call (line 298), and each authenticated S3 request flows through `rpc()`, an unresponsive FreeIPA server can exhaust all available goroutines over time.

The existing retry logic (`requestRetries = 3`) and `isRetryable()` already handle `net.Error` timeouts correctly (line 388), but without a `Timeout` on the client, timeout errors never fire for silently unresponsive servers. The retries only help with connection resets and EOF.

## Fix

Add `Timeout: 30 * time.Second` to the `http.Client`, consistent with how other clients in the codebase are configured:

- `s3log/webhook.go:46`: `Timeout: 3 * time.Second`
- `s3event/webhook.go:68`: `Timeout: 3 * time.Second`

30 seconds is appropriate for IPA RPC calls (which involve vault access and crypto operations) vs 1-3 seconds for fire-and-forget webhooks.

## Origin

Introduced in #1005 (`ee315276`, 2025-01-09). PR #1377 later added retry logic for IPA requests but did not add a client timeout.

## Related

- Kubernetes [#100959](https://github.com/kubernetes/kubernetes/pull/100959): added auth token review request timeout for the same class of server-side hang