### PR TITLE
fix: reject unsupported RDMA RC token schemes with 501

### DIFF
--- a/cumiddleware/cuobj.go
+++ b/cumiddleware/cuobj.go
@@ -33,6 +33,9 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 	"github.com/valyala/fasthttp"
+
+	"github.com/versity/versitygw/s3api/utils"
+	"github.com/versity/versitygw/s3err"
 )
 
 // String keys used for fasthttp user-value storage.
@@ -147,6 +150,23 @@ func CuObjMiddleware(ctx fiber.Ctx) error {
 	// which case Content-Length is 0/absent; fall back to the token's own
 	// registered-buffer-size field (already part of the documented wire
 	// format) rather than leaving the backend with no usable size.
+	//
+	// Fixed-width binary RC token schemes (e.g. AMD hipObject's 88-hex-char
+	// token) are structurally incompatible with this gateway's DC transport.
+	// Reject them with 501 instead of a 400 parse error so such clients can
+	// fall back to the HTTP data path: they treat a response without
+	// x-amz-rdma-reply as "RDMA not supported", so the reply header is
+	// deliberately left unset. The error is serialized and sent directly
+	// (terminal response) because the global error handler collapses
+	// non-fiber errors into 500.
+	if isRCTokenScheme(token) {
+		requestID, hostID := utils.EnsureRequestIDs(ctx)
+		err := s3err.GetNotImplementedErr(HeaderRDMAToken, "")
+		ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
+		ctx.Status(err.HTTPStatusCode)
+		return ctx.Send(err.XMLBody(requestID, hostID))
+	}
+
 	rctx.SetUserValue(localKeyRDMADescr, token)
 
 	remoteStart, err := parseRDMATokenBaseAddr(token)
@@ -162,6 +182,39 @@ func CuObjMiddleware(ctx fiber.Ctx) error {
 	}
 
 	return ctx.Next()
+}
+
+// isHexDigit reports whether c is an ASCII hexadecimal digit.
+func isHexDigit(c byte) bool {
+	return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+		(c >= 'A' && c <= 'F')
+}
+
+// isRCTokenScheme reports whether the token's first colon-delimited field
+// is longer than any cuObject base address can be: a cuObject base address
+// is a hex-encoded uint64 (at most 16 hex chars, see the token layout
+// comment above), while fixed-width binary RC token schemes such as AMD
+// hipObject's (44-byte payload hex-encoded to 88 chars, optionally
+// suffixed ":addr:size") always exceed it. Non-hex first fields are left
+// to the regular cuObject parsing, which reports them as malformed.
+// Note this deliberately reclassifies 17+-char non-canonical hex values
+// (e.g. leading zeros) as unsupported; well-formed cuObject tokens are
+// unaffected.
+func isRCTokenScheme(token string) bool {
+	i := strings.IndexByte(token, ':')
+	first := token
+	if i >= 0 {
+		first = token[:i]
+	}
+	if len(first) <= 16 {
+		return false
+	}
+	for j := 0; j < len(first); j++ {
+		if !isHexDigit(first[j]) {
+			return false
+		}
+	}
+	return true
 }
 
 // parseRDMATokenBaseAddr extracts the remote base address — the first

