### PR TITLE
fix: include policy-accessible buckets in ListBuckets

### DIFF
--- a/auth/bucket_policy.go
+++ b/auth/bucket_policy.go
@@ -250,6 +250,16 @@ func ValidatePolicyDocument(policyBin []byte, bucket string, iam IAMService) err
 	return nil
 }
 
+// PolicyGrantsListBucket reports whether the bucket policy grants the account
+// s3:ListBucket permission on the bucket. Returns false for an empty or
+// unparseable policy, or when access is denied (fail-closed).
+func PolicyGrantsListBucket(policy []byte, access, bucket string) bool {
+	if len(policy) == 0 {
+		return false
+	}
+	return VerifyBucketPolicy(policy, access, bucket, "", nil, ListBucketAction) == nil
+}
+
 func VerifyBucketPolicy(policy []byte, access, bucket, object string, normalizeObjectKey objectKeyNormalizer, actions ...Action) error {
 	if len(actions) == 0 {
 		return s3err.GetAPIError(s3err.ErrAccessDenied)

--- a/auth/bucket_policy_listbucket_test.go
+++ b/auth/bucket_policy_listbucket_test.go
@@ -1,0 +1,133 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicyGrantsListBucket(t *testing.T) {
+	const bucket = "my-bucket"
+	const account = "alice"
+
+	// policyStmt builds a single-statement bucket policy JSON document.
+	policyStmt := func(effect, principal, action, resource string) []byte {
+		return []byte(fmt.Sprintf(`{
+			"Version": "2012-10-17",
+			"Statement": [{
+				"Effect": "%s",
+				"Principal": %s,
+				"Action": %s,
+				"Resource": %s
+			}]
+		}`, effect, principal, action, resource))
+	}
+
+	// multiStmt builds a two-statement policy (e.g. Allow + Deny).
+	multiStmt := func(stmts ...string) []byte {
+		stmtsJSON := ""
+		for i, s := range stmts {
+			if i > 0 {
+				stmtsJSON += ","
+			}
+			stmtsJSON += s
+		}
+		return []byte(fmt.Sprintf(`{
+			"Version": "2012-10-17",
+			"Statement": [%s]
+		}`, stmtsJSON))
+	}
+
+	stmt := func(effect, principal, action, resource string) string {
+		return fmt.Sprintf(`{
+			"Effect": "%s",
+			"Principal": %s,
+			"Action": %s,
+			"Resource": %s
+		}`, effect, principal, action, resource)
+	}
+
+	bucketARN := fmt.Sprintf(`"arn:aws:s3:::%s"`, bucket)
+	bucketObjARN := fmt.Sprintf(`"arn:aws:s3:::%s/*"`, bucket)
+
+	tests := []struct {
+		name   string
+		policy []byte
+		want   bool
+	}{
+		{
+			name:   "nil policy",
+			policy: nil,
+			want:   false,
+		},
+		{
+			name:   "empty policy",
+			policy: []byte{},
+			want:   false,
+		},
+		{
+			name:   "grants ListBucket to account",
+			policy: policyStmt("Allow", `["alice"]`, `["s3:ListBucket"]`, fmt.Sprintf(`[%s, %s]`, bucketARN, bucketObjARN)),
+			want:   true,
+		},
+		{
+			name:   "grants ListBucket to different account",
+			policy: policyStmt("Allow", `["bob"]`, `["s3:ListBucket"]`, fmt.Sprintf(`[%s, %s]`, bucketARN, bucketObjARN)),
+			want:   false,
+		},
+		{
+			name:   "grants only GetObject not ListBucket",
+			policy: policyStmt("Allow", `["alice"]`, `["s3:GetObject"]`, fmt.Sprintf(`[%s, %s]`, bucketARN, bucketObjARN)),
+			want:   false,
+		},
+		{
+			name:   "grants s3 wildcard action",
+			policy: policyStmt("Allow", `["alice"]`, `["s3:*"]`, fmt.Sprintf(`[%s, %s]`, bucketARN, bucketObjARN)),
+			want:   true,
+		},
+		{
+			name:   "public principal grants ListBucket",
+			policy: policyStmt("Allow", `"*"`, `["s3:ListBucket"]`, bucketARN),
+			want:   true,
+		},
+		{
+			name: "explicit deny overrides allow",
+			policy: multiStmt(
+				stmt("Allow", `["alice"]`, `["s3:ListBucket"]`, bucketARN),
+				stmt("Deny", `["alice"]`, `["s3:ListBucket"]`, bucketARN),
+			),
+			want: false,
+		},
+		{
+			name:   "resource mismatch (different bucket)",
+			policy: policyStmt("Allow", `["alice"]`, `["s3:ListBucket"]`, `"arn:aws:s3:::other-bucket"`),
+			want:   false,
+		},
+		{
+			name:   "malformed policy JSON",
+			policy: []byte(`{not valid json`),
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := PolicyGrantsListBucket(tt.policy, account, bucket)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/backend/azure/azure.go
+++ b/backend/azure/azure.go
@@ -289,6 +289,16 @@ outer:
 						// TODO: using modification date here instead of creation, is that ok?
 						CreationDate: *v.Properties.LastModified,
 					})
+				} else {
+					// not the owner — check if the bucket policy grants s3:ListBucket.
+					policy, perr := az.getContainerMetaData(ctx, *v.Name, string(keyPolicy))
+					if perr == nil && auth.PolicyGrantsListBucket(policy, input.Owner, *v.Name) {
+						buckets = append(buckets, s3response.ListAllMyBucketsEntry{
+							Name: *v.Name,
+							// TODO: using modification date here instead of creation, is that ok?
+							CreationDate: *v.Properties.LastModified,
+						})
+					}
 				}
 			}
 		}

