### PR TITLE
tests: build the integration SDK config without the host's AWS setup

### DIFF
--- a/tests/integration/s3conf.go
+++ b/tests/integration/s3conf.go
@@ -24,13 +24,12 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	v4 "github.com/aws/aws-sdk-go-v2/aws/signer/v4"
-	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/aws/smithy-go/middleware"
+	"github.com/aws/smithy-go/logging"
 )
 
 type S3Conf struct {
@@ -205,32 +204,29 @@ func (cfg *S3Conf) getUserClient(usr user) *s3.Client {
 	return config.GetClient()
 }
 
+// Config builds the SDK configuration from the harness's own settings and
+// nothing else. It does not go through config.LoadDefaultConfig: region,
+// credentials, endpoint, and HTTP client all come from S3Conf, so the host's
+// shared AWS configuration has nothing to contribute, and consulting it made
+// the harness fail outright under an AWS_PROFILE the host does not define --
+// the SDK insists a named profile exist even when every setting it could
+// supply is already given.
 func (c *S3Conf) Config() aws.Config {
-	creds := c.getCreds()
-
-	opts := []func(*config.LoadOptions) error{
-		config.WithRegion(c.awsRegion),
-		config.WithCredentialsProvider(creds),
-		config.WithHTTPClient(c.httpClient),
-		config.WithRetryMaxAttempts(1),
+	cfg := aws.Config{
+		Region:           c.awsRegion,
+		Credentials:      c.getCreds(),
+		HTTPClient:       c.httpClient,
+		RetryMaxAttempts: 1,
+		Logger:           logging.NewStandardLogger(os.Stderr),
 	}
 
-	opts = append(opts, config.WithHTTPClient(c.httpClient))
-
 	if c.checksumDisable {
-		opts = append(opts,
-			config.WithAPIOptions([]func(*middleware.Stack) error{v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware}))
+		cfg.APIOptions = append(cfg.APIOptions,
+			v4.SwapComputePayloadSHA256ForUnsignedPayloadMiddleware)
 	}
 
 	if c.debug {
-		opts = append(opts,
-			config.WithClientLogMode(aws.LogSigning|aws.LogRetries|aws.LogRequest|aws.LogResponse|aws.LogRequestEventMessage|aws.LogResponseEventMessage))
-	}
-
-	cfg, err := config.LoadDefaultConfig(
-		context.TODO(), opts...)
-	if err != nil {
-		log.Fatalln("error:", err)
+		cfg.ClientLogMode = aws.LogSigning | aws.LogRetries | aws.LogRequest | aws.LogResponse | aws.LogRequestEventMessage | aws.LogResponseEventMessage
 	}
 
 	if c.endpoint != "" && c.endpoint != "aws" {


### PR DESCRIPTION
The integration harness went through `config.LoadDefaultConfig` to build its `aws.Config`, even though it supplies the region, credentials, endpoint, and HTTP client itself. That made it read the host's shared AWS configuration, and with `AWS_PROFILE` set in the environment the SDK insists the named profile exist: on a machine whose shell sets a profile the SDK cannot find, every test in `cmd/versitygw` died at client setup with

    error: failed to get shared config profile, <name>

Build the `aws.Config` directly from the harness settings instead. Nothing the shared configuration could supply was used -- credentials and region were always overridden -- and disabling only the shared files would not have helped, since the SDK still requires a profile named by `AWS_PROFILE` to resolve. The default stderr logger `LoadDefaultConfig` installed is kept so `--debug` output is unchanged.