### PR TITLE
fix: update Fiber to `v3.4.0`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/go-ldap/ldap/v3 v3.4.13
-	github.com/gofiber/fiber/v3 v3.3.0
+	github.com/gofiber/fiber/v3 v3.4.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/vault-client-go v0.4.3
@@ -65,7 +65,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
 	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/go-secure-stdlib/strutil v0.1.2 // indirect
-	github.com/klauspost/compress v1.18.6 // indirect
+	github.com/klauspost/compress v1.19.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mattn/go-colorable v0.1.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/go-ldap/ldap/v3 v3.4.13 h1:+x1nG9h+MZN7h/lUi5Q3UZ0fJ1GyDQYbPvbuH38baD
 github.com/go-ldap/ldap/v3 v3.4.13/go.mod h1:LxsGZV6vbaK0sIvYfsv47rfh4ca0JXokCoKjZxsszv0=
 github.com/gofiber/fiber/v3 v3.3.0 h1:QBd3sYCqdy6Qs5gJYzSw4I4SbqL204jPqpdub/ueiw8=
 github.com/gofiber/fiber/v3 v3.3.0/go.mod h1:YH7/TAoRaU4kF8slDCtQuFJ1NzC+3MtxUI4KfvQtaIA=
+github.com/gofiber/fiber/v3 v3.4.0 h1:F0aND4vwZF7dR7cbvSwFQQEpBU902XHKWxrLsFBkVqw=
+github.com/gofiber/fiber/v3 v3.4.0/go.mod h1:nAhJfdxUIJJph2tPWPmqWf8QDIN2iiqQiQf3lENZpdk=
 github.com/gofiber/schema v1.8.0 h1:NGsC9toPHmj8Xg4KpznuXBzNmHG6V5YV0tXKpKMcmis=
 github.com/gofiber/schema v1.8.0/go.mod h1:lmbXPQ8hvzXSLkdS2DS7pb4kpunC2Roh7Sj3HMjGfzA=
 github.com/gofiber/utils/v2 v2.1.1 h1:kGnoGjwEnFW6w0x45W+kLlmMJvqBGkuUA4oMWKn/T/I=
@@ -121,6 +123,8 @@ github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRt
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=
 github.com/klauspost/compress v1.18.6/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.19.0 h1:sXLILfc9jV2QYWkzFOPWStmcUVH2RHEB1JCdY2oVvCQ=
+github.com/klauspost/compress v1.19.0/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/klauspost/cpuid/v2 v2.3.0 h1:S4CRMLnYUhGeDFDqkGriYKdfoFlDnMtqTiI/sFzhA9Y=
 github.com/klauspost/cpuid/v2 v2.3.0/go.mod h1:hqwkgyIinND0mEev00jJYCxPNVRVXFQeu1XKlok6oO0=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/s3api/server.go
+++ b/s3api/server.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gofiber/fiber/v3"
 	"github.com/gofiber/fiber/v3/middleware/logger"
 	"github.com/gofiber/fiber/v3/middleware/recover"
-	"github.com/valyala/fasthttp"
 	"github.com/versity/versitygw/auth"
 	"github.com/versity/versitygw/backend"
 	"github.com/versity/versitygw/debuglogger"
@@ -115,7 +114,6 @@ func New(
 		// in the global error handler
 		ReadBufferSize: requestHeaderMaxSize,
 	})
-	installRequestHeaderLimitErrorHandler(app)
 
 	server.app = app
 	server.Router.app = app
@@ -404,38 +402,6 @@ func (sa *S3ApiServer) ShutDown() error {
 // in the context locals
 func stackTraceHandler(ctx fiber.Ctx, e any) {
 	utils.ContextKeyStack.Set(ctx, e)
-}
-
-// installRequestHeaderLimitErrorHandler converts fasthttp small-buffer errors
-// into the S3 RequestHeaderSectionTooLarge response.
-//
-// This is a temporary solution until Fiber handles request header limit errors
-// before response writes correctly. See:
-// https://github.com/gofiber/fiber/issues/4423
-func installRequestHeaderLimitErrorHandler(app *fiber.App) {
-	server := app.Server()
-	fiberErrorHandler := server.ErrorHandler
-	server.ErrorHandler = func(ctx *fasthttp.RequestCtx, err error) {
-		var smallBufferErr *fasthttp.ErrSmallBuffer
-		if errors.As(err, &smallBufferErr) {
-			debuglogger.Logf("total request headers size exceeds the allowed 8KB")
-
-			requestID := utils.NewS3RequestID()
-			hostID := utils.NewS3HostID()
-			apiErr := s3err.GetRequestHeaderSectionTooLargeErr(requestHeaderMaxSize)
-
-			ctx.Response.Reset()
-			ctx.Response.Header.SetContentType(fiber.MIMEApplicationXML)
-			ctx.Response.Header.Set(utils.HeaderAmzRequestID, requestID)
-			ctx.Response.Header.Set(utils.HeaderAmzID2, hostID)
-			ctx.SetStatusCode(apiErr.StatusCode())
-			ctx.SetConnectionClose()
-			ctx.SetBody(apiErr.XMLBody(requestID, hostID))
-			return
-		}
-
-		fiberErrorHandler(ctx, err)
-	}
 }
 
 // globalErrorHandler catches the errors before reaching to


### PR DESCRIPTION
Upgrade Fiber to `v3.4.0`, which includes the middleware fix merged in [gofiber/fiber#4426](https://github.com/gofiber/fiber/pull/4426).

Parser and server errors no longer fall through normal 404/405 route scanning during middleware traversal. Large request headers are therefore handled directly by `globalErrorHandler` without invoking it twice.

Remove the now-unnecessary `installRequestHeaderLimitErrorHandler` workaround and update transitive dependencies.