### PR TITLE
fix: object verson mtime

### DIFF
--- a/backend/posix/posix.go
+++ b/backend/posix/posix.go
@@ -1166,8 +1166,18 @@ func (p *Posix) createObjVersion(bucket, key string, size int64, acc auth.Accoun
 	}
 	defer f.cleanup()
 
+	// Keeps original time
+	srcInfo, _ := sf.Stat()
+	beforeMTime := srcInfo.ModTime()
+
 	// Prioritize copy_file_range for internal file-to-file version copies.
 	_, err = io.Copy(f.File(), sf)
+
+	err = os.Chtimes(f.File().Name(), time.Now(), beforeMTime)
+	if err != nil {
+		return versionPath, err
+	}
+
 	if err != nil {
 		return versionPath, err
 	}


### PR DESCRIPTION
Fixes #2311

## Why
- All non-latest versions have the wrong mtime.
- This happens because the archived version is created by opening the current object and copying it, which changes the mtime instead of preserving the original.

## Changes
- Keeping the original mtime.

Please let me know if you would like any changes. Thanks