### PR TITLE
fix: s3proxy sends bodyless CreateBucket when the configuration is empty

### DIFF
--- a/backend/s3proxy/s3.go
+++ b/backend/s3proxy/s3.go
@@ -204,6 +204,15 @@ func (s *S3Proxy) CreateBucket(ctx context.Context, input *s3.CreateBucketInput,
 		}
 	}
 
+	// drop an empty CreateBucketConfiguration: strict backends (Ceph RGW) reject the empty element
+	if input.CreateBucketConfiguration != nil &&
+		len(input.CreateBucketConfiguration.Tags) == 0 &&
+		input.CreateBucketConfiguration.LocationConstraint == "" &&
+		input.CreateBucketConfiguration.Location == nil &&
+		input.CreateBucketConfiguration.Bucket == nil {
+		input.CreateBucketConfiguration = nil
+	}
+
 	_, err := s.client.CreateBucket(ctx, input)
 	if err != nil {
 		return handleError(err)

--- a/backend/s3proxy/s3_test.go
+++ b/backend/s3proxy/s3_test.go
@@ -1,0 +1,171 @@
+// Copyright 2023 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package s3proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+// captureHTTPClient records the request the aws sdk sends and answers 200,
+// so tests can assert on the wire format without a real backend.
+type captureHTTPClient struct {
+	body          []byte
+	contentLength int64
+}
+
+func (c *captureHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	c.contentLength = req.ContentLength
+	if req.Body != nil {
+		b, err := io.ReadAll(req.Body)
+		if err != nil {
+			return nil, err
+		}
+		c.body = b
+	} else {
+		c.body = nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{},
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+func newCaptureProxy(t *testing.T) (*S3Proxy, *captureHTTPClient) {
+	t.Helper()
+	capture := &captureHTTPClient{}
+	client := s3.New(s3.Options{
+		Region:       "us-east-1",
+		BaseEndpoint: aws.String("http://backend.test"),
+		UsePathStyle: true,
+		Credentials:  credentials.NewStaticCredentialsProvider("access", "secret", ""),
+		HTTPClient:   capture,
+	})
+	p, err := NewWithClient(context.Background(), client, "")
+	if err != nil {
+		t.Fatalf("NewWithClient: %v", err)
+	}
+	return p, capture
+}
+
+// The api layer always populates CreateBucketConfiguration (it carries the
+// bucket tags), so the backend must drop it when empty: strict backends such
+// as Ceph RGW reject an empty <CreateBucketConfiguration/> element with
+// 400 InvalidArgument, while a bodyless CreateBucket is accepted by all
+// tested backends for this no-location case.
+func TestCreateBucketOmitsEmptyConfiguration(t *testing.T) {
+	p, capture := newCaptureProxy(t)
+
+	err := p.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket:                    aws.String("test-bucket"),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{},
+	}, []byte{})
+	if err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if len(capture.body) != 0 {
+		t.Errorf("CreateBucket without tags must send no body, got %q", capture.body)
+	}
+	if capture.contentLength != 0 {
+		t.Errorf("CreateBucket without tags must send Content-Length 0, got %d", capture.contentLength)
+	}
+}
+
+func TestCreateBucketKeepsTaggedConfiguration(t *testing.T) {
+	p, capture := newCaptureProxy(t)
+
+	err := p.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket: aws.String("test-bucket"),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			Tags: []types.Tag{
+				{Key: aws.String("env"), Value: aws.String("test")},
+			},
+		},
+	}, []byte{})
+	if err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	body := string(capture.body)
+	if !strings.Contains(body, "<Key>env</Key>") || !strings.Contains(body, "<Value>test</Value>") {
+		t.Errorf("CreateBucket with tags must forward the configuration, got %q", body)
+	}
+}
+
+func TestCreateBucketKeepsLocationConstraint(t *testing.T) {
+	p, capture := newCaptureProxy(t)
+
+	err := p.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket: aws.String("test-bucket"),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			LocationConstraint: types.BucketLocationConstraint("eu-west-1"),
+		},
+	}, []byte{})
+	if err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if !strings.Contains(string(capture.body), "<LocationConstraint>eu-west-1</LocationConstraint>") {
+		t.Errorf("CreateBucket with a location constraint must forward the configuration, got %q", capture.body)
+	}
+}
+
+func TestCreateBucketKeepsLocationInfo(t *testing.T) {
+	p, capture := newCaptureProxy(t)
+
+	err := p.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket: aws.String("test-bucket"),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			Location: &types.LocationInfo{
+				Name: aws.String("usw2-az1"),
+				Type: types.LocationTypeAvailabilityZone,
+			},
+		},
+	}, []byte{})
+	if err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if !strings.Contains(string(capture.body), "usw2-az1") {
+		t.Errorf("CreateBucket with location info must forward the configuration, got %q", capture.body)
+	}
+}
+
+func TestCreateBucketKeepsBucketInfo(t *testing.T) {
+	p, capture := newCaptureProxy(t)
+
+	err := p.CreateBucket(context.Background(), &s3.CreateBucketInput{
+		Bucket: aws.String("test-bucket"),
+		CreateBucketConfiguration: &types.CreateBucketConfiguration{
+			Bucket: &types.BucketInfo{
+				DataRedundancy: types.DataRedundancySingleAvailabilityZone,
+				Type:           types.BucketTypeDirectory,
+			},
+		},
+	}, []byte{})
+	if err != nil {
+		t.Fatalf("CreateBucket: %v", err)
+	}
+	if !strings.Contains(string(capture.body), "Directory") {
+		t.Errorf("CreateBucket with bucket info must forward the configuration, got %q", capture.body)
+	}
+}


