### PR TITLE
fix: return `BucketAlreadyExists` for existing dirs without acl meta attr

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -669,6 +669,12 @@ func (p *Posix) CreateBucket(ctx context.Context, input *s3.CreateBucketInput, a
 	err = os.Mkdir(bucket, p.newDirPerm)
 	if err != nil && os.IsExist(err) {
 		aclJSON, err := p.meta.RetrieveAttribute(nil, bucket, "", aclkey)
+		if errors.Is(err, meta.ErrNoSuchKey) {
+			// The directory already exists but has no gateway-managed acl
+			// attribute, e.g. a preexisting directory on a dataset the
+			// gateway was pointed at rather than one created via CreateBucket
+			return s3err.GetBucketErr(s3err.ErrBucketAlreadyExists, bucket)
+		}
 		if err != nil {
 			return fmt.Errorf("get bucket acl: %w", err)
 		}


### PR DESCRIPTION
`CreateBucket` on an existing directory read the bucket acl meta attribute to decide between `BucketAlreadyOwnedByYou` and `BucketAlreadyExists`. For a directory that predates the gateway (or was created outside it) the attribute is missing, so the retrieve failed with `meta.ErrNoSuchKey` and the call returned a wrapped internal error instead of an S3 error. Treat a missing acl attribute as a bucket that exists and is not owned by the caller.