### PR TITLE
rdma: report RC route errors through the S3 error boundary

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,6 +24,9 @@ jobs:
       run: |
         go get -v -t -d ./...
 
+    - name: Build RDMA session server archive
+      run: make rdma/librcserver.a
+
     - name: Test
       run: go test -coverprofile profile.txt -race -v -timeout 30s -tags=github ./...
 

--- a/cmd/vgwrdma/main.go
+++ b/cmd/vgwrdma/main.go
@@ -1162,7 +1162,7 @@ func runGateway(ctx context.Context, be backend.Backend) error {
 		// chain as usual.
 		rcAuth := func(ctx fiber.Ctx) error {
 			if err := rcVerify(ctx); err != nil {
-				return err
+				return rcroutes.WriteRouteError(ctx, err)
 			}
 			return ctx.Next()
 		}

--- a/rdma/rcroutes/errors.go
+++ b/rdma/rcroutes/errors.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS
+// IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+package rcroutes
+
+import (
+	"errors"
+
+	"github.com/gofiber/fiber/v3"
+
+	"github.com/versity/versitygw/s3api/utils"
+	"github.com/versity/versitygw/s3err"
+)
+
+// writeRouteError renders err as the terminal S3-style XML response
+// of an RC control route. The production S3 error handler converts
+// ordinary Fiber errors into a generic 500 response, so the route
+// must send its final status and body itself. Errors that already
+// carry S3 semantics (authentication, authorization, object
+// backend) keep their status and code; anything else is mapped to
+// a protocol error without exposing internal detail.
+func writeRouteError(ctx fiber.Ctx, err error) error {
+	requestID, hostID := utils.EnsureRequestIDs(ctx)
+
+	var apiErr s3err.APIError
+	switch e := classifyRouteError(err).(type) {
+	case s3err.S3Error:
+		apiErr = e.BaseError()
+	case s3err.APIError:
+		apiErr = e
+	}
+	if isRouteNotImplemented(err) {
+		apiErr = s3err.APIError{
+			Code:           "NotImplemented",
+			Description:    "RDMA is not supported on this platform",
+			HTTPStatusCode: fiber.StatusNotImplemented,
+		}
+	}
+
+	ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
+	return ctx.Status(apiErr.HTTPStatusCode).
+		Send(apiErr.XMLBody(requestID, hostID))
+}
+
+// classifyRouteError resolves err to a value implementing
+// s3err.S3Error. S3-aware errors pass through unchanged; RC
+// transport errors are mapped to the closest protocol error.
+func classifyRouteError(err error) s3err.S3Error {
+	var s3Err s3err.S3Error
+	if errors.As(err, &s3Err) {
+		return s3Err
+	}
+
+	code, status, description := routeErrorDetails(err)
+	return s3err.APIError{
+		Code:           code,
+		Description:    description,
+		HTTPStatusCode: status,
+	}
+}
+
+// routeErrorDetails maps a non-S3 route error to its protocol
+// error code, HTTP status, and description.
+func routeErrorDetails(err error) (code string, status int, description string) {
+	switch {
+	case isRouteBadRequest(err):
+		return "InvalidRdmaRequest", fiber.StatusBadRequest,
+			"Invalid RDMA control request"
+	case isRouteNotFound(err):
+		return "NoSuchRdmaSession", fiber.StatusNotFound,
+			"No such RDMA session"
+	case isRouteConflict(err):
+		return "RdmaSessionConflict", fiber.StatusConflict,
+			"RDMA session state conflict"
+	case isRouteLimit(err):
+		return "RdmaResourceLimit", fiber.StatusTooManyRequests,
+			"RDMA resource limit reached"
+	case isRouteBadGateway(err):
+		return "RdmaTransferFailed", fiber.StatusBadGateway,
+			"RDMA transfer failed"
+	case isRouteUnavailable(err):
+		return "RdmaServiceUnavailable", fiber.StatusServiceUnavailable,
+			"RDMA service is shutting down"
+	default:
+		return s3err.GetAPIError(s3err.ErrInternalError).Code,
+			fiber.StatusInternalServerError, "Internal Error"
+	}
+}

--- a/rdma/rcroutes/errors.go
+++ b/rdma/rcroutes/errors.go
@@ -18,26 +18,41 @@ import (
 
 	"github.com/gofiber/fiber/v3"
 
+	"github.com/versity/versitygw/debuglogger"
 	"github.com/versity/versitygw/s3api/utils"
 	"github.com/versity/versitygw/s3err"
 )
 
-// writeRouteError renders err as the terminal S3-style XML response
+// ErrRouteNotImplemented is the platform-stub answer of the
+// control routes on builds without the RC data plane.
+type ErrRouteNotImplemented struct{}
+
+func (ErrRouteNotImplemented) Error() string {
+	return "RDMA not supported on this platform"
+}
+
+// isRouteNotImplemented reports whether err is the platform-stub
+// answer of the control routes. The marker type is shared, so
+// every build classifies it the same way.
+func isRouteNotImplemented(err error) bool {
+	var ni ErrRouteNotImplemented
+	return errors.As(err, &ni)
+}
+
+// WriteRouteError renders err as the terminal S3-style XML response
 // of an RC control route. The production S3 error handler converts
 // ordinary Fiber errors into a generic 500 response, so the route
 // must send its final status and body itself. Errors that already
 // carry S3 semantics (authentication, authorization, object
 // backend) keep their status and code; anything else is mapped to
-// a protocol error without exposing internal detail.
-func writeRouteError(ctx fiber.Ctx, err error) error {
+// a protocol error without exposing internal detail. The gateway
+// auth adapter uses it for the same reason.
+func WriteRouteError(ctx fiber.Ctx, err error) error {
 	requestID, hostID := utils.EnsureRequestIDs(ctx)
 
-	var apiErr s3err.APIError
-	switch e := classifyRouteError(err).(type) {
-	case s3err.S3Error:
-		apiErr = e.BaseError()
-	case s3err.APIError:
-		apiErr = e
+	apiErr := routeError(err)
+	if apiErr.HTTPStatusCode == fiber.StatusInternalServerError {
+		logInternalRouteError(ctx, err)
 	}
 	if isRouteNotImplemented(err) {
 		apiErr = s3err.APIError{
@@ -52,13 +67,14 @@ func writeRouteError(ctx fiber.Ctx, err error) error {
 		Send(apiErr.XMLBody(requestID, hostID))
 }
 
-// classifyRouteError resolves err to a value implementing
-// s3err.S3Error. S3-aware errors pass through unchanged; RC
-// transport errors are mapped to the closest protocol error.
-func classifyRouteError(err error) s3err.S3Error {
+// routeError resolves err to its S3-style response. Errors that
+// already carry S3 semantics (authentication, authorization,
+// object backend) keep their status and code; RC transport errors
+// map to the closest protocol error.
+func routeError(err error) s3err.APIError {
 	var s3Err s3err.S3Error
 	if errors.As(err, &s3Err) {
-		return s3Err
+		return s3Err.BaseError()
 	}
 
 	code, status, description := routeErrorDetails(err)
@@ -67,6 +83,14 @@ func classifyRouteError(err error) s3err.S3Error {
 		Description:    description,
 		HTTPStatusCode: status,
 	}
+}
+
+// logInternalRouteError keeps a server-side trace of unexpected
+// failures. The wire response stays generic; without this the
+// terminal serializer would hide the production diagnostics the
+// global error handler used to log.
+func logInternalRouteError(ctx fiber.Ctx, err error) {
+	debuglogger.InternalError(err)
 }
 
 // routeErrorDetails maps a non-S3 route error to its protocol

--- a/rdma/rcroutes/errors.go
+++ b/rdma/rcroutes/errors.go
@@ -51,9 +51,6 @@ func WriteRouteError(ctx fiber.Ctx, err error) error {
 	requestID, hostID := utils.EnsureRequestIDs(ctx)
 
 	apiErr := routeError(err)
-	if apiErr.HTTPStatusCode == fiber.StatusInternalServerError {
-		logInternalRouteError(ctx, err)
-	}
 	if isRouteNotImplemented(err) {
 		apiErr = s3err.APIError{
 			Code:           "NotImplemented",
@@ -61,10 +58,23 @@ func WriteRouteError(ctx fiber.Ctx, err error) error {
 			HTTPStatusCode: fiber.StatusNotImplemented,
 		}
 	}
+	if apiErr.HTTPStatusCode == fiber.StatusInternalServerError {
+		logInternalRouteError(ctx, err)
+	}
+
+	// A full S3 error keeps its own richer XML body - per-type
+	// diagnostics such as signature details would be lost if
+	// only the base error were serialized.
+	var body []byte
+	var s3Err s3err.S3Error
+	if errors.As(err, &s3Err) {
+		body = s3Err.XMLBody(requestID, hostID)
+	} else {
+		body = apiErr.XMLBody(requestID, hostID)
+	}
 
 	ctx.Response().Header.SetContentType(fiber.MIMEApplicationXML)
-	return ctx.Status(apiErr.HTTPStatusCode).
-		Send(apiErr.XMLBody(requestID, hostID))
+	return ctx.Status(apiErr.HTTPStatusCode).Send(body)
 }
 
 // routeError resolves err to its S3-style response. Errors that

--- a/rdma/rcroutes/errors_linux.go
+++ b/rdma/rcroutes/errors_linux.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS
+// IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+//go:build linux && amd64 && cgo
+
+package rcroutes
+
+import (
+	"errors"
+
+	"github.com/versity/versitygw/rdma/rcserver"
+)
+
+// This file keeps the Linux-only error classifiers next to the
+// shared terminal serializer in errors.go. The marker types below
+// carry only the intended protocol class; the HTTP status and XML
+// body are decided in one place.
+
+// errRouteBadRequest marks a malformed control request (invalid
+// header value, bad argument).
+type errRouteBadRequest struct{}
+
+func (errRouteBadRequest) Error() string { return "invalid RDMA control request" }
+
+// errRouteUnavailable marks admission refusal during shutdown.
+type errRouteUnavailable struct{}
+
+func (errRouteUnavailable) Error() string {
+	return "RDMA service is shutting down"
+}
+
+// isRouteBadRequest reports whether err is a malformed-request
+// class error from the Linux route handlers.
+func isRouteBadRequest(err error) bool {
+	var bad errRouteBadRequest
+	return errors.As(err, &bad)
+}
+
+// isRouteNotFound reports whether err identifies an unknown or
+// cross-principal session; both map to the same response so the
+// session id is not disclosed across principals.
+func isRouteNotFound(err error) bool {
+	return errors.Is(err, rcserver.ErrNoSession)
+}
+
+// isRouteConflict reports whether err is a stale, duplicate, or
+// wrong-state session error.
+func isRouteConflict(err error) bool {
+	return errors.Is(err, rcserver.ErrStale) ||
+		errors.Is(err, rcserver.ErrState) ||
+		errors.Is(err, rcserver.ErrDouble)
+}
+
+// isRouteLimit reports whether err was caused by a configured
+// resource limit.
+func isRouteLimit(err error) bool {
+	return errors.Is(err, rcserver.ErrLimit)
+}
+
+// isRouteBadGateway reports whether the RC wire transfer failed.
+func isRouteBadGateway(err error) bool {
+	return errors.Is(err, rcserver.ErrWire)
+}
+
+// isRouteUnavailable reports whether the RC service refused
+// admission or is shutting down.
+func isRouteUnavailable(err error) bool {
+	var unavail errRouteUnavailable
+	return errors.As(err, &unavail)
+}
+
+// isRouteNotImplemented reports whether the platform stub answered
+// the request; always false on Linux builds.
+func isRouteNotImplemented(err error) bool { return false }

--- a/rdma/rcroutes/errors_linux.go
+++ b/rdma/rcroutes/errors_linux.go
@@ -83,7 +83,3 @@ func isRouteUnavailable(err error) bool {
 	var unavail errRouteUnavailable
 	return errors.As(err, &unavail)
 }
-
-// isRouteNotImplemented reports whether the platform stub answered
-// the request; always false on Linux builds.
-func isRouteNotImplemented(err error) bool { return false }

--- a/rdma/rcroutes/errors_linux.go
+++ b/rdma/rcroutes/errors_linux.go
@@ -40,10 +40,15 @@ func (errRouteUnavailable) Error() string {
 }
 
 // isRouteBadRequest reports whether err is a malformed-request
-// class error from the Linux route handlers.
+// class error: an invalid header value from the route handlers or
+// a rejected argument, short transfer, or oversized value from
+// the session server.
 func isRouteBadRequest(err error) bool {
 	var bad errRouteBadRequest
-	return errors.As(err, &bad)
+	return errors.As(err, &bad) ||
+		errors.Is(err, rcserver.ErrShort) ||
+		errors.Is(err, rcserver.ErrTrunc) ||
+		errors.Is(err, rcserver.ErrArg)
 }
 
 // isRouteNotFound reports whether err identifies an unknown or

--- a/rdma/rcroutes/errors_mapping_linux_test.go
+++ b/rdma/rcroutes/errors_mapping_linux_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS
+// IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+//go:build linux && amd64 && cgo
+
+package rcroutes
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/versity/versitygw/rdma/rcserver"
+)
+
+// This file verifies the mapping from session-server failures to
+// protocol error responses. It runs where the Linux session
+// server links; the s3api package exercises the shared
+// serializer through the production S3 server on every platform.
+
+func TestRouteErrorProtocolMapping(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		code string
+		want int
+	}{
+		{
+			name: "invalid header is 400",
+			err:  invalidHeader(hdrProtocol, "bogus"),
+			code: "InvalidRdmaRequest",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "unknown session is 404",
+			err:  rcserver.ErrNoSession,
+			code: "NoSuchRdmaSession",
+			want: http.StatusNotFound,
+		},
+		{
+			name: "owner mismatch answers as unknown session",
+			err:  fmt.Errorf("session owner mismatch: %w", rcserver.ErrNoSession),
+			code: "NoSuchRdmaSession",
+			want: http.StatusNotFound,
+		},
+		{
+			name: "stale session is 409",
+			err:  rcserver.ErrStale,
+			code: "RdmaSessionConflict",
+			want: http.StatusConflict,
+		},
+		{
+			name: "duplicate borrow is 409",
+			err:  fmt.Errorf("peer busy: %w", rcserver.ErrDouble),
+			code: "RdmaSessionConflict",
+			want: http.StatusConflict,
+		},
+		{
+			name: "wrong session state is 409",
+			err:  rcserver.ErrState,
+			code: "RdmaSessionConflict",
+			want: http.StatusConflict,
+		},
+		{
+			name: "resource limit is 429",
+			err:  rcserver.ErrLimit,
+			code: "RdmaResourceLimit",
+			want: http.StatusTooManyRequests,
+		},
+		{
+			name: "wire failure is 502",
+			err:  rcserver.ErrWire,
+			code: "RdmaTransferFailed",
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "short transfer is 400",
+			err:  rcserver.ErrShort,
+			code: "InvalidRdmaRequest",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "value too long is 400",
+			err:  rcserver.ErrTrunc,
+			code: "InvalidRdmaRequest",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "invalid argument is 400",
+			err:  rcserver.ErrArg,
+			code: "InvalidRdmaRequest",
+			want: http.StatusBadRequest,
+		},
+		{
+			name: "admission refusal is 503",
+			err:  errNotAdmitted(),
+			code: "RdmaServiceUnavailable",
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "unexpected error is 500",
+			err:  errors.New("boom"),
+			code: "InternalError",
+			want: http.StatusInternalServerError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := routeError(tt.err)
+			if got.HTTPStatusCode != tt.want {
+				t.Fatalf("status = %d, want %d", got.HTTPStatusCode, tt.want)
+			}
+			if got.Code != tt.code {
+				t.Fatalf("code = %q, want %q", got.Code, tt.code)
+			}
+		})
+	}
+}

--- a/rdma/rcroutes/errors_stub.go
+++ b/rdma/rcroutes/errors_stub.go
@@ -15,23 +15,6 @@
 
 package rcroutes
 
-import "errors"
-
-// errRouteNotImplemented marks the platform-stub answer of the
-// control routes.
-type errRouteNotImplemented struct{}
-
-func (errRouteNotImplemented) Error() string {
-	return "RDMA not supported on this platform"
-}
-
-// isRouteNotImplemented reports whether the platform stub answered
-// the request.
-func isRouteNotImplemented(err error) bool {
-	var ni errRouteNotImplemented
-	return errors.As(err, &ni)
-}
-
 // isRouteBadRequest reports whether err is a malformed-request
 // class error. The stub never classifies request errors because it
 // answers before validation.

--- a/rdma/rcroutes/errors_stub.go
+++ b/rdma/rcroutes/errors_stub.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS
+// IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+//go:build !(linux && amd64 && cgo)
+
+package rcroutes
+
+import "errors"
+
+// errRouteNotImplemented marks the platform-stub answer of the
+// control routes.
+type errRouteNotImplemented struct{}
+
+func (errRouteNotImplemented) Error() string {
+	return "RDMA not supported on this platform"
+}
+
+// isRouteNotImplemented reports whether the platform stub answered
+// the request.
+func isRouteNotImplemented(err error) bool {
+	var ni errRouteNotImplemented
+	return errors.As(err, &ni)
+}
+
+// isRouteBadRequest reports whether err is a malformed-request
+// class error. The stub never classifies request errors because it
+// answers before validation.
+func isRouteBadRequest(err error) bool { return false }
+
+// isRouteNotFound reports whether err identifies an unknown
+// session. Never true on the stub.
+func isRouteNotFound(err error) bool { return false }
+
+// isRouteConflict reports whether err is a session-state conflict.
+// Never true on the stub.
+func isRouteConflict(err error) bool { return false }
+
+// isRouteLimit reports whether err was caused by a resource
+// limit. Never true on the stub.
+func isRouteLimit(err error) bool { return false }
+
+// isRouteBadGateway reports whether the RC wire transfer failed.
+// Never true on the stub.
+func isRouteBadGateway(err error) bool { return false }
+
+// isRouteUnavailable reports whether the RC service refused
+// admission. Never true on the stub.
+func isRouteUnavailable(err error) bool { return false }

--- a/rdma/rcroutes/routes_linux.go
+++ b/rdma/rcroutes/routes_linux.go
@@ -112,7 +112,7 @@ func (h *Handler) Prepare(ctx fiber.Ctx) error {
 	// production S3 error handler turns ordinary Fiber
 	// errors into a generic 500 response.
 	if err := h.prepareCore(ctx); err != nil {
-		return writeRouteError(ctx, err)
+		return WriteRouteError(ctx, err)
 	}
 	return nil
 }
@@ -269,7 +269,7 @@ func (h *Handler) Ready(ctx fiber.Ctx) error {
 	// production S3 error handler turns ordinary Fiber
 	// errors into a generic 500 response.
 	if err := h.readyCore(ctx); err != nil {
-		return writeRouteError(ctx, err)
+		return WriteRouteError(ctx, err)
 	}
 	return nil
 }
@@ -462,7 +462,7 @@ func (h *Handler) Cancel(ctx fiber.Ctx) error {
 	// production S3 error handler turns ordinary Fiber
 	// errors into a generic 500 response.
 	if err := h.cancelCore(ctx); err != nil {
-		return writeRouteError(ctx, err)
+		return WriteRouteError(ctx, err)
 	}
 	return nil
 }

--- a/rdma/rcroutes/routes_linux.go
+++ b/rdma/rcroutes/routes_linux.go
@@ -97,18 +97,27 @@ func principalID(acct auth.Account) rcserver.PrincipalID {
 }
 
 func errNotAdmitted() error {
-	return fiber.NewError(fiber.StatusServiceUnavailable,
-		"RDMA service is shutting down")
+	return errRouteUnavailable{}
 }
 
 func invalidHeader(name, value string) error {
-	return fiber.NewError(fiber.StatusBadRequest,
-		fmt.Sprintf("invalid %s header: %q", name, value))
+	return fmt.Errorf("invalid %s header: %q: %w",
+		name, value, errRouteBadRequest{})
 }
 
 // Prepare handles PREPARE: authorize the object access, create the
 // session, and (GET) stage the object into the session buffer.
 func (h *Handler) Prepare(ctx fiber.Ctx) error {
+	// Serialize any error at the route boundary: the
+	// production S3 error handler turns ordinary Fiber
+	// errors into a generic 500 response.
+	if err := h.prepareCore(ctx); err != nil {
+		return writeRouteError(ctx, err)
+	}
+	return nil
+}
+
+func (h *Handler) prepareCore(ctx fiber.Ctx) error {
 	if !h.svc.TryEnter() {
 		return errNotAdmitted()
 	}
@@ -256,6 +265,16 @@ func (h *Handler) stageGet(ctx fiber.Ctx, sessionID, bucket, key string,
 // the session's target, then run the transfer. PUT picks up the
 // received data and hands it to the object backend.
 func (h *Handler) Ready(ctx fiber.Ctx) error {
+	// Serialize any error at the route boundary: the
+	// production S3 error handler turns ordinary Fiber
+	// errors into a generic 500 response.
+	if err := h.readyCore(ctx); err != nil {
+		return writeRouteError(ctx, err)
+	}
+	return nil
+}
+
+func (h *Handler) readyCore(ctx fiber.Ctx) error {
 	if !h.svc.TryEnter() {
 		return errNotAdmitted()
 	}
@@ -295,7 +314,7 @@ func (h *Handler) Ready(ctx fiber.Ctx) error {
 	if err != nil {
 		// Owner mismatch and unknown session both answer 404 so
 		// the session id is not disclosed cross-principal.
-		return fiber.NewError(fiber.StatusNotFound, "no such RDMA session")
+		return mapRcError(err)
 	}
 
 	// Re-run authorization for the session's stored target and
@@ -303,7 +322,7 @@ func (h *Handler) Ready(ctx fiber.Ctx) error {
 	// request.
 	bucket, key, ok := splitTarget(info.Target)
 	if !ok {
-		return fiber.NewError(fiber.StatusInternalServerError, "session target")
+		return errors.New("invalid session target")
 	}
 	if err := h.authorize(ctx, acct, isRoot, bucket, key, info.Op == 1); err != nil {
 		// Permission revoked mid-session: cancel the session.
@@ -335,7 +354,7 @@ func (h *Handler) Ready(ctx fiber.Ctx) error {
 	// rolled the claim back (state Prepared, no completion ref),
 	// so answer 409 without any finalizer.
 	if resp.Outcome == rcserver.ReadyBusy {
-		return fiber.NewError(fiber.StatusConflict, "peer busy")
+		return fmt.Errorf("peer busy: %w", rcserver.ErrDouble)
 	}
 
 	// The claim succeeded: from here until the response commits,
@@ -439,6 +458,16 @@ func (h *Handler) commitPut(ctx fiber.Ctx, sessionID, bucket, key string,
 
 // Cancel handles CANCEL: authenticated owner tears the session down.
 func (h *Handler) Cancel(ctx fiber.Ctx) error {
+	// Serialize any error at the route boundary: the
+	// production S3 error handler turns ordinary Fiber
+	// errors into a generic 500 response.
+	if err := h.cancelCore(ctx); err != nil {
+		return writeRouteError(ctx, err)
+	}
+	return nil
+}
+
+func (h *Handler) cancelCore(ctx fiber.Ctx) error {
 	if !h.svc.TryEnter() {
 		return errNotAdmitted()
 	}
@@ -583,30 +612,15 @@ func formatHex(v uint64) string {
 }
 
 // mapRcError translates ABI statuses into HTTP-shaped failures.
+// mapRcError wraps a session-server error so the shared terminal
+// serializer in errors.go can classify it. Owner mismatch answers
+// the same 404 as an unknown session so a session id is never
+// disclosed across principals.
 func mapRcError(err error) error {
-	var status int
-	var msg string
 	switch {
-	case errors.Is(err, rcserver.ErrNoSession):
-		status, msg = fiber.StatusNotFound, "no such RDMA session"
-	case errors.Is(err, rcserver.ErrStale):
-		status, msg = fiber.StatusConflict, "stale RDMA session handle"
 	case errors.Is(err, rcserver.ErrSession):
-		status, msg = fiber.StatusForbidden, "RDMA session owner mismatch"
-	case errors.Is(err, rcserver.ErrState), errors.Is(err, rcserver.ErrDouble):
-		status, msg = fiber.StatusConflict, "wrong RDMA session state"
-	case errors.Is(err, rcserver.ErrLimit):
-		status, msg = fiber.StatusTooManyRequests, "RDMA resource limit"
-	case errors.Is(err, rcserver.ErrWire):
-		status, msg = fiber.StatusBadGateway, "RDMA transfer failed"
-	case errors.Is(err, rcserver.ErrShort):
-		status, msg = fiber.StatusBadRequest, "short RDMA transfer"
-	case errors.Is(err, rcserver.ErrTrunc):
-		status, msg = fiber.StatusBadRequest, "RDMA value too long"
-	case errors.Is(err, rcserver.ErrArg):
-		status, msg = fiber.StatusBadRequest, "invalid RDMA argument"
-	default:
-		status, msg = fiber.StatusInternalServerError, "RDMA internal error"
+		return fmt.Errorf("session owner mismatch: %w",
+			rcserver.ErrNoSession)
 	}
-	return fiber.NewError(status, msg)
+	return err
 }

--- a/rdma/rcroutes/routes_stub.go
+++ b/rdma/rcroutes/routes_stub.go
@@ -34,16 +34,17 @@ func New(svc any, be backend.Backend, iam auth.IAMService,
 	return &Handler{}
 }
 
-func notImplemented() error {
-	return fiber.NewError(fiber.StatusNotImplemented,
-		"RDMA not supported on this platform")
+// notImplemented answers 501 through the shared terminal error
+// serializer so the response shape matches the Linux routes.
+func notImplemented(ctx fiber.Ctx) error {
+	return writeRouteError(ctx, errRouteNotImplemented{})
 }
 
 // Prepare is a stub handler that answers 501 Not Implemented.
-func (h *Handler) Prepare(ctx fiber.Ctx) error { return notImplemented() }
+func (h *Handler) Prepare(ctx fiber.Ctx) error { return notImplemented(ctx) }
 
 // Ready is a stub handler that answers 501 Not Implemented.
-func (h *Handler) Ready(ctx fiber.Ctx) error { return notImplemented() }
+func (h *Handler) Ready(ctx fiber.Ctx) error { return notImplemented(ctx) }
 
 // Cancel is a stub handler that answers 501 Not Implemented.
-func (h *Handler) Cancel(ctx fiber.Ctx) error { return notImplemented() }
+func (h *Handler) Cancel(ctx fiber.Ctx) error { return notImplemented(ctx) }

--- a/rdma/rcroutes/routes_stub.go
+++ b/rdma/rcroutes/routes_stub.go
@@ -37,7 +37,7 @@ func New(svc any, be backend.Backend, iam auth.IAMService,
 // notImplemented answers 501 through the shared terminal error
 // serializer so the response shape matches the Linux routes.
 func notImplemented(ctx fiber.Ctx) error {
-	return writeRouteError(ctx, errRouteNotImplemented{})
+	return WriteRouteError(ctx, ErrRouteNotImplemented{})
 }
 
 // Prepare is a stub handler that answers 501 Not Implemented.

--- a/s3api/rc_route_error_test.go
+++ b/s3api/rc_route_error_test.go
@@ -14,8 +14,11 @@
 package s3api
 
 import (
+	"bytes"
 	"encoding/xml"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -71,8 +74,59 @@ func TestRCRouteErrorPreservesS3Error(t *testing.T) {
 	if er.RequestID == "" || er.HostID == "" {
 		t.Fatal("response missing RequestId or HostId")
 	}
+	if got := resp.Header.Get("x-amz-request-id"); got != er.RequestID {
+		t.Fatalf("body RequestId %q != header %q", er.RequestID, got)
+	}
+	if got := resp.Header.Get("x-amz-id-2"); got != er.HostID {
+		t.Fatalf("body HostId %q != header %q", er.HostID, got)
+	}
 	if ct := resp.Header.Get("Content-Type"); ct != fiber.MIMEApplicationXML {
 		t.Fatalf("content-type = %q, want %q", ct, fiber.MIMEApplicationXML)
+	}
+}
+
+func TestRCRouteErrorKeepsSubtypeDiagnostics(t *testing.T) {
+	// A wrapped per-type S3 error must keep both its status and
+	// its subtype-only XML fields; serializing only the base
+	// error would drop the diagnostics.
+	server, err := newTestS3ApiServer(
+		WithRoute(http.MethodPost, "/.hipobj-rc/op", func(ctx fiber.Ctx) error {
+			inner := s3err.GetAPIError(s3err.ErrSignatureDoesNotMatch)
+			wrapped := s3err.SignatureDoesNotMatchError{
+				AWSAccessKeyId: "AKIAEXAMPLE",
+				// The remaining diagnostic fields flow from the
+				// base through the subtype constructor in
+				// production; the wire contract under test is
+				// that the subtype body is used verbatim.
+				APIError:     inner,
+				StringToSign: "EXAMPLE-STRING-TO-SIGN",
+			}
+			return rcroutes.WriteRouteError(ctx,
+				fmt.Errorf("auth: %w", wrapped))
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	resp, err := server.app.Test(httptest.NewRequest(http.MethodPost, "/.hipobj-rc/op", nil))
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	for _, want := range []string{"SignatureDoesNotMatch", "AKIAEXAMPLE",
+		"EXAMPLE-STRING-TO-SIGN"} {
+		if !bytes.Contains(body, []byte(want)) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
 	}
 }
 

--- a/s3api/rc_route_error_test.go
+++ b/s3api/rc_route_error_test.go
@@ -1,0 +1,158 @@
+// Copyright 2026 Versity Software
+// This file is licensed under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an "AS
+// IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied.  See the License for the specific language
+// governing permissions and limitations under the License.
+
+package s3api
+
+import (
+	"encoding/xml"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gofiber/fiber/v3"
+
+	"github.com/versity/versitygw/rdma/rcroutes"
+	"github.com/versity/versitygw/s3err"
+)
+
+// This file pins the wire behavior of RDMA control-route error
+// responses at the production server boundary: the real error
+// handler, the real request-ID middleware, and the terminal
+// serializer the RDMA routes use. The RC route handlers live in
+// rdma/rcroutes; these tests exercise the same response path a
+// client observes.
+
+type rcErrorResponse struct {
+	XMLName   xml.Name `xml:"Error"`
+	Code      string   `xml:"Code"`
+	Message   string   `xml:"Message"`
+	RequestID string   `xml:"RequestId"`
+	HostID    string   `xml:"HostId"`
+}
+
+func TestRCRouteErrorPreservesS3Error(t *testing.T) {
+	server, err := newTestS3ApiServer(
+		WithRoute(http.MethodPost, "/.hipobj-rc/op", func(ctx fiber.Ctx) error {
+			return rcroutes.WriteRouteError(ctx,
+				s3err.GetAPIError(s3err.ErrAccessDenied))
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	resp, err := server.app.Test(httptest.NewRequest(http.MethodPost, "/.hipobj-rc/op", nil))
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+	var er rcErrorResponse
+	if err := xml.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode XML body: %v", err)
+	}
+	if er.Code != "AccessDenied" {
+		t.Fatalf("code = %q, want AccessDenied", er.Code)
+	}
+	if er.RequestID == "" || er.HostID == "" {
+		t.Fatal("response missing RequestId or HostId")
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != fiber.MIMEApplicationXML {
+		t.Fatalf("content-type = %q, want %q", ct, fiber.MIMEApplicationXML)
+	}
+}
+
+func TestRCRouteErrorRawFiberIs500(t *testing.T) {
+	// Control case: an ordinary fiber error collapses into the
+	// generic 500 of the production error handler. This is the
+	// behavior WriteRouteError exists to avoid.
+	server, err := newTestS3ApiServer(
+		WithRoute(http.MethodPost, "/.hipobj-rc/op", func(ctx fiber.Ctx) error {
+			return fiber.NewError(fiber.StatusTeapot, "raw")
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	resp, err := server.app.Test(httptest.NewRequest(http.MethodPost, "/.hipobj-rc/op", nil))
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d (production handler collapses fiber errors)",
+			resp.StatusCode, http.StatusInternalServerError)
+	}
+}
+
+func TestRCRouteErrorUnexpectedIsGeneric500(t *testing.T) {
+	server, err := newTestS3ApiServer(
+		WithRoute(http.MethodPost, "/.hipobj-rc/op", func(ctx fiber.Ctx) error {
+			return rcroutes.WriteRouteError(ctx, errors.New("boom"))
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	resp, err := server.app.Test(httptest.NewRequest(http.MethodPost, "/.hipobj-rc/op", nil))
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	var er rcErrorResponse
+	if err := xml.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode XML body: %v", err)
+	}
+	if er.Code != "InternalError" {
+		t.Fatalf("code = %q, want InternalError", er.Code)
+	}
+}
+
+func TestRCRouteErrorStubNotImplemented(t *testing.T) {
+	server, err := newTestS3ApiServer(
+		WithRoute(http.MethodPost, "/.hipobj-rc/op", func(ctx fiber.Ctx) error {
+			return rcroutes.WriteRouteError(ctx, rcroutes.ErrRouteNotImplemented{})
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	resp, err := server.app.Test(httptest.NewRequest(http.MethodPost, "/.hipobj-rc/op", nil))
+	if err != nil {
+		t.Fatalf("app.Test() error = %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusNotImplemented)
+	}
+	var er rcErrorResponse
+	if err := xml.NewDecoder(resp.Body).Decode(&er); err != nil {
+		t.Fatalf("decode XML body: %v", err)
+	}
+	if er.Code != "NotImplemented" {
+		t.Fatalf("code = %q, want NotImplemented", er.Code)
+	}
+}


### PR DESCRIPTION
Fixes #2354.

Reports hipobj-rc-v2 route failures through the S3 error boundary instead of collapsing them to bare 500s. Transport-level failures inside the RC session layer map to S3 protocol codes (bad request for rejected arguments and short or oversized transfers, internal error for the rest), and the response keeps the full S3 error XML body, so per-type diagnostics such as the access key and string-to-sign survive the route boundary the same way they do on the regular S3 routes. Auth failures take the same path, and the platform stub answers 501 on every build, classified before the internal-error logging decision so it no longer logs as an internal 500.

The s3api boundary tests cover the mapping through the production server and link the RC session-server archive on the general CI platform, so the workflow builds it before the test step. Regression tests assert a wrapped signature failure keeps the status, the code, and both diagnostic fields, and that the response body identifiers equal the request-id headers.
