### PR TITLE
feat: add chart sidecar and versioning directory support

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: versitygw
 description: A Helm chart for deploying the Versity S3 Gateway on Kubernetes
 type: application
-version: 0.3.3
+version: 0.3.4
 sources:
   - https://github.com/versity/versitygw
 icon: https://raw.githubusercontent.com/versity/versitygw/main/webui/web/assets/images/Versity-logo-blue-horizontal.png

--- a/chart/README.md
+++ b/chart/README.md
@@ -63,7 +63,7 @@ You can find the list of available Helm chart versions in the [GitHub packages p
 
 ## Backend Storage
 
-The `gateway.backend.type` value selects the storage backend. Use `gateway.backend.args` to pass backend-specific arguments.
+The `gateway.backend.type` value selects the storage backend. Use `gateway.backend.args` to pass backend-specific arguments. For the POSIX sidecar metadata store and POSIX/ScoutFS object versioning, prefer `gateway.backend.sidecarDir` and `gateway.backend.versioningDir`; the chart mounts those directories from persistent storage and wires the corresponding backend environment variables automatically.
 
 | Backend | Description | Example `gateway.backend.args` |
 |---------|-------------|--------------------------------|
@@ -72,6 +72,26 @@ The `gateway.backend.type` value selects the storage backend. Use `gateway.backe
 | [s3](https://github.com/versity/versitygw/wiki/S3-Backend) | Proxy to an existing S3-compatible object store | `--access KEY --secret SECRET --endpoint https://s3.example.com` |
 | [azure](https://github.com/versity/versitygw/wiki/AzureBlob-Backend) | Azure Blob Storage | `--account myaccount --key mykey` |
 | [plugin](https://github.com/versity/versitygw/wiki/Plugin-Backend) | Custom backend via shared library plugin | `/path/to/plugin.so` |
+
+Example for POSIX with sidecar metadata:
+
+```yaml
+gateway:
+  backend:
+    type: posix
+    args: /mnt/data
+    sidecarDir: /mnt/metadata
+```
+
+Example for POSIX or ScoutFS with object versioning enabled:
+
+```yaml
+gateway:
+  backend:
+    type: posix
+    args: /mnt/data
+    versioningDir: /mnt/versioning
+```
 
 ## Optional Features
 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -13,6 +13,12 @@
 {{- if and .Values.persistence.create .Values.persistence.hostPath }}
   {{- fail "persistence.create must be false for persistence.hostPath can be set" }}
 {{- end }}
+{{- if and .Values.gateway.backend.sidecarDir (ne .Values.gateway.backend.type "posix") }}
+  {{- fail "gateway.backend.sidecarDir is only supported with the posix backend" }}
+{{- end }}
+{{- if and .Values.gateway.backend.versioningDir (not (or (eq .Values.gateway.backend.type "posix") (eq .Values.gateway.backend.type "scoutfs"))) }}
+  {{- fail "gateway.backend.versioningDir is only supported with the posix and scoutfs backends" }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -61,6 +67,14 @@ spec:
               value: {{ .Values.gateway.backend.type | quote }}
             - name: VGW_BACKEND_ARGS
               value: {{ .Values.gateway.backend.args | quote }}
+            {{- if .Values.gateway.backend.sidecarDir }}
+            - name: VGW_META_SIDECAR
+              value: {{ .Values.gateway.backend.sidecarDir | quote }}
+            {{- end }}
+            {{- if .Values.gateway.backend.versioningDir }}
+            - name: VGW_VERSIONING_DIR
+              value: {{ .Values.gateway.backend.versioningDir | quote }}
+            {{- end }}
             # Root credentials — sourced from a Kubernetes Secret
             - name: ROOT_ACCESS_KEY_ID
               valueFrom:
@@ -209,6 +223,18 @@ spec:
               mountPath: /mnt/data
               subPath: data
               readOnly: false
+            {{- if .Values.gateway.backend.sidecarDir }}
+            - name: data
+              mountPath: {{ .Values.gateway.backend.sidecarDir }}
+              subPath: metadata
+              readOnly: false
+            {{- end }}
+            {{- if .Values.gateway.backend.versioningDir }}
+            - name: data
+              mountPath: {{ .Values.gateway.backend.versioningDir }}
+              subPath: versioning
+              readOnly: false
+            {{- end }}
             - name: data
               mountPath: /mnt/iam
               subPath: iam

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -133,10 +133,20 @@ gateway:
     type: posix
     # Additional arguments passed to the backend
     args: "/mnt/data"
+    # Optional directory for POSIX sidecar metadata storage. When set, the chart
+    # mounts this path from persistent storage and exports VGW_META_SIDECAR.
+    sidecarDir: ""
+    # Optional directory for POSIX or ScoutFS object version storage. When set,
+    # the chart mounts this path from persistent storage and exports VGW_VERSIONING_DIR.
+    versioningDir: ""
     # for s3 backend:
     # args: "--access 0123456 --secret 0xdeadbeef --endpoint http://s3.example.com"
     # for azure backend:
     # args: ""--account 0123456 --access-key 0xdeadbeef"
+    # for posix backend with sidecar metadata:
+    # sidecarDir: "/mnt/metadata"
+    # for posix or scoutfs backend with object versioning:
+    # versioningDir: "/mnt/versioning"
 
   # The port versitygw listens on for S3 API requests.
   port: 7070


### PR DESCRIPTION
The Helm chart now supports dedicated sidecar metadata and versioning directories alongside the primary data directory. For POSIX deployments, users can configure a sidecar metadata path without forcing backend flags through a single args string, and POSIX or ScoutFS deployments can expose a persistent versioning directory through the chart as well.

This makes the chart usable for filesystem-backed setups that need sidecar metadata storage or object versioning support, while keeping the configuration aligned with the existing persistent data and IAM layout. The chart version is bumped to reflect the new deployment behavior.

Fixes #2204
Fixes #2216