### PR TITLE
fix(posix): omit null version id for suspended buckets

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -3938,6 +3938,12 @@ func (p *Posix) PutObjectWithPostFunc(ctx context.Context, po s3response.PutObje
 		}
 	}
 
+	// "null" identifies the current object internally while versioning is
+	// suspended, but S3 omits the version ID from the PutObject response.
+	if versionID == nullVersionId {
+		versionID = ""
+	}
+
 	err = postprocess(f.File())
 	if err != nil {
 		return s3response.PutObjectOutput{},

--- a/s3api/controllers/base_test.go
+++ b/s3api/controllers/base_test.go
@@ -198,9 +198,10 @@ func TestSetResponseHeaders(t *testing.T) {
 		headers map[string]*string
 	}
 	tests := []struct {
-		name     string
-		args     args
-		expected map[string]string
+		name       string
+		args       args
+		expected   map[string]string
+		unexpected []string
 	}{
 		{
 			name: "should not set if map is nil",
@@ -215,7 +216,7 @@ func TestSetResponseHeaders(t *testing.T) {
 				headers: map[string]*string{
 					"x-amz-checksum-algorithm": utils.GetStringPtr("crc32"),
 					"x-amz-meta-key":           utils.GetStringPtr("meta_key"),
-					"x-amz-mp-size":            utils.GetStringPtr(""),
+					"x-amz-version-id":         utils.GetStringPtr(""),
 					"something":                nil,
 				},
 			},
@@ -223,6 +224,7 @@ func TestSetResponseHeaders(t *testing.T) {
 				"x-amz-checksum-algorithm": "crc32",
 				"x-amz-meta-key":           "meta_key",
 			},
+			unexpected: []string{"x-amz-version-id", "something"},
 		},
 	}
 	for _, tt := range tests {
@@ -235,6 +237,9 @@ func TestSetResponseHeaders(t *testing.T) {
 					v := ctx.Response().Header.Peek(key)
 					assert.Equal(t, val, string(v))
 				}
+			}
+			for _, key := range tt.unexpected {
+				assert.Empty(t, ctx.Response().Header.Peek(key))
 			}
 		})
 	}

--- a/tests/integration/ListObjectVersions.go
+++ b/tests/integration/ListObjectVersions.go
@@ -336,9 +336,9 @@ func ListObjectVersions_containing_null_versionId_obj(s *S3Conf) error {
 			return err
 		}
 
-		if getString(out.res.VersionId) != nullVersionId {
-			return fmt.Errorf("expected the uploaded object versionId to be %v, instead got %v",
-				nullVersionId, getString(out.res.VersionId))
+		if out.res.VersionId != nil {
+			return fmt.Errorf("expected PutObject response to omit versionId, instead got %v",
+				getString(out.res.VersionId))
 		}
 
 		versions[0].IsLatest = getBoolPtr(false)

--- a/tests/integration/versioning.go
+++ b/tests/integration/versioning.go
@@ -64,9 +64,9 @@ func Versioning_PutObject_suspended_null_versionId_obj(s *S3Conf) error {
 			return err
 		}
 
-		if getString(out.res.VersionId) != nullVersionId {
-			return fmt.Errorf("expected the uploaded object versionId to be %v, instead got %v",
-				nullVersionId, getString(out.res.VersionId))
+		if out.res.VersionId != nil {
+			return fmt.Errorf("expected PutObject response to omit versionId, instead got %v",
+				getString(out.res.VersionId))
 		}
 
 		return nil
@@ -161,9 +161,9 @@ func Versioning_PutObject_overwrite_null_versionId_obj(s *S3Conf) error {
 			return err
 		}
 
-		if getString(out.res.VersionId) != nullVersionId {
-			return fmt.Errorf("expected the uploaded object versionId to be %v, insted got %v",
-				nullVersionId, getString(out.res.VersionId))
+		if out.res.VersionId != nil {
+			return fmt.Errorf("expected PutObject response to omit versionId, instead got %v",
+				getString(out.res.VersionId))
 		}
 
 		versions[0].IsLatest = getBoolPtr(false)


### PR DESCRIPTION
## Summary
- keep `null` as the stored object version ID while bucket versioning is suspended
- omit `x-amz-version-id` from the successful `PutObject` response in that state
- update the existing versioning integration tests and response-header unit coverage

## Expected S3 behavior

Two related behaviors need to remain distinct:

1. Objects written while versioning is suspended are stored as the `null` version. `ListObjectVersions` therefore reports `VersionId: "null"`.
2. The `PutObject` response for a versioning-suspended bucket does not include `x-amz-version-id`. The AWS PutObject API reference shows this header absent in its **Versioning suspended** sample response and present in its **Versioning enabled** sample response.

References:
- [PutObject response examples](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_Examples)
- [Adding objects to versioning-suspended buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/AddingObjectstoVersionSuspendedBuckets.html)

## Implementation

The POSIX backend continues to use `null` internally for the current suspended-version object. After object metadata has been persisted, the response-only `VersionID` is normalized to an empty string. `SetResponseHeaders` already omits empty values, so `x-amz-version-id` is not rendered.

The existing integration tests in `tests/integration/versioning.go` now verify both sides of the contract:
- `PutObjectOutput.VersionId` is absent for suspended uploads
- `ListObjectVersions` still returns the stored object with `VersionId: "null"`

The existing table-driven `TestSetResponseHeaders` also explicitly verifies that an empty `x-amz-version-id` is absent from the Fiber response.

## Automated testing

```console
$ go test ./backend/posix ./s3api/controllers ./tests/integration -count=1
?   github.com/versity/versitygw/backend/posix       [no test files]
ok  github.com/versity/versitygw/s3api/controllers
?   github.com/versity/versitygw/tests/integration  [no test files]

$ go vet ./backend/posix ./s3api/controllers ./tests/integration
```

The integration package is compiled by the command above; its S3 scenarios run through the project integration test harness.

## CLI reproduction and verification

The issue was reproduced against a running VersityGW POSIX deployment and verified with the patched binary on a separate port using isolated POSIX root and versioning directories.

### Before

```console
$ aws --endpoint-url "$ENDPOINT" s3api put-object \
    --bucket "$BUCKET" --key issue-2164 --body test-data
{
    "ETag": "\"0771d979fc8e5f9805d53c9136114b32\"",
    "VersionId": "null"
}
```

### After

```console
$ aws --endpoint-url "$PATCHED_ENDPOINT" s3api put-object \
    --bucket "$BUCKET" --key issue-2164 --body test-data
{
    "ETag": "\"0771d979fc8e5f9805d53c9136114b32\""
}
```

The patched response omits `VersionId`; subsequent `ListObjectVersions` continues to identify the stored suspended object as the `null` version. Temporary test resources were removed after verification.

Fixes #2164