--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -443,6 +443,18 @@ func (p *Posix) ListBuckets(ctx context.Context, input s3response.ListBucketsInp
 				Name:         fi.Name(),
 				CreationDate: fi.ModTime(),
 			})
+			continue
+		}
+
+		// not the owner — check if the bucket policy grants s3:ListBucket.
+		// Policy retrieval errors are tolerated (fail-closed) so a corrupted
+		// policy attribute on one bucket doesn't break listing for everyone.
+		policy, perr := p.meta.RetrieveAttribute(nil, fi.Name(), "", policykey)
+		if perr == nil && auth.PolicyGrantsListBucket(policy, input.Owner, fi.Name()) {
+			buckets = append(buckets, s3response.ListAllMyBucketsEntry{
+				Name:         fi.Name(),
+				CreationDate: fi.ModTime(),
+			})
 		}
 	}
 

--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -140,6 +140,16 @@ func (s *S3Proxy) ListBuckets(ctx context.Context, input s3response.ListBucketsI
 				Name:         *b.Name,
 				CreationDate: *b.CreationDate,
 			})
+			continue
+		}
+
+		// not the owner — check if the bucket policy grants s3:ListBucket.
+		policy, perr := s.getMetaBucketObjData(ctx, *b.Name, metaPrefixPolicy, false)
+		if perr == nil && auth.PolicyGrantsListBucket(policy, input.Owner, *b.Name) {
+			buckets = append(buckets, s3response.ListAllMyBucketsEntry{
+				Name:         *b.Name,
+				CreationDate: *b.CreationDate,
+			})
 		}
 	}
 

--- a/tests/integration/ListBuckets.go
+++ b/tests/integration/ListBuckets.go
@@ -433,3 +433,64 @@ func ListBuckets_success(s *S3Conf) error {
 		return nil
 	})
 }