--- a/cumiddleware/cuobj_test.go
+++ b/cumiddleware/cuobj_test.go
@@ -21,6 +21,7 @@ package cumiddleware
 
 import (
 	"bytes"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -179,4 +180,80 @@ func TestSetRDMAReplyHeaderNoopForNonFasthttpContext(t *testing.T) {
 	// HTTP layer.
 	ctx := InjectRDMAContext(t.Context(), "descr", 10, 0)
 	SetRDMAReplyHeader(ctx, http.StatusOK, 10)
+}
+
+// rcToken builds a fixed-width hex RC token of the hipObject shape:
+// 88 lowercase hex chars, optionally suffixed with ":addr:size".
+func rcToken(suffix string) string {
+	tok := ""
+	for i := 0; i < 88; i++ {
+		tok += string(rune('0' + i%10))
+	}
+	return tok + suffix
+}
+
+func TestRCTokenSchemeRejectedWith501(t *testing.T) {
+	cases := []struct {
+		name  string
+		token string
+	}{
+		{"88 hex chars, no colon", rcToken("")},
+		{"88 hex chars with addr:size suffix", rcToken(":1234abcd:1000")},
+		{"88 hex chars uppercase", func() string {
+			tok := ""
+			for i := 0; i < 88; i++ {
+				tok += string(rune('A' + i%6))
+			}
+			return tok
+		}()},
+		{"17-char leading-zero hex first field", "0ffffffffffffffff:00000001"},
+		{"suffix contents are not inspected", rcToken(":not-hex!:not-hex2")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			app, reached := newTestApp(t)
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set(HeaderRDMAToken, tc.token)
+			resp, err := app.Test(req)
+			assert.NoError(t, err)
+			assert.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+			assert.Equal(t, fiber.MIMEApplicationXML,
+				resp.Header.Get("Content-Type"))
+			assert.Empty(t, resp.Header.Get(HeaderRDMAReply))
+			body, _ := io.ReadAll(resp.Body)
+			assert.Contains(t, string(body), "<Code>NotImplemented</Code>")
+			select {
+			case <-reached:
+				t.Fatal("handler should not have been reached for an RC token")
+			default:
+			}
+		})
+	}
+}
+
+func TestRCTokenSchemeBoundaryPassesThrough(t *testing.T) {
+	// A 16-hex-char first field is a legal cuObject base address; with a
+	// valid second field the request must reach the downstream handler.
+	app, reached := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set(HeaderRDMAToken, "ffffffffffffffff:00000001:01020304:0102:010203:1:0102030405060708090a0b0c0d0e0f10")
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	select {
+	case <-reached:
+	default:
+		t.Fatal("handler should have been reached for a cuObject token")
+	}
+}
+
+func TestRCTokenSchemeMalformedStill400(t *testing.T) {
+	// A >16-char first field that is not hex is not an RC token scheme; it
+	// falls through to the cuObject parser, which rejects it as malformed.
+	app, _ := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set(HeaderRDMAToken, "zzzzzzzzzzzzzzzzzzzz:00000001")
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }

--- a/cumiddleware/cuobj_test.go
+++ b/cumiddleware/cuobj_test.go
@@ -250,10 +250,43 @@ func TestRCTokenSchemeBoundaryPassesThrough(t *testing.T) {
 func TestRCTokenSchemeMalformedStill400(t *testing.T) {
 	// A >16-char first field that is not hex is not an RC token scheme; it
 	// falls through to the cuObject parser, which rejects it as malformed.
+	// The expectation below holds for the standalone test app used here;
+	// in a production server the fiber error handler currently maps this
+	// to a 500 (pre-existing behavior, out of scope for this change).
 	app, _ := newTestApp(t)
 	req := httptest.NewRequest(http.MethodPost, "/", nil)
 	req.Header.Set(HeaderRDMAToken, "zzzzzzzzzzzzzzzzzzzz:00000001")
 	resp, err := app.Test(req)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestRCTokenScheme16HexNoColonStill400(t *testing.T) {
+	// A 16-hex-char token with no colon at all is a malformed cuObject
+	// token ("missing base address field"), not an RC scheme; the exact
+	// fixture pins that boundary.
+	app, _ := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set(HeaderRDMAToken, "ffffffffffffffff")
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestLegacyDescriptorTakesPrecedenceOverRCToken(t *testing.T) {
+	// When both the legacy descriptor header and an RC-shaped combined
+	// token are present, the legacy path handles the request and the RC
+	// gate must not fire.
+	app, reached := newTestApp(t)
+	req := httptest.NewRequest(http.MethodPost, "/", nil)
+	req.Header.Set(HeaderRDMADescr, "legacy-descriptor")
+	req.Header.Set(HeaderRDMAToken, rcToken(""))
+	resp, err := app.Test(req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	select {
+	case <-reached:
+	default:
+		t.Fatal("handler should have been reached via the legacy path")
+	}
 }


### PR DESCRIPTION
The RDMA token parser in the cuObject middleware accepts only the cuObject combined-token format, whose first colon-delimited field is a hex-encoded uint64 base address (at most 16 hex chars). Clients using fixed-width binary RC token schemes, such as AMD hipObject (a 44-byte payload hex-encoded to 88 chars, optionally suffixed with ":addr:size"), fail that parse and receive a 400 Bad Request. Since such clients decide between RDMA and the HTTP data path by looking for the x-amz-rdma-reply header, a 400 blocks their fallback entirely.

This rejects structurally incompatible token schemes with 501 Not Implemented instead. A first field longer than 16 hex chars cannot be a valid cuObject base address, so well-formed cuObject tokens never hit the new path, and non-hex fields still fall through to the existing malformed-token 400. The response is a standard S3 XML error sent directly from the middleware (the global error handler collapses non-fiber errors into 500), and the x-amz-rdma-reply header is deliberately left unset so RDMA-capable clients fall back to the HTTP path for this request.

Unit tests cover the RC token shapes (88-hex with and without suffix, uppercase, 17-char leading-zero boundary), pass-through of well-formed cuObject tokens, the malformed and 16-hex-no-colon 400 paths, and legacy descriptor precedence.
