### PR TITLE
feat: Add 'sessionAffinity' and 'sessionAffinityConfig'

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: versitygw
 description: A Helm chart for deploying the Versity S3 Gateway on Kubernetes
 type: application
-version: 0.3.4
+version: 0.3.5
 sources:
   - https://github.com/versity/versitygw
 icon: https://raw.githubusercontent.com/versity/versitygw/main/webui/web/assets/images/Versity-logo-blue-horizontal.png

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -6,6 +6,13 @@ metadata:
     {{- include "versitygw.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if .Values.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.sessionAffinity }}
+  {{- end }}
+  {{- with .Values.service.sessionAffinityConfig }}
+  sessionAffinityConfig:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   ports:
     - port: {{ .Values.gateway.port }}
       targetPort: s3-api

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -56,6 +56,15 @@ securityContext:
 # To make the server available outside the cluster, the type should be changed to `NodePort` or `LoadBalancer`.
 service:
   type: ClusterIP
+  # Session affinity for the Service. Supported values: "None" (default) or "ClientIP".
+  # Use "ClientIP" to route requests from the same client to the same pod.
+  sessionAffinity: ""
+  # Configuration for the session affinity (only used when sessionAffinity is "ClientIP").
+  # Example:
+  #   sessionAffinityConfig:
+  #     clientIP:
+  #       timeoutSeconds: 10800
+  sessionAffinityConfig: {}
 
 # --- Ingress ---
 # Expose the S3 API via a Kubernetes Ingress resource.


### PR DESCRIPTION
This PR adds support for `sessionAffinity` and `sessionAffinityConfig` for Kubernetes Services.

By default, when an application is running with multiple instances (HA), client requests are distributed across the pods using a round-robin strategy.

However, some applications require session persistence. For example, if a client uploads or creates data on one pod and then sends a follow-up request, that request may be routed to a different pod where the data is not available yet, resulting in unexpected behavior.

Enabling `sessionAffinity` ensures that requests from the same client are consistently routed to the same pod.

This feature is also useful for scenarios such as multipart file uploads, where all requests belonging to the same upload session should be handled by the same application instance.