### PR TITLE
website: return 400 for plaintext HTTP sent to a TLS listener

### DIFF
--- a/s3api/utils/multi_listener.go
+++ b/s3api/utils/multi_listener.go
@@ -15,9 +15,11 @@
 package utils
 
 import (
+	"bufio"
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
@@ -371,7 +373,7 @@ func NewMultiAddrTLSListener(network, address string, getCertificateFunc func(*t
 				return nil, fmt.Errorf("failed to set permissions on socket %s: %w", address, err)
 			}
 		}
-		return NewMultiListener(tls.NewListener(ln, config)), nil
+		return NewMultiListener(tls.NewListener(newHTTPDetectListener(ln), config)), nil
 	}
 
 	addrs, err := resolveHostnameAddrs(address)
@@ -391,9 +393,82 @@ func NewMultiAddrTLSListener(network, address string, getCertificateFunc func(*t
 			}
 			return nil, fmt.Errorf("failed to bind TLS listener %s: %w", addr, err)
 		}
-		listeners = append(listeners, tls.NewListener(ln, config))
+		listeners = append(listeners, tls.NewListener(newHTTPDetectListener(ln), config))
 	}
 
 	// Return MultiListener for multiple addresses
 	return NewMultiListener(listeners...), nil
+}
+
+// errPlaintextHTTPOnTLS is returned by httpDetectConn.Read after it has replied
+// to a plaintext HTTP request that was sent to a TLS listener. Returning an error
+// aborts the (impossible) TLS handshake so the connection is closed after the
+// 400 response has been written.
+var errPlaintextHTTPOnTLS = errors.New("plaintext HTTP request received on TLS listener")
+
+// plaintextHTTPResponse is the reply sent to a client that speaks plaintext HTTP
+// to a TLS port. It mirrors the behaviour of net/http's TLS server, which turns
+// the same misconfiguration into a clear 400 rather than an aborted connection.
+const plaintextHTTPResponse = "HTTP/1.0 400 Bad Request\r\n" +
+	"Content-Type: text/plain; charset=utf-8\r\n" +
+	"Connection: close\r\n" +
+	"\r\n" +
+	"Client sent an HTTP request to an HTTPS server.\n"
+
+// looksLikePlaintextHTTP reports whether the first bytes of a connection are the
+// start of a plaintext HTTP request line. A real TLS ClientHello begins with the
+// handshake record type byte (0x16), which never matches these method prefixes.
+func looksLikePlaintextHTTP(b []byte) bool {
+	if len(b) < 5 {
+		return false
+	}
+	switch string(b[:5]) {
+	case "GET /", "HEAD ", "POST ", "PUT /", "DELET", "OPTIO", "PATCH", "TRACE", "CONNE":
+		return true
+	}
+	return false
+}
+
+// httpDetectListener wraps a listener whose connections are about to be upgraded
+// to TLS. It detects the common misconfiguration of a client sending a plaintext
+// HTTP request to a TLS port and returns a clear 400 response instead of leaving
+// the client with an aborted/empty reply (curl exit code 52).
+type httpDetectListener struct {
+	net.Listener
+}
+
+func newHTTPDetectListener(ln net.Listener) net.Listener {
+	return httpDetectListener{Listener: ln}
+}
+
+func (l httpDetectListener) Accept() (net.Conn, error) {
+	conn, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+	return &httpDetectConn{Conn: conn, r: bufio.NewReader(conn)}, nil
+}
+
+// httpDetectConn peeks at the first bytes of a connection before the TLS layer
+// consumes them. If they are a plaintext HTTP request, it writes a 400 response
+// and then fails subsequent reads so the handshake aborts cleanly.
+type httpDetectConn struct {
+	net.Conn
+	r       *bufio.Reader
+	checked bool
+	blocked bool
+}
+
+func (c *httpDetectConn) Read(p []byte) (int, error) {
+	if !c.checked {
+		c.checked = true
+		if peek, err := c.r.Peek(5); err == nil && looksLikePlaintextHTTP(peek) {
+			_, _ = io.WriteString(c.Conn, plaintextHTTPResponse)
+			c.blocked = true
+		}
+	}
+	if c.blocked {
+		return 0, errPlaintextHTTPOnTLS
+	}
+	return c.r.Read(p)
 }

