### PR TITLE
fix: buckets with versioning enabled don't have "Show versions" button in UI

### DIFF
--- a/webui/web/explorer.html
+++ b/webui/web/explorer.html
@@ -1231,6 +1231,7 @@ under the License.
         // If we have a bucket from URL, show it
         if (currentBucket) {
           showObjectsView();
+          await checkBucketVersioning();
           await loadObjects();
         } else {
           showBucketsView();


### PR DESCRIPTION
The `Show versions` button only appears right after enabling versioning. Refreshing the UI causes it to disappear.
<img width="654" height="214" alt="Screenshot 2026-08-07 at 16 42 36" src="https://github.com/user-attachments/assets/22c67341-ec2d-4705-a2c7-ecc1f4c0eeb4" />

After refreshing, the `Versioning` modal also always asks if you want to enable versioning even for buckets where it is already enabled.
