### PR TITLE
fix: use dir permissions option for temporary directories

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1744,7 +1744,7 @@ func (p *Posix) CreateMultipartUpload(ctx context.Context, mpu s3response.Create
 	tmppath := filepath.Join(bucket, objdir)
 	// the unique upload id is a directory for all of the parts
 	// associated with this specific multipart upload
-	err = os.MkdirAll(filepath.Join(tmppath, uploadID), 0755)
+	err = os.MkdirAll(filepath.Join(tmppath, uploadID), p.newDirPerm)
 	if err != nil {
 		return s3response.InitiateMultipartUploadResult{}, fmt.Errorf("create upload temp dir: %w", err)
 	}


### PR DESCRIPTION
The multipart upload temp directory was created with a hard-coded 0755 mode instead of the configured --dir-perms value, unlike every other directory creation path in this backend. This caused inconsistent permissions below bucket directories.

Fixes #2266