### PR TITLE
fix: count CommonPrefixes in POSIX ListObjectsV2 responses

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -6268,7 +6268,7 @@ func (p *Posix) ListObjectsV2Parametrized(ctx context.Context, input *s3.ListObj
 		return s3response.ListObjectsV2Result{}, fmt.Errorf("walk %v: %w", bucket, err)
 	}
 
-	count := int32(len(results.Objects))
+	count := int32(len(results.Objects) + len(results.CommonPrefixes))
 
 	return s3response.ListObjectsV2Result{
 		CommonPrefixes:        results.CommonPrefixes,


### PR DESCRIPTION
## Problem

The POSIX backend calculated `ListObjectsV2.KeyCount` using only the
number of returned objects:

```go
len(results.Objects)
```
When a delimiter listing returned only CommonPrefixes, the response
contained KeyCount=0 even though prefixes were present. This caused
Docker Registry garbage collection to fail with:
Path not found: /docker/registry/v2/repositories

## Solution
Calculate KeyCount using both returned objects and common prefixes:
```go
len(results.Objects) + len(results.CommonPrefixes)
```
This matches AWS S3 semantics and the existing Azure backend behavior.

## Testing
- go test ./backend/posix ./backend passed.
- go test ./... passed.

## AI Assistance

AI was used during the investigation and writing process to inspect the relevant code paths, identify the `KeyCount` calculation issue, and help prepare this pull request description. The final code change and test
results were reviewed manually.