### PR DESCRIPTION

## Problem

Since 9bde1ddb (`feat: implements tagging support for CreateBucket`, closes #1595,
shipped in every release since v1.0.19) the api layer always populates
`CreateBucketConfiguration` on the `CreateBucketInput` it hands to the backend —
the field only exists to carry bucket tags. The aws-sdk then serializes an empty
`<CreateBucketConfiguration/>` element (103 bytes) on **every** CreateBucket the
s3proxy backend issues, whether or not the client supplied tags or a location
constraint.

Strict backends reject that request:

| Backend | empty `<CreateBucketConfiguration/>` | bodyless CreateBucket |
|---|---|---|
| Ceph RGW Quincy 17.2.8 (`quay.io/ceph/demo:latest-quincy`) | **400 InvalidArgument** | 200 |
| Ceph RGW Squid 19.2.0 (`quay.io/ceph/demo:latest-squid`) | **400 InvalidArgument** | 200 |
| MinIO | 200 (tolerated) | 200 |
| SeaweedFS | 200 (tolerated) | 200 |

The RGW behavior is longstanding and consistent across releases — not a recent
Ceph change — so every versitygw release since v1.0.19 has been unable to
create buckets on a Ceph backend.

So bucket creation through the gateway is completely broken for s3proxy
deployments in front of Ceph RGW (API, admin UI and any S3 client alike), while
tests against MinIO pass — presumably why this went unnoticed since October
2025. The posix backend is unaffected (no backend HTTP call).

## Fix

In the s3proxy backend, drop `CreateBucketConfiguration` before calling the
backend when it carries no content (no tags, no location constraint, no
location/bucket info). A bodyless CreateBucket is accepted by all tested
backends for this no-location case. Configurations that do carry content are
forwarded unchanged, so the tagging feature from #1595 keeps working. The check lives in the s3proxy backend rather
than the api layer because the posix and azure backends dereference
`input.CreateBucketConfiguration` unconditionally.

## Verification

- **New wire-level unit tests** (`backend/s3proxy/s3_test.go`, the package's
  first): an injected capturing HTTP client asserts what the sdk actually
  sends. `TestCreateBucketOmitsEmptyConfiguration` fails before this fix
  (empty element on the wire, non-zero Content-Length) and passes with it;
  four preservation tests prove that configurations carrying tags (#1595),
  a location constraint, location info, or bucket info are still forwarded.
- Wire capture (socat dump backend) of the full gateway binary: a no-tags
  CreateBucket is now bodyless (`Content-Length: 0`; previously the 103-byte
  empty element), a CreateBucket with `<Tags>` still sends the configuration.
- **Verified end-to-end against Ceph RGW (squid-era)**: CreateBucket through
  the patched gateway succeeds (200, bucket usable and deletable) where the
  unpatched gateway fails with 400 InvalidArgument. The raw-element behavior
  was additionally confirmed with direct requests: bodyless CreateBucket →
  200, empty element → 400, consistent across three RGW nodes.
- `go build ./cmd/versitygw`, `go vet ./backend/s3proxy/`, `gofmt` clean.
- **Regression runs:** full unit suite (`go test -race -tags=github ./...`) all
  green; the functional suite (`runtests.sh`) passes 39/39; `versitygw test
  full-flow` against an s3proxy→posix chain yields byte-identical results with
  and without this fix (188 PASS / 36 FAIL — the 36 are pre-existing chain
  failures unrelated to CreateBucket, identical failure list on both builds).