+
+func ListBuckets_with_bucket_policy(s *S3Conf) error {
+	testName := "ListBuckets_with_bucket_policy"
+	return actionHandler(s, testName, func(s3client *s3.Client, bucket string) error {
+		testuser := getUser("user")
+
+		err := createUsers(s, []user{testuser})
+		if err != nil {
+			return err
+		}
+
+		userClient := s.getUserClient(testuser)
+
+		// Before the policy, the user should not see the bucket.
+		ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
+		out, err := userClient.ListBuckets(ctx, &s3.ListBucketsInput{})
+		cancel()
+		if err != nil {
+			return err
+		}
+		for _, b := range out.Buckets {
+			if *b.Name == bucket {
+				return fmt.Errorf("bucket %v should not be visible to user %v before policy is set",
+					bucket, testuser.access)
+			}
+		}
+
+		// Grant the test user s3:ListBucket on the bucket via bucket policy.
+		policy := genPolicyDoc("Allow",
+			fmt.Sprintf(`["%s"]`, testuser.access),
+			`["s3:ListBucket"]`,
+			fmt.Sprintf(`"arn:aws:s3:::%s"`, bucket))
+
+		err = putBucketPolicy(s3client, bucket, policy)
+		if err != nil {
+			return err
+		}
+
+		// After the policy, the user should see the bucket.
+		ctx, cancel = context.WithTimeout(context.Background(), shortTimeout)
+		out, err = userClient.ListBuckets(ctx, &s3.ListBucketsInput{})
+		cancel()
+		if err != nil {
+			return err
+		}
+
+		found := false
+		for _, b := range out.Buckets {
+			if *b.Name == bucket {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("expected bucket %v in ListBuckets result for user %v after policy, but it was not found",
+				bucket, testuser.access)
+		}
+
+		return nil
+	})
+}

--- a/tests/integration/group-tests.go
+++ b/tests/integration/group-tests.go
@@ -109,6 +109,7 @@ func TestListBuckets(ts *TestState) {
 	ts.Sync(ListBuckets_truncated)
 	ts.Sync(ListBuckets_success)
 	ts.Sync(ListBuckets_empty_success)
+	ts.Sync(ListBuckets_with_bucket_policy)
 }
 
 func TestDeleteBucket(ts *TestState) {
@@ -1456,6 +1457,7 @@ func GetIntTests() IntTests {
 		"ListBuckets_truncated":                                                    ListBuckets_truncated,
 		"ListBuckets_success":                                                      ListBuckets_success,
 		"ListBuckets_empty_success":                                                ListBuckets_empty_success,
+		"ListBuckets_with_bucket_policy":                                           ListBuckets_with_bucket_policy,
 		"DeleteBucket_non_existing_bucket":                                         DeleteBucket_non_existing_bucket,
 		"DeleteBucket_non_empty_bucket":                                            DeleteBucket_non_empty_bucket,
 		"DeleteBucket_incorrect_expected_bucket_owner":                             DeleteBucket_incorrect_expected_bucket_owner,


### PR DESCRIPTION
## Summary

`ListBuckets` (S3 `GET /`) only returned buckets the requesting account owns. Buckets accessible via a bucket policy granting `s3:ListBucket` were invisible to non-owner users, breaking the WebUI Explorer and any S3 client relying on `ListBuckets` for discovery.

Fixes #2219.

## Changes

- **New shared helper** `auth.PolicyGrantsListBucket(policy, access, bucket) bool` — returns true if the bucket policy grants the account `s3:ListBucket` on the bucket. Fail-closed: empty/unparseable/denied policies return false.
- **posix** `ListBuckets` — after the ownership check fails, lazily fetches the bucket policy (`policykey` attribute) and includes the bucket if the policy grants `s3:ListBucket`.
- **s3proxy** `ListBuckets` — same pattern via `getMetaBucketObjData(metaPrefixPolicy)`.
- **azure** `ListBuckets` — same pattern via `getContainerMetaData(keyPolicy)`.

## Design notes

- **Lazy fetch**: the policy attribute is only read when `acl.Owner != account`, so the common case (user lists their own buckets) has no extra I/O.
- **Fail-closed on policy errors**: a corrupted/unreadable policy attribute on one bucket is silently skipped rather than aborting the entire `ListBuckets` response. ACL parse errors still abort (preserving prior behavior). This asymmetry is intentional — the policy read is new, and one bad bucket should not break listing for everyone.
- **No-ACL buckets**: preserved prior behavior (skipped). The policy fallback only triggers when an ACL exists but the owner differs.
- **Admin/root path**: unchanged — admins see all buckets.
- **Deny overrides Allow**: handled by the existing `isAllowed` logic in `VerifyBucketPolicy`.
- **Public principal** (`"Principal": "*"`): a bucket with a public `s3:ListBucket` policy will now appear in every user's `ListBuckets` output. This is consistent with the issue's stated intent and AWS S3 behavior.

## Testing

- **Unit tests** (`auth/bucket_policy_listbucket_test.go`): 10 table-driven cases for `PolicyGrantsListBucket` — nil/empty policy, grants to account, grants to different account, GetObject-only, `s3:*` wildcard, public principal, explicit Deny overrides Allow, resource mismatch, malformed JSON.
- **Integration test** (`tests/integration/ListBuckets.go`): `ListBuckets_with_bucket_policy` — creates a user, verifies the bucket is NOT visible before the policy, applies a bucket policy granting `s3:ListBucket`, verifies the bucket IS visible after. Registered in `group-tests.go`.
- All 7 existing `ListBuckets` integration tests pass with no regressions (verified locally against a posix backend).
- `go build`, `go vet`, and `go test ./auth/...` all pass.