### PR TITLE
feat: add helm chart admin and webui ingress support

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: versitygw
 description: A Helm chart for deploying the Versity S3 Gateway on Kubernetes
 type: application
-version: 0.3.4
+version: 0.3.5
 sources:
   - https://github.com/versity/versitygw
 icon: https://raw.githubusercontent.com/versity/versitygw/main/webui/web/assets/images/Versity-logo-blue-horizontal.png

--- a/chart/templates/ingress.yaml
+++ b/chart/templates/ingress.yaml
@@ -33,3 +33,75 @@ spec:
           {{- end }}
     {{- end }}
 {{- end }}
+{{- if and .Values.admin.enabled .Values.admin.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "versitygw.fullname" . }}-admin
+  labels:
+    {{- include "versitygw.labels" . | nindent 4 }}
+  {{- with .Values.admin.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.admin.ingress.className }}
+  ingressClassName: {{ .Values.admin.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.admin.ingress.tls }}
+  tls:
+    {{- toYaml .Values.admin.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.admin.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "versitygw.fullname" $ }}
+                port:
+                  name: admin
+          {{- end }}
+    {{- end }}
+{{- end }}
+{{- if and .Values.webui.enabled .Values.webui.ingress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "versitygw.fullname" . }}-webui
+  labels:
+    {{- include "versitygw.labels" . | nindent 4 }}
+  {{- with .Values.webui.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.webui.ingress.className }}
+  ingressClassName: {{ .Values.webui.ingress.className | quote }}
+  {{- end }}
+  {{- if .Values.webui.ingress.tls }}
+  tls:
+    {{- toYaml .Values.webui.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.webui.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "versitygw.fullname" $ }}
+                port:
+                  name: webui
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -164,6 +164,7 @@ gateway:
   # Access log file path for S3 requests (AWS log format). Empty = disabled.
   accessLog: ""
   # Default CORS allowed origin. Empty = CORS disabled.
+  # Must include the scheme prefix, e.g. "https://example.com" or "http://example.com".
   corsAllowOrigin: ""
   # Disable strict S3 bucket naming validation.
   disableStrictBucketNames: false
@@ -178,6 +179,20 @@ admin:
   maxConnections: 250000
   # Maximum in-flight requests for the admin server.
   maxRequests: 100000
+  # --- Ingress ---
+  # Expose the Admin API via a Kubernetes Ingress resource.
+  # Requires an ingress controller (e.g. nginx, traefik) to be installed in the cluster.
+  ingress:
+    enabled: false
+    # IngressClass to use (maps to spec.ingressClassName).
+    className: ""
+    annotations: {}
+    hosts:
+      - host: s3-admin.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
   # --- HTTPRoute ---
   # Expose the Admin API via a Gateway API HTTPRoute resource.
   # Requires Gateway API CRDs and a Gateway API implementation (Envoy Gateway, Istio, Kgateway, etc.) in the cluster.
@@ -218,6 +233,20 @@ webui:
   # Kubernetes because it uses the internal pod IP addresses.
   adminGateways: []
   # - s3-admin.example.com
+  # --- Ingress ---
+  # Expose the WebUI via a Kubernetes Ingress resource.
+  # Requires an ingress controller (e.g. nginx, traefik) to be installed in the cluster.
+  ingress:
+    enabled: false
+    # IngressClass to use (maps to spec.ingressClassName).
+    className: ""
+    annotations: {}
+    hosts:
+      - host: versitygw.example.com
+        paths:
+          - path: /
+            pathType: Prefix
+    tls: []
   # --- HTTPRoute ---
   # Expose the WebUI via a Gateway API HTTPRoute resource.
   # Requires Gateway API CRDs and a Gateway API implementation (Envoy Gateway, Istio, Kgateway, etc.) in the cluster.


### PR DESCRIPTION
This change is needed to expose the admin API and WebUI through standard Kubernetes Ingress resources instead of only through service access or Gateway API routes. It adds configurable ingress blocks in values.yaml, and renders dedicated ingress objects for admin and webui when enabled.

Also update corsAllowOrigin comment.

Fixes #2251
Fixes #2252