--- a/s3api/utils/tls_http_detect_test.go
+++ b/s3api/utils/tls_http_detect_test.go
@@ -1,0 +1,155 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"bytes"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+)
+
+// newTestCertificate returns an in-memory self-signed certificate usable by the
+// TLS listener under test.
+func newTestCertificate(t *testing.T) *tls.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		DNSNames:     []string{"localhost"},
+		IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+
+	return &tls.Certificate{Certificate: [][]byte{der}, PrivateKey: key}
+}
+
+// serveTLSAccept accepts connections from ln and drives a single read on each so
+// that the TLS handshake (and any plaintext-HTTP detection) is triggered, exactly
+// like a real HTTP server would. Accepted request bytes are echoed back so the
+// no-regression test can observe a successful round trip.
+func serveTLSAccept(ln net.Listener) {
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		go func(c net.Conn) {
+			defer c.Close()
+			buf := make([]byte, 512)
+			n, err := c.Read(buf)
+			if err != nil {
+				return
+			}
+			_, _ = c.Write(buf[:n])
+		}(conn)
+	}
+}
+
+// TestMultiAddrTLSListenerRejectsPlaintextHTTP reproduces versity/versitygw#2261:
+// a client that speaks plaintext HTTP to a TLS listener must receive an
+// actionable HTTP 400 instead of an aborted/empty response (curl exit code 52).
+func TestMultiAddrTLSListenerRejectsPlaintextHTTP(t *testing.T) {
+	cert := newTestCertificate(t)
+	getCert := func(*tls.ClientHelloInfo) (*tls.Certificate, error) { return cert, nil }
+
+	ln, err := NewMultiAddrTLSListener("tcp", "127.0.0.1:0", getCert, ListenerOptions{})
+	if err != nil {
+		t.Fatalf("create TLS listener: %v", err)
+	}
+	defer ln.Close()
+
+	go serveTLSAccept(ln)
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Write([]byte("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")); err != nil {
+		t.Fatalf("write plaintext request: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, 1024)
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("expected an HTTP 400 response, got read error (empty/aborted reply): %v", err)
+	}
+
+	resp := buf[:n]
+	if !bytes.Contains(resp, []byte("400")) {
+		t.Fatalf("expected a 400 status in response, got: %q", resp)
+	}
+	if !bytes.HasPrefix(resp, []byte("HTTP/")) {
+		t.Fatalf("expected a plaintext HTTP response, got: %q", resp)
+	}
+}
+
+// TestMultiAddrTLSListenerAllowsRealTLS ensures the plaintext-HTTP detection does
+// not interfere with legitimate TLS clients.
+func TestMultiAddrTLSListenerAllowsRealTLS(t *testing.T) {
+	cert := newTestCertificate(t)
+	getCert := func(*tls.ClientHelloInfo) (*tls.Certificate, error) { return cert, nil }
+
+	ln, err := NewMultiAddrTLSListener("tcp", "127.0.0.1:0", getCert, ListenerOptions{})
+	if err != nil {
+		t.Fatalf("create TLS listener: %v", err)
+	}
+	defer ln.Close()
+
+	go serveTLSAccept(ln)
+
+	conn, err := tls.Dial("tcp", ln.Addr().String(), &tls.Config{InsecureSkipVerify: true})
+	if err != nil {
+		t.Fatalf("TLS dial failed (regression): %v", err)
+	}
+	defer conn.Close()
+
+	msg := []byte("ping over tls")
+	if _, err := conn.Write(msg); err != nil {
+		t.Fatalf("tls write: %v", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	buf := make([]byte, len(msg))
+	n, err := conn.Read(buf)
+	if err != nil {
+		t.Fatalf("tls read: %v", err)
+	}
+	if !bytes.Equal(buf[:n], msg) {
+		t.Fatalf("expected echo %q, got %q", msg, buf[:n])
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #2261.

When versitygw is configured with TLS (for example a bucket-website endpoint started with `--cert`/`--key`), a client that sends **plaintext HTTP to the HTTPS port** currently gets an aborted connection with no response body — `curl` reports exit code 52 (`Empty reply from server`) and browsers show a generic empty-response error. The user is given no hint that they simply used `http://` instead of `https://`.

This mirrors a well-known case that Go's own `net/http` TLS server already handles: it detects the plaintext request and replies with `400 Bad Request: Client sent an HTTP request to an HTTPS server.` versitygw's fiber/fasthttp servers do not, so the misconfiguration is silent.

## Change

`NewMultiAddrTLSListener` (used by the website, S3 API, admin and web UI TLS endpoints) now wraps each raw listener with a tiny detector that peeks at the first bytes of a connection **before** the TLS layer consumes them:

- If they are the start of a plaintext HTTP request line (`GET /`, `POST `, `HEAD `, …), it writes a plain `HTTP/1.0 400 Bad Request` with `Client sent an HTTP request to an HTTPS server.` and closes the connection.
- Otherwise the bytes are replayed untouched to the TLS handshake. A real TLS `ClientHello` always begins with the `0x16` handshake record byte, which never matches an HTTP method prefix, so legitimate TLS clients are unaffected.

The change is confined to the listener wiring — no protocol or handler changes.

## Tests

Added `s3api/utils/tls_http_detect_test.go`:

- `TestMultiAddrTLSListenerRejectsPlaintextHTTP` — reproduces #2261: without the fix a plaintext `GET` yields an EOF/empty reply; with the fix the client reads back an `HTTP/... 400` response.
- `TestMultiAddrTLSListenerAllowsRealTLS` — regression guard: a genuine `tls.Dial` handshake still completes and round-trips data.

```
go test ./s3api/utils/     # ok
go vet ./s3api/utils/      # clean
gofmt -s -l ...            # clean
staticcheck ./s3api/utils/ # clean
```

Signed-off-by: JSup <hanjisang0914@gmail.com>